### PR TITLE
Simplify configurations

### DIFF
--- a/src/util/configuration.rs
+++ b/src/util/configuration.rs
@@ -1,26 +1,20 @@
-use crate::util::environment::Environment;
 use crate::util::settings::Settings;
+use config::{Config, ConfigError, File};
 
-use std::borrow::Cow;
+static CONFIGURATION_FOLDER: &str = "configuration";
+static BASE_FILE: &str = "base";
+static DEFAULT_EXTRA_FILE: &str = "local";
 
-pub fn get_configuration() -> Result<Settings, config::ConfigError> {
-    let mut settings = config::Config::default();
-    let base_path = std::env::current_dir().expect("Failed to determine current directory");
-    let configuration_directory = base_path.join("configuration");
+pub fn get_configuration() -> Result<Settings, ConfigError> {
+    let mut settings = Config::default();
+    let base_path = std::env::current_dir().map_err(|err| ConfigError::Message(err.to_string()))?;
+    let configuration_directory = base_path.join(CONFIGURATION_FOLDER);
 
-    settings.merge(config::File::from(configuration_directory.join("base")).required(true))?;
+    settings.merge(File::from(configuration_directory.join(BASE_FILE)).required(true))?;
 
-    let environment: Environment = std::env::var("APP_ENVIRONMENT")
-        .map(Cow::from)
-        .unwrap_or_else(|_| "local".into())
-        .parse()
-        .expect("Failed to parse APP_ENVIRONMENT");
+    let extra_file = std::env::var("APP_ENVIRONMENT").unwrap_or_else(|_| DEFAULT_EXTRA_FILE.into());
 
-    settings.merge(
-        config::File::from(configuration_directory.join(environment.as_str())).required(true),
-    )?;
-
-    settings.merge(config::Environment::with_prefix("app").separator("__"))?;
+    settings.merge(File::from(configuration_directory.join(extra_file)).required(true))?;
 
     settings.try_into()
 }

--- a/src/util/configuration.rs
+++ b/src/util/configuration.rs
@@ -1,7 +1,7 @@
 use crate::util::settings::Settings;
 use config::{Config, ConfigError, File};
 
-static CONFIGURATION_FOLDER: &str = "configuration";
+static CONFIGURATION_DIRECTORY: &str = "configuration";
 static BASE_FILE: &str = "base";
 static DEFAULT_EXTRA_FILE: &str = "local";
 


### PR DESCRIPTION
Sorry no associated issue, it's me learning rust.

## Changes
* No explicit panics out of configuration.rs, always return ConfigError
* Move string to constants at the top of file (not sure if it adds anything, just a stylistic habit)
* Couldn't see the need to convert env var to Environment and then to $str, simplified
* Remove extra environment specification, wasn't sure why it's there

@wlthomson the last two, may need to be reinstated, but I couldn't figure out why they are need.

Would be nice to have conversion from error returned by current_dir to ConfigError, but they are from external crates (could make a common type, but thought map_err is enough)