### PR TITLE
#252 Add mock repository logging

### DIFF
--- a/src/database/repository/mock/item.rs
+++ b/src/database/repository/mock/item.rs
@@ -1,6 +1,7 @@
 use crate::database::repository::RepositoryError;
 use crate::database::schema::{DatabaseRow, ItemRow};
 
+use log::info;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -15,6 +16,7 @@ impl ItemRepository {
     }
 
     pub async fn insert_one(&self, item: &ItemRow) -> Result<(), RepositoryError> {
+        info!("Inserting item record (item.id={})", item.id);
         self.mock_data
             .lock()
             .unwrap()
@@ -23,10 +25,11 @@ impl ItemRepository {
     }
 
     pub async fn find_one_by_id(&self, id: &str) -> Result<ItemRow, RepositoryError> {
+        info!("Querying item record (item.id={})", id);
         match self.mock_data.lock().unwrap().get(&id.to_string()) {
             Some(DatabaseRow::Item(item)) => Ok(item.clone()),
             _ => Err(RepositoryError {
-                msg: String::from(format!("Failed to find item {}", id)),
+                msg: String::from(format!("Failed to find item record (item.id={})", id)),
             }),
         }
     }

--- a/src/database/repository/mock/item_line.rs
+++ b/src/database/repository/mock/item_line.rs
@@ -1,6 +1,7 @@
 use crate::database::repository::RepositoryError;
 use crate::database::schema::{DatabaseRow, ItemLineRow};
 
+use log::info;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -15,6 +16,7 @@ impl ItemLineRepository {
     }
 
     pub async fn insert_one(&self, item_line: &ItemLineRow) -> Result<(), RepositoryError> {
+        info!("Inserting item_line record (item_line.id={})", item_line.id);
         self.mock_data.lock().unwrap().insert(
             item_line.id.to_string(),
             DatabaseRow::ItemLine(item_line.clone()),
@@ -23,10 +25,14 @@ impl ItemLineRepository {
     }
 
     pub async fn find_one_by_id(&self, id: &str) -> Result<ItemLineRow, RepositoryError> {
+        info!("Querying item_line record (item_line.id={})", id);
         match self.mock_data.lock().unwrap().get(&id.to_string()) {
             Some(DatabaseRow::ItemLine(item_line)) => Ok(item_line.clone()),
             _ => Err(RepositoryError {
-                msg: String::from(format!("Failed to find item_line {}", id)),
+                msg: String::from(format!(
+                    "Failed to find item_line record (item_line.id={})",
+                    id
+                )),
             }),
         }
     }

--- a/src/database/repository/mock/name.rs
+++ b/src/database/repository/mock/name.rs
@@ -1,6 +1,7 @@
 use crate::database::repository::RepositoryError;
 use crate::database::schema::{DatabaseRow, NameRow};
 
+use log::info;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -15,6 +16,7 @@ impl NameRepository {
     }
 
     pub async fn insert_one(&self, name: &NameRow) -> Result<(), RepositoryError> {
+        info!("Inserting name record (name.id={})", name.id);
         self.mock_data
             .lock()
             .unwrap()
@@ -23,10 +25,11 @@ impl NameRepository {
     }
 
     pub async fn find_one_by_id(&self, id: &str) -> Result<NameRow, RepositoryError> {
+        info!("Querying name record (name.id={})", id);
         match self.mock_data.lock().unwrap().get(&id.to_string()) {
             Some(DatabaseRow::Name(name)) => Ok(name.clone()),
             _ => Err(RepositoryError {
-                msg: String::from(format!("Failed to find name {}", id)),
+                msg: String::from(format!("Failed to find name record (name.id={})", id)),
             }),
         }
     }

--- a/src/database/repository/mock/requisition.rs
+++ b/src/database/repository/mock/requisition.rs
@@ -1,6 +1,7 @@
 use crate::database::repository::RepositoryError;
 use crate::database::schema::{DatabaseRow, RequisitionRow};
 
+use log::info;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -15,6 +16,10 @@ impl RequisitionRepository {
     }
 
     pub async fn insert_one(&self, requisition: &RequisitionRow) -> Result<(), RepositoryError> {
+        info!(
+            "Inserting requisition record (requisition.id={})",
+            requisition.id
+        );
         self.mock_data.lock().unwrap().insert(
             requisition.id.to_string(),
             DatabaseRow::Requisition(requisition.clone()),
@@ -23,10 +28,14 @@ impl RequisitionRepository {
     }
 
     pub async fn find_one_by_id(&self, id: &str) -> Result<RequisitionRow, RepositoryError> {
+        info!("Querying requisition record (requisition.id={})", id);
         match self.mock_data.lock().unwrap().get(&id.to_string()) {
             Some(DatabaseRow::Requisition(requisition)) => Ok(requisition.clone()),
             _ => Err(RepositoryError {
-                msg: String::from(format!("Failed to find requisition {}", id)),
+                msg: String::from(format!(
+                    "Failed to find requisition record (requisition.id={})",
+                    id
+                )),
             }),
         }
     }

--- a/src/database/repository/mock/requisition_line.rs
+++ b/src/database/repository/mock/requisition_line.rs
@@ -1,6 +1,7 @@
 use crate::database::repository::RepositoryError;
 use crate::database::schema::{DatabaseRow, RequisitionLineRow};
 
+use log::info;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -18,6 +19,10 @@ impl RequisitionLineRepository {
         &self,
         requisition_line: &RequisitionLineRow,
     ) -> Result<(), RepositoryError> {
+        info!(
+            "Inserting requisition_line record (requisition_line.id={})",
+            requisition_line.id
+        );
         self.mock_data.lock().unwrap().insert(
             requisition_line.id.to_string(),
             DatabaseRow::RequisitionLine(requisition_line.clone()),
@@ -26,10 +31,14 @@ impl RequisitionLineRepository {
     }
 
     pub async fn find_one_by_id(&self, id: &str) -> Result<RequisitionLineRow, RepositoryError> {
+        info!("Querying requisition_line record (id={})", id);
         match self.mock_data.lock().unwrap().get(&id.to_string()) {
             Some(DatabaseRow::RequisitionLine(requisition_line)) => Ok(requisition_line.clone()),
             _ => Err(RepositoryError {
-                msg: String::from(format!("Failed to find requisition_line {}", id)),
+                msg: String::from(format!(
+                    "Failed to find requisition_line record (requisition_line.id={})",
+                    id
+                )),
             }),
         }
     }
@@ -38,6 +47,10 @@ impl RequisitionLineRepository {
         &self,
         requisition_id: &str,
     ) -> Result<Vec<RequisitionLineRow>, RepositoryError> {
+        info!(
+            "Querying requisition_line records (requisition_line.requisition_id={})",
+            requisition_id
+        );
         let mut requisition_lines = vec![];
         self.mock_data
             .lock()

--- a/src/database/repository/mock/store.rs
+++ b/src/database/repository/mock/store.rs
@@ -1,6 +1,7 @@
 use crate::database::repository::RepositoryError;
 use crate::database::schema::{DatabaseRow, StoreRow};
 
+use log::info;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -15,6 +16,7 @@ impl StoreRepository {
     }
 
     pub async fn insert_one(&self, store: &StoreRow) -> Result<(), RepositoryError> {
+        info!("Inserting store record (store.id={})", store.id);
         self.mock_data
             .lock()
             .unwrap()
@@ -23,10 +25,11 @@ impl StoreRepository {
     }
 
     pub async fn find_one_by_id(&self, id: &str) -> Result<StoreRow, RepositoryError> {
+        info!("Querying store record (store.id={})", id);
         match self.mock_data.lock().unwrap().get(&String::from(id)) {
             Some(DatabaseRow::Store(store)) => Ok(store.clone()),
             _ => Err(RepositoryError {
-                msg: String::from(format!("Failed to find store {}", id)),
+                msg: String::from(format!("Failed to find store record (store.id={})", id)),
             }),
         }
     }

--- a/src/database/repository/mock/transact.rs
+++ b/src/database/repository/mock/transact.rs
@@ -1,6 +1,7 @@
 use crate::database::repository::RepositoryError;
 use crate::database::schema::{DatabaseRow, TransactRow, TransactRowType};
 
+use log::info;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -15,6 +16,7 @@ impl TransactRepository {
     }
 
     pub async fn insert_one(&self, transact: &TransactRow) -> Result<(), RepositoryError> {
+        info!("Inserting transact record (transact.id={})", transact.id);
         self.mock_data.lock().unwrap().insert(
             transact.id.to_string(),
             DatabaseRow::Transact(transact.clone()),
@@ -23,10 +25,14 @@ impl TransactRepository {
     }
 
     pub async fn find_one_by_id(&self, id: &str) -> Result<TransactRow, RepositoryError> {
+        info!("Querying transact record (transact.id={})", id);
         match self.mock_data.lock().unwrap().get(&id.to_string()) {
             Some(DatabaseRow::Transact(transact)) => Ok(transact.clone()),
             _ => Err(RepositoryError {
-                msg: String::from(format!("Failed to find transact {}", id)),
+                msg: String::from(format!(
+                    "Failed to find transact record (transact.id={})",
+                    id
+                )),
             }),
         }
     }
@@ -46,6 +52,11 @@ impl CustomerInvoiceRepository {
         &self,
         name_id: &str,
     ) -> Result<Vec<TransactRow>, RepositoryError> {
+        info!(
+            "Querying transact_line records (transact_line.name_id={})",
+            name_id
+        );
+
         let mut customer_invoices = vec![];
         self.mock_data.lock().unwrap().clone().into_iter().for_each(
             |(_id, row): (String, DatabaseRow)| {
@@ -65,6 +76,10 @@ impl CustomerInvoiceRepository {
         &self,
         store_id: &str,
     ) -> Result<Vec<TransactRow>, RepositoryError> {
+        info!(
+            "Querying customer_invoice records (transact.store_id={})",
+            store_id
+        );
         let mut customer_invoices = vec![];
         self.mock_data.lock().unwrap().clone().into_iter().for_each(
             |(_id, row): (String, DatabaseRow)| {

--- a/src/database/repository/mock/transact_line.rs
+++ b/src/database/repository/mock/transact_line.rs
@@ -1,6 +1,7 @@
 use crate::database::repository::RepositoryError;
 use crate::database::schema::{DatabaseRow, TransactLineRow};
 
+use log::info;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -15,6 +16,10 @@ impl TransactLineRepository {
     }
 
     pub async fn insert_one(&self, transact_line: &TransactLineRow) -> Result<(), RepositoryError> {
+        info!(
+            "Inserting transact_line record (transact_line.id={})",
+            transact_line.id
+        );
         self.mock_data.lock().unwrap().insert(
             transact_line.id.to_string(),
             DatabaseRow::TransactLine(transact_line.clone()),
@@ -23,10 +28,14 @@ impl TransactLineRepository {
     }
 
     pub async fn find_one_by_id(&self, id: &str) -> Result<TransactLineRow, RepositoryError> {
+        info!("Querying transact_line record (transact_line.id={})", id);
         match self.mock_data.lock().unwrap().get(&id.to_string()) {
             Some(DatabaseRow::TransactLine(transact_line)) => Ok(transact_line.clone()),
             _ => Err(RepositoryError {
-                msg: String::from(format!("Failed to find transact_line {}", id)),
+                msg: String::from(format!(
+                    "Failed to find transact_line record (transact_line.id={})",
+                    id
+                )),
             }),
         }
     }
@@ -35,6 +44,10 @@ impl TransactLineRepository {
         &self,
         transact_id: &str,
     ) -> Result<Vec<TransactLineRow>, RepositoryError> {
+        info!(
+            "Querying transact_line records (transact_line.transact_id={})",
+            transact_id
+        );
         let mut transact_lines = vec![];
         self.mock_data
             .lock()

--- a/src/database/repository/mock/user_account.rs
+++ b/src/database/repository/mock/user_account.rs
@@ -1,6 +1,7 @@
 use crate::database::repository::RepositoryError;
 use crate::database::schema::{DatabaseRow, UserAccountRow};
 
+use log::info;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -15,6 +16,10 @@ impl UserAccountRepository {
     }
 
     pub async fn insert_one(&self, user_account: &UserAccountRow) -> Result<(), RepositoryError> {
+        info!(
+            "Inserting user_account record (user_account.id={})",
+            user_account.id
+        );
         self.mock_data.lock().unwrap().insert(
             user_account.id.to_string(),
             DatabaseRow::UserAccount(user_account.clone()),
@@ -23,10 +28,14 @@ impl UserAccountRepository {
     }
 
     pub async fn find_one_by_id(&self, id: &str) -> Result<UserAccountRow, RepositoryError> {
+        info!("Querying user_account {}", id);
         match self.mock_data.lock().unwrap().get(&id.to_string()) {
             Some(DatabaseRow::UserAccount(user_account)) => Ok(user_account.clone()),
             _ => Err(RepositoryError {
-                msg: String::from(format!("Failed to find user_account {}", id)),
+                msg: String::from(format!(
+                    "Failed to find user_account record (user_account.id={})",
+                    id
+                )),
             }),
         }
     }


### PR DESCRIPTION
Closes #251.

Example output:

```
[2021-08-19T07:21:52Z INFO  remote_server::database::repository::repository::requisition] Querying requisition record (requisition.id=requisition_za)
[2021-08-19T07:21:52Z INFO  remote_server::database::repository::repository::name] Querying name record (name.id=name_store_a)
[2021-08-19T07:21:52Z INFO  remote_server::database::repository::repository::store] Querying store record (store.id=store_b)
[2021-08-19T07:21:52Z INFO  remote_server::database::repository::repository::requisition_line] Querying requisition_line records (requisition_line.requisition_id=requisition_za)
[2021-08-19T07:21:52Z INFO  remote_server::database::repository::repository::item] Querying item record (item.id=item_a)
```