### PR TITLE
#221 RepositoryRegistry should not #[derive(Clone)]

### DIFF
--- a/src/server/data/registry.rs
+++ b/src/server/data/registry.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 use std::sync::Mutex;
 
-#[derive(Clone)]
 pub struct RepositoryRegistry {
     pub repositories: anymap::Map<dyn anymap::any::CloneAny + Send + Sync>,
     pub sync_sender: Arc<Mutex<tokio::sync::mpsc::Sender<()>>>,


### PR DESCRIPTION
Closes #221.