### PR TITLE
281- Implement first translation version

### DIFF
--- a/src/database/repository/diesel/name.rs
+++ b/src/database/repository/diesel/name.rs
@@ -1,38 +1,94 @@
-use super::DBBackendConnection;
+use super::{DBBackendConnection, DBTransaction};
 
-use crate::database::{
-    repository::{repository::get_connection, RepositoryError},
-    schema::NameRow,
-};
+use crate::database::{repository::RepositoryError, schema::NameRow};
 
 use diesel::{
     prelude::*,
     r2d2::{ConnectionManager, Pool},
 };
 
+pub enum TxHolder<'a> {
+    OwnedTx(DBTransaction),
+    SharedTx(&'a DBTransaction),
+}
+
+impl<'a> TxHolder<'a> {
+    fn get_tx(&self) -> &DBTransaction {
+        match self {
+            TxHolder::OwnedTx(ref t) => &t,
+            TxHolder::SharedTx(t) => t,
+        }
+    }
+}
+
+pub trait TransactionGetter {
+    fn get(&self) -> Result<TxHolder, RepositoryError>;
+}
+
 #[derive(Clone)]
-pub struct NameRepository {
+pub struct PoolTransactionGetter {
     pool: Pool<ConnectionManager<DBBackendConnection>>,
 }
 
-impl NameRepository {
-    pub fn new(pool: Pool<ConnectionManager<DBBackendConnection>>) -> NameRepository {
-        NameRepository { pool }
+impl TransactionGetter for PoolTransactionGetter {
+    fn get(&self) -> Result<TxHolder, RepositoryError> {
+        let conn = self.pool.get().map_err(|_| RepositoryError::DBError {
+            msg: "Failed to open Connection".to_string(),
+        })?;
+        Ok(TxHolder::OwnedTx(conn))
     }
+}
 
+pub struct ExistingTransactionGetter<'a> {
+    transaction: &'a DBTransaction,
+}
+
+impl<'a> TransactionGetter for ExistingTransactionGetter<'a> {
+    fn get(&self) -> Result<TxHolder, RepositoryError> {
+        Ok(TxHolder::SharedTx(self.transaction))
+    }
+}
+
+#[derive(Clone)]
+pub struct NameRepositoryImp<T: TransactionGetter> {
+    //pool: Option<Pool<ConnectionManager<DBBackendConnection>>>,
+    getter: T,
+}
+
+pub type NameRepository = NameRepositoryImp<PoolTransactionGetter>;
+
+pub fn new_name_repository(
+    pool: Pool<ConnectionManager<DBBackendConnection>>,
+) -> NameRepositoryImp<PoolTransactionGetter> {
+    NameRepositoryImp {
+        getter: PoolTransactionGetter { pool },
+    }
+}
+
+pub fn new_tx_name_repository<'a>(
+    tx: &'a DBTransaction,
+) -> NameRepositoryImp<ExistingTransactionGetter<'a>> {
+    NameRepositoryImp {
+        getter: ExistingTransactionGetter { transaction: tx },
+    }
+}
+
+impl<T: TransactionGetter> NameRepositoryImp<T> {
     pub async fn insert_one(&self, name_row: &NameRow) -> Result<(), RepositoryError> {
         use crate::database::schema::diesel_schema::name_table::dsl::*;
-        let connection = get_connection(&self.pool)?;
+        let tx_holder = self.getter.get()?;
         diesel::insert_into(name_table)
             .values(name_row)
-            .execute(&connection)?;
+            .execute(tx_holder.get_tx())?;
         Ok(())
     }
 
     pub async fn find_one_by_id(&self, name_id: &str) -> Result<NameRow, RepositoryError> {
         use crate::database::schema::diesel_schema::name_table::dsl::*;
-        let connection = get_connection(&self.pool)?;
-        let result = name_table.filter(id.eq(name_id)).first(&connection)?;
+        let tx_holder = self.getter.get()?;
+        let result = name_table
+            .filter(id.eq(name_id))
+            .first(tx_holder.get_tx())?;
         Ok(result)
     }
 }

--- a/src/database/repository/diesel/transaction_manager.rs
+++ b/src/database/repository/diesel/transaction_manager.rs
@@ -1,0 +1,48 @@
+use crate::database::repository::RepositoryError;
+
+use super::{get_connection, DBBackendConnection, DBTransaction};
+
+use diesel::{
+    connection::TransactionManager,
+    r2d2::{ConnectionManager, Pool},
+    Connection,
+};
+
+#[derive(Clone)]
+pub struct TxManager {
+    pool: Pool<ConnectionManager<DBBackendConnection>>,
+}
+
+impl TxManager {
+    pub fn new(pool: Pool<ConnectionManager<DBBackendConnection>>) -> TxManager {
+        TxManager { pool }
+    }
+
+    pub fn create_tx(&self) -> Result<DBTransaction, RepositoryError> {
+        get_connection(&self.pool)
+    }
+
+    pub async fn transaction<'a, T, Fut>(
+        &self,
+        con: &DBTransaction,
+        f: impl FnOnce() -> Fut,
+    ) -> Result<T, RepositoryError>
+    where
+        Fut: std::future::Future<Output = Result<T, RepositoryError>>,
+    {
+        //let con = get_connection(&self.pool)?;
+        let transaction_manager = con.transaction_manager();
+        transaction_manager.begin_transaction(con)?;
+
+        match f().await {
+            Ok(value) => {
+                transaction_manager.commit_transaction(con)?;
+                Ok(value)
+            }
+            Err(e) => {
+                transaction_manager.rollback_transaction(con)?;
+                Err(e)
+            }
+        }
+    }
+}

--- a/src/database/repository/mod.rs
+++ b/src/database/repository/mod.rs
@@ -33,7 +33,7 @@ pub enum RepositoryError {
 pub mod repository;
 
 pub use repository::{
-    CustomerInvoiceRepository, ItemLineRepository, ItemRepository, NameRepository,
-    RequisitionLineRepository, RequisitionRepository, StoreRepository, TransactLineRepository,
-    TransactRepository, UserAccountRepository,
+    new_tx_name_repository, CustomerInvoiceRepository, DBTransaction, ItemLineRepository,
+    ItemRepository, NameRepository, RequisitionLineRepository, RequisitionRepository,
+    StoreRepository, TransactLineRepository, TransactRepository, TxManager, UserAccountRepository,
 };

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -3,3 +3,4 @@ pub mod configuration;
 pub mod environment;
 pub mod settings;
 pub mod sync;
+pub mod test_db;

--- a/src/util/sync/mod.rs
+++ b/src/util/sync/mod.rs
@@ -2,6 +2,7 @@ mod connection;
 mod credentials;
 mod queue;
 mod server;
+mod translation;
 
 pub use connection::SyncConnection;
 pub use credentials::SyncCredentials;

--- a/src/util/sync/translation.rs
+++ b/src/util/sync/translation.rs
@@ -1,0 +1,241 @@
+use crate::{
+    database::{
+        repository::{new_tx_name_repository, DBTransaction, RepositoryError, TxManager},
+        schema::NameRow,
+    },
+    server::data::RepositoryRegistry,
+};
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+#[derive(Debug)]
+pub enum SyncType {
+    Delete,
+    Update,
+    Insert,
+}
+
+#[derive(Debug)]
+pub struct SyncRecord {
+    sync_type: SyncType,
+    record_type: String,
+    data: String,
+}
+
+#[async_trait]
+trait Mutatable {
+    async fn make_sync_mutation(&self, sync_type: &SyncType, tx: &DBTransaction);
+}
+
+#[derive(Deserialize)]
+struct LegacyNameTable {
+    #[serde(rename = "ID")]
+    id: String,
+    name: String,
+    fax: String,
+    phone: String,
+    customer: bool,
+    bill_address1: String,
+    bill_address2: String,
+    supplier: bool,
+    #[serde(rename = "charge code")]
+    charge_code: String,
+    margin: i64,
+    comment: String,
+    currency_ID: String,
+    country: String,
+    freightfac: i64,
+    email: String,
+    custom1: String,
+    code: String,
+    last: String,
+    first: String,
+    title: String,
+    female: bool,
+    date_of_birth: String,
+    overpayment: i64,
+    group_ID: String,
+    hold: bool,
+    ship_address1: String,
+    ship_address2: String,
+    url: String,
+    barcode: String,
+    postal_address1: String,
+    postal_address2: String,
+    category1_ID: String,
+    region_ID: String,
+    #[serde(rename = "type")]
+    table_type: String,
+    price_category: String,
+    flag: String,
+    manufacturer: bool,
+    print_invoice_alphabetical: bool,
+    custom2: String,
+    custom3: String,
+    default_order_days: i64,
+    connection_type: i64,
+    //PATIENT_PHOTO": "[object Picture]",
+    NEXT_OF_KIN_ID: String,
+    POBOX: String,
+    ZIP: i64,
+    middle: String,
+    preferred: bool,
+    Blood_Group: String,
+    marital_status: String,
+    Benchmark: bool,
+    next_of_kin_relative: String,
+    mother_id: String,
+    postal_address3: String,
+    postal_address4: String,
+    bill_address3: String,
+    bill_address4: String,
+    ship_address3: String,
+    ship_address4: String,
+    ethnicity_ID: String,
+    occupation_ID: String,
+    religion_ID: String,
+    national_health_number: String,
+    Master_RTM_Supplier_Code: i64,
+    ordering_method: String,
+    donor: bool,
+    latitude: i64,
+    longitude: i64,
+    Master_RTM_Supplier_name: String,
+    category2_ID: String,
+    category3_ID: String,
+    category4_ID: String,
+    category5_ID: String,
+    category6_ID: String,
+    bill_address5: String,
+    bill_postal_zip_code: String,
+    postal_address5: String,
+    postal_zip_code: String,
+    ship_address5: String,
+    ship_postal_zip_code: String,
+    supplying_store_id: String,
+    license_number: String,
+    license_expiry: String,
+    has_current_license: bool,
+    //custom_data": null,
+    maximum_credit: i64,
+    nationality_ID: String,
+    created_date: String,
+}
+
+impl From<&LegacyNameTable> for NameRow {
+    fn from(t: &LegacyNameTable) -> NameRow {
+        NameRow {
+            id: t.id.to_string(),
+            name: t.name.to_string(),
+        }
+    }
+}
+
+impl LegacyNameTable {
+    async fn try_translate(sync_record: &SyncRecord, tx: &DBTransaction) -> Result<bool, String> {
+        if sync_record.record_type != "name" {
+            return Ok(false);
+        }
+
+        let data = serde_json::from_str::<LegacyNameTable>(&sync_record.data)
+            .map_err(|_| "Deserialization Error".to_string())?;
+
+        let repo = new_tx_name_repository(&tx);
+        let name_row = NameRow::from(&data);
+        repo.insert_one(&name_row)
+            .await
+            .map_err(|_| "DB Error".to_string())?;
+        Ok(true)
+    }
+}
+
+async fn do_translation(sync_record: &SyncRecord, tx: &DBTransaction) -> Result<(), String> {
+    if LegacyNameTable::try_translate(sync_record, tx).await? {
+        return Ok(());
+    }
+
+    Err("Cannot find matching translation".to_string())
+}
+
+pub async fn import_sync_records(
+    registry: &RepositoryRegistry,
+    records: &Vec<SyncRecord>,
+) -> Result<(), String> {
+    let tx_manager = registry.get::<TxManager>();
+    let tx = tx_manager.create_tx().unwrap();
+    tx_manager
+        .transaction(&tx, || async {
+            for record in records {
+                do_translation(&record, &tx)
+                    .await
+                    .map_err(|e| RepositoryError::DBError { msg: e })?;
+            }
+            Ok(())
+        })
+        .await
+        .unwrap();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        database::repository::{repository::get_repositories, NameRepository},
+        server::data::RepositoryRegistry,
+        util::{
+            settings::{DatabaseSettings, ServerSettings, Settings, SyncSettings},
+            test_db::setup,
+        },
+    };
+
+    use super::{import_sync_records, SyncRecord, SyncType};
+
+    #[tokio::test]
+    async fn test_name_translation() {
+        let db_name = "omsupply-database-name-translation";
+        // The following settings work for PG and Sqlite (username, password, host and port are
+        // ignored for the later)
+        let settings = Settings {
+            server: ServerSettings {
+                host: "localhost".to_string(),
+                port: 5432,
+            },
+            database: DatabaseSettings {
+                username: "postgres".to_string(),
+                password: "password".to_string(),
+                port: 5432,
+                host: "localhost".to_string(),
+                database_name: db_name.to_owned(),
+            },
+            sync: SyncSettings {
+                username: "postgres".to_string(),
+                password: "password".to_string(),
+                port: 5432,
+                host: "localhost".to_string(),
+                interval: 100000000,
+            },
+        };
+        setup(&settings.database).await;
+        let repositories = get_repositories(&settings).await;
+        let registry = RepositoryRegistry { repositories };
+        let record_1 = SyncRecord {
+            sync_type: SyncType::Insert,
+            record_type: "name".to_string(),
+            data: r#"
+            {"ID":"CB929EB86530455AB0392277FAC3DBA4","name":"Birch Store","fax":"","phone":"","customer":true,"bill_address1":"234 Evil Street","bill_address2":"Scotland","supplier":false,"charge code":"SNA","margin":0,"comment":"","currency_ID":"8009D512AC0E4FD78625E3C8273B0171","country":"","freightfac":1,"email":"","custom1":"","code":"SNA","last":"","first":"","title":"","female":false,"date_of_birth":"0000-00-00","overpayment":0,"group_ID":"","hold":false,"ship_address1":"","ship_address2":"","url":"","barcode":"*SNA*","postal_address1":"","postal_address2":"","category1_ID":"","region_ID":"","type":"facility","price_category":"A","flag":"","manufacturer":false,"print_invoice_alphabetical":false,"custom2":"","custom3":"","default_order_days":0,"connection_type":0,"PATIENT_PHOTO":"[object Picture]","NEXT_OF_KIN_ID":"","POBOX":"","ZIP":0,"middle":"","preferred":false,"Blood_Group":"","marital_status":"","Benchmark":false,"next_of_kin_relative":"","mother_id":"","postal_address3":"","postal_address4":"","bill_address3":"","bill_address4":"","ship_address3":"","ship_address4":"","ethnicity_ID":"","occupation_ID":"","religion_ID":"","national_health_number":"","Master_RTM_Supplier_Code":0,"ordering_method":"sh","donor":false,"latitude":0,"longitude":0,"Master_RTM_Supplier_name":"","category2_ID":"","category3_ID":"","category4_ID":"","category5_ID":"","category6_ID":"","bill_address5":"","bill_postal_zip_code":"","postal_address5":"","postal_zip_code":"","ship_address5":"","ship_postal_zip_code":"","supplying_store_id":"D77F67339BF8400886D009178F4962E1","license_number":"","license_expiry":"0000-00-00","has_current_license":false,"custom_data":null,"maximum_credit":0,"nationality_ID":"","created_date":"0000-00-00"}
+            "#.to_string(),
+        };
+        let records = vec![record_1];
+
+        import_sync_records(&registry, &records).await.unwrap();
+
+        let name_repo = registry.get::<NameRepository>();
+        let entry = name_repo
+            .find_one_by_id("CB929EB86530455AB0392277FAC3DBA4")
+            .await
+            .unwrap();
+
+        assert_eq!(entry.name, "Birch Store");
+    }
+}

--- a/src/util/test_db.rs
+++ b/src/util/test_db.rs
@@ -1,4 +1,4 @@
-use remote_server::util::settings::DatabaseSettings;
+use crate::util::settings::DatabaseSettings;
 
 #[cfg(not(feature = "dieselsqlite"))]
 pub async fn setup(db_settings: &DatabaseSettings) {

--- a/tests/repository/basic.rs
+++ b/tests/repository/basic.rs
@@ -17,7 +17,7 @@ mod repository_basic_test {
         util::settings::{DatabaseSettings, ServerSettings, Settings, SyncSettings},
     };
 
-    use crate::repository::test_db;
+    use remote_server::util::test_db;
 
     async fn requisition_test(repo: &RequisitionRepository) {
         let item1 = RequisitionRow {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,3 @@
 mod repository {
     mod basic;
-    mod test_db;
 }


### PR DESCRIPTION
Here is my work in progress for the sync translations. There are two issues that are somewhat unrelated to the ticket but I would like to get some feedback on:

1) I would like to reuse existing Repositories for the sync transactions, e.g. use multiple repository calls in the same transaction. I did a proof of concept for the NameRepository. There are currently two versions of a generic NameRepositoryImp, one that works with a connection pool (as before) and one that works with a reference to an ongoing transaction. This works fine but I find the code a bit cumbersome/verbose. The blocker for me to make it a bit more concise is in:

```
pub type RepositoryMap = Map<AnyRepository>;
pub type AnyRepository = dyn CloneAny + Send + Sync;
```
I.e. the Repository has to be Clone + Send + Sync which is not possible for a reference to a transaction. My Question is, do we need to have it Send + Sync? If yes I could wrap the transaction reference into a Mutex and make the code look a bit nicer... other ideas?

2) Question for @chris-morgan : In TxManager I had to introduce a create_tx() method to work around a lifetime problem related to async functions. Any idea how to avoid it? (see todo comment)
