### PR TITLE
[No issue] Add linux support to the init script + update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,20 @@ mSupply remote server is a component of the Open mSupply system:
 
 ### Windows
 
-  - Install [WSL2](https://docs.microsoft.com/en-us/windows/wsl/install-win10) and [Ubuntu 20.04 LTS](https://www.microsoft.com/en-nz/p/ubuntu-2004-lts/9n6svws3rx71).
-  - Follow the [Rust installation guide](https://www.rust-lang.org/tools/install) for `Windows Subsystem for Linux` users.
-  - Follow the [Docker Desktop installation guide](https://docs.docker.com/docker-for-windows/wsl) for WLS2.
+- Install [WSL2](https://docs.microsoft.com/en-us/windows/wsl/install-win10) and [Ubuntu 20.04 LTS](https://www.microsoft.com/en-nz/p/ubuntu-2004-lts/9n6svws3rx71).
+- Follow the [Rust installation guide](https://www.rust-lang.org/tools/install) for `Windows Subsystem for Linux` users.
+- Follow the [Docker Desktop installation guide](https://docs.docker.com/docker-for-windows/wsl) for WLS2.
 
 ### MacOS
 
-  - Follow the [Rust installation guide](https://www.rust-lang.org/tools/install).
-  - Follow the [Docker Desktop installation guide](https://docs.docker.com/docker-for-mac/install/) for Mac.
+- Follow the [Rust installation guide](https://www.rust-lang.org/tools/install).
+- Follow the [Docker Desktop installation guide](https://docs.docker.com/docker-for-mac/install/) for Mac.
+
+### Ubuntu
+
+- Follow the [Rust installation guide](https://www.rust-lang.org/tools/install).
+- Follow the [Docker Desktop installation guide](https://docs.docker.com/engine/install/) for Linux.
+- Install pkg-config `sudo apt install pkg-config` (needed to install/compile sqlx-cli)
 
 ### Optional
 

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -8,7 +8,12 @@ DB_PASSWORD="${POSTGRES_PASSWORD:=password}"
 DB_NAME="${POSTGRES_DB:=omsupply-database}"
 DB_PORT="${POSTGRES_PORT:=5432}"
 
-docker run \
+DOCKER_CMD="docker"
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    DOCKER_CMD="sudo docker"
+fi
+
+$DOCKER_CMD run \
     -e POSTGRES_USER=${DB_USER} \
     -e POSTGRES_PASSWORD=${DB_PASSWORD} \
     -e POSTGRES_DB=${DB_NAME} \


### PR DESCRIPTION
Not optimal, but spinning up Postgres in rootless mode doesn't seem to work...