### PR TITLE
Explore aysnc graphql errors

### DIFF
--- a/configuration/base.yaml
+++ b/configuration/base.yaml
@@ -6,7 +6,7 @@ sync:
   password: "password"
   interval: 300
 database:
-  host: "localhost"
+  host: "127.0.0.1"
   port: 5432
   username: "postgres"
   password: "password"

--- a/configuration/base.yaml
+++ b/configuration/base.yaml
@@ -6,7 +6,7 @@ sync:
   password: "password"
   interval: 300
 database:
-  host: "127.0.0.1"
+  host: "localhost"
   port: 5432
   username: "postgres"
   password: "password"

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,9 +64,6 @@ async fn main() -> std::io::Result<()> {
     tokio::select! {
         result = http_server => result,
         () = async {
-          sync_sender.schedule_send(Duration::from_secs(settings.sync.interval)).await;
-        } => unreachable!("Sync receiver unexpectedly died!?"),
-        () = async {
           sync_receiver.listen().await;
         } => unreachable!("Sync scheduler unexpectedly died!?"),
     }


### PR DESCRIPTION
Demonstration of extending error handling with async graphql, you can use this docker command to run `docker run -ti -p 8000:8001 msupplyfoundation/remote-server:graphql-error-example`, and conclusions are here: https://github.com/openmsupply/org-issues/discussions/25#discussioncomment-1282539

If you want to check out docker setup it's in remote-server-docker branch: https://github.com/openmsupply/remote-server/compare/remote-server-docker

Once docker image is loaded, navigate to localhost:8000/graphql and try queries below (the play button let's you select which one to run)

```gql
#-- to show a string error
query stringError {
  name(id: "this_causes_string_error") {
    id
    name
  }
}
#-- to show what happens when there is a panic somewhere that we missed
query panicError {
  name(id: "this_causes_uhandled_panic") {
    id
    name
  }
}
#-- to show what happens with two batch of errors
query panicAndStringError {
  panicError: name(id: "this_causes_uhandled_panic") {
    id
    name
  }
  stringError: name(id: "this_causes_string_error") {
    id
    name
  }
}
#-- to show that batch queries are working
query batchQueryNoError {
  nameOne: name(id: "") {
    id
    name
  }
  nameTwo: name(id: "") {
    id
    name
  }
}
#-- to show that the first thrown error is the only error thrown
query panicAndStringErrorWithPanicDelay {
  panicError: name(id: "this_causes_uhandled_panic", delaySeconds: 10) {
    id
    name
  }
  stringError: name(id: "this_causes_string_error") {
    id
    name
  }
}
#-- to show that delay is working
query batchQueryNoErrorWithDelay {
  nameOne: name(id: "", delaySeconds: 2) {
    id
    name
  }
  nameTwo: name(id: "") {
    id
    name
  }
}

#-- to show that delay is working
query structuredError {
  name(id: "this_causes_structured_error") {
    id
    name
  }
}

#-- structured input parameters with no error
query structureInput {
  name(
    id: ""
    structuredInput: [{ type: ONE }, { type: THREE, direction: true }]
  ) {
    id
    name
  }
}

# -- structured input parameters with error
# -- commented out because GraphIQL can't deal with one query being wrong
# query structureInputWithError {
#   name(
#     id: ""
#     structuredInput: [{ type: ONE }, { type: FOUR, direction: true }]
#   ) {
#     id
#     name
#   }
# }
```