### PR TITLE
281 simple translation 2

### DIFF
--- a/migrations/postgres/00000105_create_item_table/up.sql
+++ b/migrations/postgres/00000105_create_item_table/up.sql
@@ -1,6 +1,6 @@
 -- Create item table.
 
-CREATE TYPE item_type AS ENUM ('general', 'service', 'cross_reference');
+CREATE TYPE item_type AS ENUM ('general', 'service', 'cross_reference', 'none_stock');
 
 CREATE TABLE item (
     id VARCHAR(255) NOT NULL PRIMARY KEY,

--- a/migrations/postgres/00000105_create_item_table/up.sql
+++ b/migrations/postgres/00000105_create_item_table/up.sql
@@ -1,9 +1,6 @@
 -- Create item table.
 
-CREATE TYPE item_type AS ENUM ('general', 'service', 'cross_reference', 'none_stock');
-
 CREATE TABLE item (
     id VARCHAR(255) NOT NULL PRIMARY KEY,
-    item_name VARCHAR(255) NOT NULL,
-    type_of item_type NOT NULL
+    name VARCHAR(255) NOT NULL
 )

--- a/migrations/sqlite/00000104_create_item_table/up.sql
+++ b/migrations/sqlite/00000104_create_item_table/up.sql
@@ -2,6 +2,5 @@
 
 CREATE TABLE item (
     id TEXT NOT NULL PRIMARY KEY,
-    item_name TEXT NOT NULL,
-    type_of TEXT CHECK(type_of IN ('general', 'service', 'cross_reference', 'none_stock')) NOT NULL
+    name TEXT NOT NULL
 )

--- a/migrations/sqlite/00000104_create_item_table/up.sql
+++ b/migrations/sqlite/00000104_create_item_table/up.sql
@@ -3,5 +3,5 @@
 CREATE TABLE item (
     id TEXT NOT NULL PRIMARY KEY,
     item_name TEXT NOT NULL,
-    type_of TEXT CHECK(type_of IN ('general', 'service', 'cross_reference')) NOT NULL
+    type_of TEXT CHECK(type_of IN ('general', 'service', 'cross_reference', 'none_stock')) NOT NULL
 )

--- a/src/database/mock/item.rs
+++ b/src/database/mock/item.rs
@@ -1,26 +1,23 @@
-use crate::database::schema::{ItemRow, ItemRowType};
+use crate::database::schema::ItemRow;
 
 pub fn mock_item_a() -> ItemRow {
     ItemRow {
         id: String::from("item_a"),
-        item_name: String::from("Item A"),
-        type_of: ItemRowType::General,
+        name: String::from("Item A"),
     }
 }
 
 pub fn mock_item_b() -> ItemRow {
     ItemRow {
         id: String::from("item_b"),
-        item_name: String::from("Item B"),
-        type_of: ItemRowType::General,
+        name: String::from("Item B"),
     }
 }
 
 pub fn mock_item_c() -> ItemRow {
     ItemRow {
         id: String::from("item_c"),
-        item_name: String::from("Item C"),
-        type_of: ItemRowType::General,
+        name: String::from("Item C"),
     }
 }
 

--- a/src/database/repository/diesel/item.rs
+++ b/src/database/repository/diesel/item.rs
@@ -1,4 +1,4 @@
-use super::DBBackendConnection;
+use super::{DBBackendConnection, DBConnection};
 
 use crate::database::{
     repository::{repository::get_connection, RepositoryError},
@@ -20,12 +20,56 @@ impl ItemRepository {
         ItemRepository { pool }
     }
 
-    pub async fn insert_one(&self, item_row: &ItemRow) -> Result<(), RepositoryError> {
+    #[cfg(feature = "postgres")]
+    pub fn upsert_one_tx(
+        connection: &DBConnection,
+        item_row: &ItemRow,
+    ) -> Result<(), RepositoryError> {
         use crate::database::schema::diesel_schema::item::dsl::*;
-        let connection = get_connection(&self.pool)?;
+
         diesel::insert_into(item)
             .values(item_row)
-            .execute(&connection)?;
+            .on_conflict(id)
+            .do_update()
+            .set(item_row)
+            .execute(connection)?;
+        Ok(())
+    }
+
+    #[cfg(feature = "sqlite")]
+    pub fn upsert_one_tx(
+        connection: &DBConnection,
+        item_row: &ItemRow,
+    ) -> Result<(), RepositoryError> {
+        use diesel::sql_types::Text;
+
+        let query = r#"
+        INSERT INTO item(id,item_name,type_of) VALUES($1, $2, $3)
+        ON CONFLICT(id) DO UPDATE SET
+            item_name=excluded.item_name,
+            type_of=excluded.type_of;"#;
+        let q = diesel::sql_query(query)
+            .bind::<Text, _>(&item_row.id)
+            .bind::<Text, _>(&item_row.item_name)
+            .bind::<crate::database::schema::item::ItemRowTypeMapping, _>(&item_row.type_of);
+        q.execute(connection)?;
+        Ok(())
+    }
+
+    pub fn insert_one_tx(
+        connection: &DBConnection,
+        item_row: &ItemRow,
+    ) -> Result<(), RepositoryError> {
+        use crate::database::schema::diesel_schema::item::dsl::*;
+        diesel::insert_into(item)
+            .values(item_row)
+            .execute(connection)?;
+        Ok(())
+    }
+
+    pub async fn insert_one(&self, item_row: &ItemRow) -> Result<(), RepositoryError> {
+        let connection = get_connection(&self.pool)?;
+        ItemRepository::insert_one_tx(&connection, item_row)?;
         Ok(())
     }
 

--- a/src/database/repository/diesel/mod.rs
+++ b/src/database/repository/diesel/mod.rs
@@ -8,6 +8,7 @@ mod name;
 mod requisition;
 mod requisition_line;
 mod store;
+mod sync;
 mod transact;
 mod transact_line;
 mod user_account;
@@ -18,6 +19,7 @@ pub use name::NameRepository;
 pub use requisition::RequisitionRepository;
 pub use requisition_line::RequisitionLineRepository;
 pub use store::StoreRepository;
+pub use sync::{IntegrationRecord, IntegrationUpsertRecord, SyncRepository};
 pub use transact::{CustomerInvoiceRepository, TransactRepository};
 pub use transact_line::TransactLineRepository;
 pub use user_account::UserAccountRepository;
@@ -31,8 +33,10 @@ use diesel::{
 #[cfg(feature = "sqlite")]
 type DBBackendConnection = SqliteConnection;
 
-#[cfg(feature = "postgres")]
+#[cfg(not(feature = "sqlite"))]
 type DBBackendConnection = PgConnection;
+
+pub type DBConnection = PooledConnection<ConnectionManager<DBBackendConnection>>;
 
 impl From<DieselError> for RepositoryError {
     fn from(err: DieselError) -> Self {
@@ -91,6 +95,7 @@ pub async fn get_repositories(settings: &Settings) -> RepositoryMap {
     repositories.insert(TransactRepository::new(pool.clone()));
     repositories.insert(TransactLineRepository::new(pool.clone()));
     repositories.insert(UserAccountRepository::new(pool.clone()));
+    repositories.insert(SyncRepository::new(pool.clone()));
 
     repositories
 }

--- a/src/database/repository/diesel/name.rs
+++ b/src/database/repository/diesel/name.rs
@@ -52,16 +52,10 @@ impl NameRepository {
         connection: &DBConnection,
         name_row: &NameRow,
     ) -> Result<(), RepositoryError> {
-        use diesel::sql_types::Text;
-
-        let query = r#"
-        INSERT INTO name(id,name) VALUES($1, $2)
-        ON CONFLICT(id) DO UPDATE SET
-            name=excluded.name;"#;
-        let q = diesel::sql_query(query)
-            .bind::<Text, _>(&name_row.id)
-            .bind::<Text, _>(&name_row.name);
-        q.execute(connection)?;
+        use crate::database::schema::diesel_schema::name_table::dsl::*;
+        diesel::replace_into(name_table)
+            .values(name_row)
+            .execute(connection)?;
         Ok(())
     }
 

--- a/src/database/repository/diesel/sync.rs
+++ b/src/database/repository/diesel/sync.rs
@@ -1,3 +1,5 @@
+use super::{get_connection, DBBackendConnection, ItemRepository, NameRepository};
+
 use crate::database::{
     repository::RepositoryError,
     schema::{ItemRow, NameRow},
@@ -7,8 +9,6 @@ use diesel::{
     prelude::*,
     r2d2::{ConnectionManager, Pool},
 };
-
-use super::{get_connection, DBBackendConnection, ItemRepository, NameRepository};
 
 pub enum IntegrationUpsertRecord {
     Name(NameRow),

--- a/src/database/repository/diesel/sync.rs
+++ b/src/database/repository/diesel/sync.rs
@@ -1,0 +1,51 @@
+use crate::database::{
+    repository::RepositoryError,
+    schema::{ItemRow, NameRow},
+};
+
+use diesel::{
+    prelude::*,
+    r2d2::{ConnectionManager, Pool},
+};
+
+use super::{get_connection, DBBackendConnection, ItemRepository, NameRepository};
+
+pub enum IntegrationUpsertRecord {
+    Name(NameRow),
+    Item(ItemRow),
+}
+
+pub struct IntegrationRecord {
+    pub upserts: Vec<IntegrationUpsertRecord>,
+}
+
+#[derive(Clone)]
+pub struct SyncRepository {
+    pool: Pool<ConnectionManager<DBBackendConnection>>,
+}
+
+impl SyncRepository {
+    pub fn new(pool: Pool<ConnectionManager<DBBackendConnection>>) -> SyncRepository {
+        SyncRepository { pool }
+    }
+
+    pub async fn integrate_records(
+        &self,
+        integration_records: &IntegrationRecord,
+    ) -> Result<(), RepositoryError> {
+        let connection = get_connection(&self.pool)?;
+        connection.transaction(|| {
+            for record in &integration_records.upserts {
+                match &record {
+                    IntegrationUpsertRecord::Name(record) => {
+                        NameRepository::upsert_one_tx(&connection, record)?
+                    }
+                    IntegrationUpsertRecord::Item(record) => {
+                        ItemRepository::upsert_one_tx(&connection, record)?
+                    }
+                }
+            }
+            Ok(())
+        })
+    }
+}

--- a/src/database/repository/mod.rs
+++ b/src/database/repository/mod.rs
@@ -24,7 +24,8 @@ pub enum RepositoryError {
 pub mod repository;
 
 pub use repository::{
-    get_repositories, CustomerInvoiceRepository, ItemLineRepository, ItemRepository,
-    NameRepository, RequisitionLineRepository, RequisitionRepository, StoreRepository,
-    TransactLineRepository, TransactRepository, UserAccountRepository,
+    get_repositories, CustomerInvoiceRepository, IntegrationRecord, ItemLineRepository,
+    ItemRepository, NameRepository, RequisitionLineRepository, RequisitionRepository,
+    StoreRepository, SyncRepository, TransactLineRepository, TransactRepository,
+    UserAccountRepository,
 };

--- a/src/database/schema/diesel_schema.rs
+++ b/src/database/schema/diesel_schema.rs
@@ -11,8 +11,7 @@ table! {
 table! {
   item {
     id -> Text,
-    item_name -> Text,
-    type_of -> crate::database::schema::item::ItemRowTypeMapping,
+    name -> Text,
   }
 }
 

--- a/src/database/schema/item.rs
+++ b/src/database/schema/item.rs
@@ -9,7 +9,7 @@ pub enum ItemRowType {
     NoneStock,
 }
 
-#[derive(Clone, Insertable, Queryable, Debug, PartialEq, Eq)]
+#[derive(Clone, Insertable, Queryable, Debug, PartialEq, Eq, AsChangeset)]
 #[table_name = "item"]
 pub struct ItemRow {
     pub id: String,

--- a/src/database/schema/item.rs
+++ b/src/database/schema/item.rs
@@ -1,18 +1,8 @@
 use super::diesel_schema::item;
-use diesel_derive_enum::DbEnum;
-
-#[derive(DbEnum, Clone, Debug, PartialEq, Eq)]
-pub enum ItemRowType {
-    General,
-    Service,
-    CrossReference,
-    NoneStock,
-}
 
 #[derive(Clone, Insertable, Queryable, Debug, PartialEq, Eq, AsChangeset)]
 #[table_name = "item"]
 pub struct ItemRow {
     pub id: String,
-    pub item_name: String,
-    pub type_of: ItemRowType,
+    pub name: String,
 }

--- a/src/database/schema/item.rs
+++ b/src/database/schema/item.rs
@@ -6,6 +6,7 @@ pub enum ItemRowType {
     General,
     Service,
     CrossReference,
+    NoneStock,
 }
 
 #[derive(Clone, Insertable, Queryable, Debug, PartialEq, Eq)]

--- a/src/database/schema/mod.rs
+++ b/src/database/schema/mod.rs
@@ -1,4 +1,4 @@
-mod item;
+pub(crate) mod item;
 mod item_line;
 mod name;
 mod requisition;

--- a/src/database/schema/mod.rs
+++ b/src/database/schema/mod.rs
@@ -23,7 +23,7 @@ pub enum DatabaseRow {
     UserAccount(UserAccountRow),
 }
 
-pub use item::{ItemRow, ItemRowType};
+pub use item::ItemRow;
 pub use item_line::ItemLineRow;
 pub use name::NameRow;
 pub use requisition::{RequisitionRow, RequisitionRowType};

--- a/src/database/schema/name.rs
+++ b/src/database/schema/name.rs
@@ -1,6 +1,6 @@
 use super::diesel_schema::name_table;
 
-#[derive(Clone, Queryable, Insertable, Debug, PartialEq, Eq)]
+#[derive(Clone, Queryable, Insertable, Debug, PartialEq, Eq, AsChangeset)]
 #[table_name = "name_table"]
 pub struct NameRow {
     pub id: String,

--- a/src/server/service/graphql/schema/mutations.rs
+++ b/src/server/service/graphql/schema/mutations.rs
@@ -3,7 +3,7 @@ use crate::database::repository::{
 };
 use crate::database::schema::{ItemRow, RequisitionLineRow, RequisitionRow};
 use crate::server::service::graphql::schema::types::{
-    InputRequisitionLine, Item, ItemType, Requisition, RequisitionType,
+    InputRequisitionLine, Item, Requisition, RequisitionType,
 };
 use crate::server::service::graphql::ContextExt;
 
@@ -17,14 +17,9 @@ impl Mutations {
         &self,
         ctx: &Context<'_>,
         #[graphql(desc = "id of the item")] id: String,
-        #[graphql(desc = "name of the item")] item_name: String,
-        #[graphql(desc = "type of the item")] type_of: ItemType,
+        #[graphql(desc = "name of the item")] name: String,
     ) -> Item {
-        let item_row = ItemRow {
-            id,
-            item_name,
-            type_of: type_of.into(),
-        };
+        let item_row = ItemRow { id, name };
 
         let item_repository = ctx.get_repository::<ItemRepository>();
 

--- a/src/server/service/graphql/schema/types.rs
+++ b/src/server/service/graphql/schema/types.rs
@@ -105,6 +105,8 @@ pub enum ItemType {
     Service,
     #[graphql(name = "cross_reference")]
     CrossReference,
+    #[graphql(name = "none_stock")]
+    NoneStock,
 }
 
 impl From<ItemRowType> for ItemType {
@@ -113,6 +115,7 @@ impl From<ItemRowType> for ItemType {
             ItemRowType::General => ItemType::General,
             ItemRowType::Service => ItemType::Service,
             ItemRowType::CrossReference => ItemType::CrossReference,
+            ItemRowType::NoneStock => ItemType::NoneStock,
         }
     }
 }
@@ -123,6 +126,7 @@ impl From<ItemType> for ItemRowType {
             ItemType::General => ItemRowType::General,
             ItemType::Service => ItemRowType::Service,
             ItemType::CrossReference => ItemRowType::CrossReference,
+            ItemType::NoneStock => ItemRowType::NoneStock,
         }
     }
 }

--- a/src/server/service/graphql/schema/types.rs
+++ b/src/server/service/graphql/schema/types.rs
@@ -5,8 +5,8 @@ use crate::{
             CustomerInvoiceRepository, RequisitionLineRepository, TransactLineRepository,
         },
         schema::{
-            ItemLineRow, ItemRow, ItemRowType, NameRow, RequisitionLineRow, RequisitionRow,
-            RequisitionRowType, StoreRow, TransactLineRow, TransactRow, TransactRowType,
+            ItemLineRow, ItemRow, NameRow, RequisitionLineRow, RequisitionRow, RequisitionRowType,
+            StoreRow, TransactLineRow, TransactRow, TransactRowType,
         },
     },
     server::service::graphql::ContextExt,
@@ -97,40 +97,6 @@ impl Store {
     }
 }
 
-#[derive(Enum, Copy, Clone, PartialEq, Eq)]
-pub enum ItemType {
-    #[graphql(name = "general")]
-    General,
-    #[graphql(name = "service")]
-    Service,
-    #[graphql(name = "cross_reference")]
-    CrossReference,
-    #[graphql(name = "none_stock")]
-    NoneStock,
-}
-
-impl From<ItemRowType> for ItemType {
-    fn from(item_type: ItemRowType) -> ItemType {
-        match item_type {
-            ItemRowType::General => ItemType::General,
-            ItemRowType::Service => ItemType::Service,
-            ItemRowType::CrossReference => ItemType::CrossReference,
-            ItemRowType::NoneStock => ItemType::NoneStock,
-        }
-    }
-}
-
-impl From<ItemType> for ItemRowType {
-    fn from(item_type: ItemType) -> ItemRowType {
-        match item_type {
-            ItemType::General => ItemRowType::General,
-            ItemType::Service => ItemRowType::Service,
-            ItemType::CrossReference => ItemRowType::CrossReference,
-            ItemType::NoneStock => ItemRowType::NoneStock,
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct Item {
     pub item_row: ItemRow,
@@ -143,11 +109,7 @@ impl Item {
     }
 
     pub async fn item_name(&self) -> &str {
-        &self.item_row.item_name
-    }
-
-    pub async fn type_of(&self) -> ItemType {
-        self.item_row.type_of.clone().into()
+        &self.item_row.name
     }
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -3,3 +3,4 @@ pub mod configuration;
 pub mod environment;
 pub mod settings;
 pub mod sync;
+pub mod test_db;

--- a/src/util/settings.rs
+++ b/src/util/settings.rs
@@ -62,7 +62,7 @@ impl DatabaseSettings {
 #[cfg(feature = "sqlite")]
 impl DatabaseSettings {
     pub fn connection_string(&self) -> String {
-        format!("{}.sqlite", self.database_name.to_string())
+        format!("{}.sqlite", self.database_name)
     }
 
     pub fn connection_string_without_db(&self) -> String {

--- a/src/util/sync/mod.rs
+++ b/src/util/sync/mod.rs
@@ -2,6 +2,7 @@ mod connection;
 mod credentials;
 mod queue;
 mod server;
+mod translation;
 
 pub use connection::SyncConnection;
 pub use credentials::SyncCredentials;

--- a/src/util/sync/translation/item.rs
+++ b/src/util/sync/translation/item.rs
@@ -1,0 +1,167 @@
+use super::SyncRecord;
+
+use crate::database::schema::{ItemRow, ItemRowType};
+
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct LegacyItemRow {
+    #[serde(rename = "ID")]
+    id: String,
+    item_name: String,
+    type_of: String,
+    /*
+    start_of_year_date: String,
+    manufacture_method: String,
+    default_pack_size: i64,
+    //dose_picture": "[object Picture]",
+    atc_category: String,
+    medication_purpose: String,
+    instructions: String,
+    user_field_7: bool,
+    flags: String,
+    ddd_value: String,
+    code: String,
+    other_names: String,
+    price_editable: bool,
+    margin: i64,
+    barcode_spare: String,
+    spare_ignore_for_orders: bool,
+    sms_pack_size: i64,
+    expiry_date_mandatory: bool,
+    volume_per_pack: i64,
+    department_ID: String,
+    weight: i64,
+    essential_drug_list: bool,
+    catalogue_code: String,
+    indic_price: i64,
+    user_field_1: String,
+    spare_hold_for_issue: bool,
+    builds_only: bool,
+    reference_bom_quantity: i64,
+    use_bill_of_materials: bool,
+    description: String,
+    spare_hold_for_receive: bool,
+    Message: String,
+    interaction_group_ID: String,
+    spare_pack_to_one_on_receive: bool,
+    cross_ref_item_ID: String,
+    strength: String,
+    user_field_4: bool,
+    user_field_6: String,
+    spare_internal_analysis: i64,
+    user_field_2: String,
+    user_field_3: String,
+    factor: i64,
+    account_stock_ID: String,
+    account_purchases_ID: String,
+    account_income_ID: String,
+    unit_ID: String,
+    outer_pack_size: i64,
+    category_ID: String,
+    ABC_category: String,
+    warning_quantity: i64,
+    user_field_5: i64,
+    print_units_in_dis_labels: bool,
+    volume_per_outer_pack: i64,
+    normal_stock: bool,
+    critical_stock: bool,
+    spare_non_stock: bool,
+    non_stock_name_ID: String,
+    is_sync: bool,
+    sms_code: String,
+    category2_ID: String,
+    category3_ID: String,
+    buy_price: i64,
+    VEN_category: String,
+    universalcodes_code: String,
+    universalcodes_name: String,
+    //kit_data": null,
+    //custom_data": null,
+    doses: i64,
+    is_vaccine: bool,
+    restricted_location_type_ID: String,
+    */
+}
+
+fn match_item_type(type_of: String) -> ItemRowType {
+    match type_of.as_str() {
+        "general" => ItemRowType::General,
+        "service" => ItemRowType::Service,
+        "cross_reference" => ItemRowType::CrossReference,
+        "non_stock" => ItemRowType::NoneStock,
+        _ => panic!("unknown type"),
+    }
+}
+
+impl LegacyItemRow {
+    pub fn try_translate(sync_record: &SyncRecord) -> Result<Option<ItemRow>, String> {
+        if sync_record.record_type != "item" {
+            return Ok(None);
+        }
+        let data = serde_json::from_str::<LegacyItemRow>(&sync_record.data)
+            .map_err(|_| "Deserialization Error".to_string())?;
+        Ok(Some(ItemRow {
+            id: data.id.to_string(),
+            item_name: data.item_name.to_string(),
+            type_of: match_item_type(data.type_of),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        database::{
+            repository::{repository::get_repositories, ItemRepository},
+            schema::ItemRowType,
+        },
+        server::data::RepositoryRegistry,
+        util::{
+            sync::translation::{import_sync_records, SyncRecord, SyncType},
+            test_db,
+        },
+    };
+
+    #[tokio::test]
+    async fn test_item_translation() {
+        let settings = test_db::get_test_settings("omsupply-database-item-translation");
+        test_db::setup(&settings.database).await;
+        let repositories = get_repositories(&settings).await;
+        let registry = RepositoryRegistry { repositories };
+        let item_repo = registry.get::<ItemRepository>();
+
+        let record = SyncRecord {
+            sync_type: SyncType::Insert,
+            record_type: "item".to_string(),
+            data: r#"
+            {"ID":"8F252B5884B74888AAB73A0D42C09E7F","item_name":"Non stock items","start_of_year_date":"0000-00-00","manufacture_method":"","default_pack_size":1,"dose_picture":"[object Picture]","atc_category":"","medication_purpose":"","instructions":"","user_field_7":false,"flags":"","ddd_value":"","code":"NSI","other_names":"","type_of":"non_stock","price_editable":false,"margin":0,"barcode_spare":"","spare_ignore_for_orders":false,"sms_pack_size":0,"expiry_date_mandatory":false,"volume_per_pack":0,"department_ID":"","weight":0,"essential_drug_list":false,"catalogue_code":"","indic_price":0,"user_field_1":"","spare_hold_for_issue":false,"builds_only":false,"reference_bom_quantity":0,"use_bill_of_materials":false,"description":"","spare_hold_for_receive":false,"Message":"","interaction_group_ID":"","spare_pack_to_one_on_receive":false,"cross_ref_item_ID":"","strength":"","user_field_4":false,"user_field_6":"","spare_internal_analysis":0,"user_field_2":"","user_field_3":"","ddd factor":0,"account_stock_ID":"52923505A91447B9923BA34A4F332014","account_purchases_ID":"330ACC81721C4126BD5DD6769466C5C4","account_income_ID":"EF34ADD07C014AB8914E30CA2E3FEA8D","unit_ID":"","outer_pack_size":0,"category_ID":"","ABC_category":"","warning_quantity":0,"user_field_5":0,"print_units_in_dis_labels":false,"volume_per_outer_pack":0,"normal_stock":false,"critical_stock":false,"spare_non_stock":false,"non_stock_name_ID":"","is_sync":false,"sms_code":"","category2_ID":"","category3_ID":"","buy_price":0,"VEN_category":"","universalcodes_code":"","universalcodes_name":"","kit_data":null,"custom_data":null,"doses":0,"is_vaccine":false,"restricted_location_type_ID":""}
+            "#.to_string(),
+        };
+        let records = vec![record];
+        import_sync_records(&registry, &records).await.unwrap();
+        let entry = item_repo
+            .find_one_by_id("8F252B5884B74888AAB73A0D42C09E7F")
+            .await
+            .unwrap();
+        assert_eq!(entry.item_name, "Non stock items");
+        assert_eq!(entry.type_of, ItemRowType::NoneStock);
+
+        // should be able to upsert
+        let record = SyncRecord {
+            sync_type: SyncType::Insert,
+            record_type: "item".to_string(),
+            data: r#"
+            {"ID":"8F252B5884B74888AAB73A0D42C09E7F","item_name":"Non stock items 2","start_of_year_date":"0000-00-00","manufacture_method":"","default_pack_size":1,"dose_picture":"[object Picture]","atc_category":"","medication_purpose":"","instructions":"","user_field_7":false,"flags":"","ddd_value":"","code":"NSI","other_names":"","type_of":"general","price_editable":false,"margin":0,"barcode_spare":"","spare_ignore_for_orders":false,"sms_pack_size":0,"expiry_date_mandatory":false,"volume_per_pack":0,"department_ID":"","weight":0,"essential_drug_list":false,"catalogue_code":"","indic_price":0,"user_field_1":"","spare_hold_for_issue":false,"builds_only":false,"reference_bom_quantity":0,"use_bill_of_materials":false,"description":"","spare_hold_for_receive":false,"Message":"","interaction_group_ID":"","spare_pack_to_one_on_receive":false,"cross_ref_item_ID":"","strength":"","user_field_4":false,"user_field_6":"","spare_internal_analysis":0,"user_field_2":"","user_field_3":"","ddd factor":0,"account_stock_ID":"52923505A91447B9923BA34A4F332014","account_purchases_ID":"330ACC81721C4126BD5DD6769466C5C4","account_income_ID":"EF34ADD07C014AB8914E30CA2E3FEA8D","unit_ID":"","outer_pack_size":0,"category_ID":"","ABC_category":"","warning_quantity":0,"user_field_5":0,"print_units_in_dis_labels":false,"volume_per_outer_pack":0,"normal_stock":false,"critical_stock":false,"spare_non_stock":false,"non_stock_name_ID":"","is_sync":false,"sms_code":"","category2_ID":"","category3_ID":"","buy_price":0,"VEN_category":"","universalcodes_code":"","universalcodes_name":"","kit_data":null,"custom_data":null,"doses":0,"is_vaccine":false,"restricted_location_type_ID":""}
+            "#.to_string(),
+        };
+        let records = vec![record];
+        import_sync_records(&registry, &records).await.unwrap();
+        let entry = item_repo
+            .find_one_by_id("8F252B5884B74888AAB73A0D42C09E7F")
+            .await
+            .unwrap();
+        assert_eq!(entry.item_name, "Non stock items 2");
+        assert_eq!(entry.type_of, ItemRowType::General);
+    }
+}

--- a/src/util/sync/translation/item.rs
+++ b/src/util/sync/translation/item.rs
@@ -109,7 +109,7 @@ mod tests {
         },
     };
 
-    #[tokio::test]
+    #[actix_rt::test]
     async fn test_item_translation() {
         let settings = test_db::get_test_settings("omsupply-database-item-translation");
         test_db::setup(&settings.database).await;

--- a/src/util/sync/translation/mod.rs
+++ b/src/util/sync/translation/mod.rs
@@ -24,6 +24,8 @@ pub struct SyncRecord {
     data: String,
 }
 
+/// Translates sync records into the local DB schema.
+/// Translated records are added to integration_records.
 fn do_translation(
     sync_record: &SyncRecord,
     integration_records: &mut IntegrationRecord,
@@ -46,6 +48,8 @@ fn do_translation(
     Err("Cannot find matching translation".to_string())
 }
 
+/// Imports sync records and writes them to the DB
+/// If needed data records are translated to the local DB schema.
 pub async fn import_sync_records(
     registry: &RepositoryRegistry,
     records: &Vec<SyncRecord>,

--- a/src/util/sync/translation/mod.rs
+++ b/src/util/sync/translation/mod.rs
@@ -1,0 +1,66 @@
+mod item;
+mod name;
+
+use crate::{
+    database::repository::{
+        repository::IntegrationUpsertRecord, IntegrationRecord, SyncRepository,
+    },
+    server::data::RepositoryRegistry,
+};
+
+use self::{item::LegacyItemRow, name::LegacyNameTable};
+
+#[derive(Debug)]
+pub enum SyncType {
+    Delete,
+    Update,
+    Insert,
+}
+
+#[derive(Debug)]
+pub struct SyncRecord {
+    sync_type: SyncType,
+    record_type: String,
+    data: String,
+}
+
+fn do_translation(
+    sync_record: &SyncRecord,
+    integration_records: &mut IntegrationRecord,
+) -> Result<(), String> {
+    if let Some(row) = LegacyNameTable::try_translate(sync_record)? {
+        integration_records
+            .upserts
+            .push(IntegrationUpsertRecord::Name(row));
+
+        return Ok(());
+    }
+    if let Some(row) = LegacyItemRow::try_translate(sync_record)? {
+        integration_records
+            .upserts
+            .push(IntegrationUpsertRecord::Item(row));
+
+        return Ok(());
+    }
+
+    Err("Cannot find matching translation".to_string())
+}
+
+pub async fn import_sync_records(
+    registry: &RepositoryRegistry,
+    records: &Vec<SyncRecord>,
+) -> Result<(), String> {
+    let mut integration_records = IntegrationRecord {
+        upserts: Vec::new(),
+    };
+    for record in records {
+        do_translation(&record, &mut integration_records)?;
+    }
+
+    let sync_repo = registry.get::<SyncRepository>();
+    sync_repo
+        .integrate_records(&integration_records)
+        .await
+        .map_err(|e| format!("Sync Error: {}", e))?;
+    Ok(())
+}

--- a/src/util/sync/translation/name.rs
+++ b/src/util/sync/translation/name.rs
@@ -1,0 +1,180 @@
+use super::SyncRecord;
+
+use crate::database::schema::NameRow;
+
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct LegacyNameTable {
+    #[serde(rename = "ID")]
+    id: String,
+    name: String,
+    /*
+    fax: String,
+    phone: String,
+    customer: bool,
+    bill_address1: String,
+    bill_address2: String,
+    supplier: bool,
+    #[serde(rename = "charge code")]
+    charge_code: String,
+    margin: i64,
+    comment: String,
+    #[serde(rename = "currency_ID")]
+    currency_id: String,
+    country: String,
+    freightfac: i64,
+    email: String,
+    custom1: String,
+    code: String,
+    last: String,
+    first: String,
+    title: String,
+    female: bool,
+    date_of_birth: String,
+    overpayment: i64,
+    #[serde(rename = "group_ID")]
+    group_id: String,
+    hold: bool,
+    ship_address1: String,
+    ship_address2: String,
+    url: String,
+    barcode: String,
+    postal_address1: String,
+    postal_address2: String,
+    #[serde(rename = "category1_ID")]
+    category1_id: String,
+    #[serde(rename = "region_ID")]
+    region_id: String,
+    #[serde(rename = "type")]
+    table_type: String,
+    price_category: String,
+    flag: String,
+    manufacturer: bool,
+    print_invoice_alphabetical: bool,
+    custom2: String,
+    custom3: String,
+    default_order_days: i64,
+    connection_type: i64,
+    //PATIENT_PHOTO": "[object Picture]",
+    NEXT_OF_KIN_ID: String,
+    POBOX: String,
+    ZIP: i64,
+    middle: String,
+    preferred: bool,
+    Blood_Group: String,
+    marital_status: String,
+    Benchmark: bool,
+    next_of_kin_relative: String,
+    mother_id: String,
+    postal_address3: String,
+    postal_address4: String,
+    bill_address3: String,
+    bill_address4: String,
+    ship_address3: String,
+    ship_address4: String,
+    ethnicity_ID: String,
+    occupation_ID: String,
+    religion_ID: String,
+    national_health_number: String,
+    Master_RTM_Supplier_Code: i64,
+    ordering_method: String,
+    donor: bool,
+    latitude: i64,
+    longitude: i64,
+    Master_RTM_Supplier_name: String,
+    category2_ID: String,
+    category3_ID: String,
+    category4_ID: String,
+    category5_ID: String,
+    category6_ID: String,
+    bill_address5: String,
+    bill_postal_zip_code: String,
+    postal_address5: String,
+    postal_zip_code: String,
+    ship_address5: String,
+    ship_postal_zip_code: String,
+    supplying_store_id: String,
+    license_number: String,
+    license_expiry: String,
+    has_current_license: bool,
+    //custom_data": null,
+    maximum_credit: i64,
+    nationality_ID: String,
+    created_date: String,
+    */
+}
+
+impl From<&LegacyNameTable> for NameRow {
+    fn from(t: &LegacyNameTable) -> NameRow {
+        NameRow {
+            id: t.id.to_string(),
+            name: t.name.to_string(),
+        }
+    }
+}
+
+impl LegacyNameTable {
+    pub fn try_translate(sync_record: &SyncRecord) -> Result<Option<NameRow>, String> {
+        if sync_record.record_type != "name" {
+            return Ok(None);
+        }
+        let data = serde_json::from_str::<LegacyNameTable>(&sync_record.data)
+            .map_err(|_| "Deserialization Error".to_string())?;
+        Ok(Some(NameRow::from(&data)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        database::repository::{repository::get_repositories, NameRepository},
+        server::data::RepositoryRegistry,
+        util::{
+            sync::translation::{import_sync_records, SyncRecord, SyncType},
+            test_db,
+        },
+    };
+
+    #[tokio::test]
+    async fn test_name_translation() {
+        let settings = test_db::get_test_settings("omsupply-database-name-translation");
+        test_db::setup(&settings.database).await;
+        let repositories = get_repositories(&settings).await;
+        let registry = RepositoryRegistry { repositories };
+        let name_repo = registry.get::<NameRepository>();
+
+        let record = SyncRecord {
+            sync_type: SyncType::Insert,
+            record_type: "name".to_string(),
+            data: r#"
+            {"ID":"CB929EB86530455AB0392277FAC3DBA4","name":"Birch Store","fax":"","phone":"","customer":true,"bill_address1":"234 Evil Street","bill_address2":"Scotland","supplier":false,"charge code":"SNA","margin":0,"comment":"","currency_ID":"8009D512AC0E4FD78625E3C8273B0171","country":"","freightfac":1,"email":"","custom1":"","code":"SNA","last":"","first":"","title":"","female":false,"date_of_birth":"0000-00-00","overpayment":0,"group_ID":"","hold":false,"ship_address1":"","ship_address2":"","url":"","barcode":"*SNA*","postal_address1":"","postal_address2":"","category1_ID":"","region_ID":"","type":"facility","price_category":"A","flag":"","manufacturer":false,"print_invoice_alphabetical":false,"custom2":"","custom3":"","default_order_days":0,"connection_type":0,"PATIENT_PHOTO":"[object Picture]","NEXT_OF_KIN_ID":"","POBOX":"","ZIP":0,"middle":"","preferred":false,"Blood_Group":"","marital_status":"","Benchmark":false,"next_of_kin_relative":"","mother_id":"","postal_address3":"","postal_address4":"","bill_address3":"","bill_address4":"","ship_address3":"","ship_address4":"","ethnicity_ID":"","occupation_ID":"","religion_ID":"","national_health_number":"","Master_RTM_Supplier_Code":0,"ordering_method":"sh","donor":false,"latitude":0,"longitude":0,"Master_RTM_Supplier_name":"","category2_ID":"","category3_ID":"","category4_ID":"","category5_ID":"","category6_ID":"","bill_address5":"","bill_postal_zip_code":"","postal_address5":"","postal_zip_code":"","ship_address5":"","ship_postal_zip_code":"","supplying_store_id":"D77F67339BF8400886D009178F4962E1","license_number":"","license_expiry":"0000-00-00","has_current_license":false,"custom_data":null,"maximum_credit":0,"nationality_ID":"","created_date":"0000-00-00"}
+            "#.to_string(),
+        };
+        let records = vec![record];
+        import_sync_records(&registry, &records).await.unwrap();
+        let entry = name_repo
+            .find_one_by_id("CB929EB86530455AB0392277FAC3DBA4")
+            .await
+            .unwrap();
+
+        assert_eq!(entry.name, "Birch Store");
+
+        // should be able to upsert
+        let record = SyncRecord {
+            sync_type: SyncType::Insert,
+            record_type: "name".to_string(),
+            data: r#"
+            {"ID":"CB929EB86530455AB0392277FAC3DBA4","name":"Birch Store 2","fax":"","phone":"","customer":true,"bill_address1":"234 Evil Street","bill_address2":"Scotland","supplier":false,"charge code":"SNA","margin":0,"comment":"","currency_ID":"8009D512AC0E4FD78625E3C8273B0171","country":"","freightfac":1,"email":"","custom1":"","code":"SNA","last":"","first":"","title":"","female":false,"date_of_birth":"0000-00-00","overpayment":0,"group_ID":"","hold":false,"ship_address1":"","ship_address2":"","url":"","barcode":"*SNA*","postal_address1":"","postal_address2":"","category1_ID":"","region_ID":"","type":"facility","price_category":"A","flag":"","manufacturer":false,"print_invoice_alphabetical":false,"custom2":"","custom3":"","default_order_days":0,"connection_type":0,"PATIENT_PHOTO":"[object Picture]","NEXT_OF_KIN_ID":"","POBOX":"","ZIP":0,"middle":"","preferred":false,"Blood_Group":"","marital_status":"","Benchmark":false,"next_of_kin_relative":"","mother_id":"","postal_address3":"","postal_address4":"","bill_address3":"","bill_address4":"","ship_address3":"","ship_address4":"","ethnicity_ID":"","occupation_ID":"","religion_ID":"","national_health_number":"","Master_RTM_Supplier_Code":0,"ordering_method":"sh","donor":false,"latitude":0,"longitude":0,"Master_RTM_Supplier_name":"","category2_ID":"","category3_ID":"","category4_ID":"","category5_ID":"","category6_ID":"","bill_address5":"","bill_postal_zip_code":"","postal_address5":"","postal_zip_code":"","ship_address5":"","ship_postal_zip_code":"","supplying_store_id":"D77F67339BF8400886D009178F4962E1","license_number":"","license_expiry":"0000-00-00","has_current_license":false,"custom_data":null,"maximum_credit":0,"nationality_ID":"","created_date":"0000-00-00"}
+            "#.to_string(),
+        };
+        let records = vec![record];
+        import_sync_records(&registry, &records).await.unwrap();
+        let entry = name_repo
+            .find_one_by_id("CB929EB86530455AB0392277FAC3DBA4")
+            .await
+            .unwrap();
+
+        assert_eq!(entry.name, "Birch Store 2");
+    }
+}

--- a/src/util/sync/translation/name.rs
+++ b/src/util/sync/translation/name.rs
@@ -136,7 +136,7 @@ mod tests {
         },
     };
 
-    #[tokio::test]
+    #[actix_rt::test]
     async fn test_name_translation() {
         let settings = test_db::get_test_settings("omsupply-database-name-translation");
         test_db::setup(&settings.database).await;

--- a/src/util/test_db.rs
+++ b/src/util/test_db.rs
@@ -1,6 +1,7 @@
+use super::settings::{DatabaseSettings, ServerSettings, Settings, SyncSettings};
+
 use diesel_migrations::{find_migrations_directory, mark_migrations_in_directory};
 
-use remote_server::util::settings::DatabaseSettings;
 
 #[cfg(feature = "postgres")]
 pub async fn setup(db_settings: &DatabaseSettings) {
@@ -69,5 +70,30 @@ pub async fn setup(db_settings: &DatabaseSettings) {
 
     for (migration, ..) in migrations.iter() {
         migration.run(&connection).unwrap();
+    }
+}
+
+// The following settings work for PG and Sqlite (username, password, host and port are
+// ignored for the later)
+pub fn get_test_settings(db_name: &str) -> Settings {
+    Settings {
+        server: ServerSettings {
+            host: "localhost".to_string(),
+            port: 5432,
+        },
+        database: DatabaseSettings {
+            username: "postgres".to_string(),
+            password: "password".to_string(),
+            port: 5432,
+            host: "localhost".to_string(),
+            database_name: db_name.to_owned(),
+        },
+        sync: SyncSettings {
+            username: "postgres".to_string(),
+            password: "password".to_string(),
+            port: 5432,
+            host: "localhost".to_string(),
+            interval: 100000000,
+        },
     }
 }

--- a/tests/repository/basic.rs
+++ b/tests/repository/basic.rs
@@ -1,23 +1,20 @@
 #[cfg(test)]
 mod repository_basic_test {
 
-    use remote_server::{
-        database::{
-            repository::{
-                repository::get_repositories, CustomerInvoiceRepository, ItemLineRepository,
-                ItemRepository, NameRepository, RequisitionLineRepository, RequisitionRepository,
-                StoreRepository, TransactLineRepository, TransactRepository, UserAccountRepository,
-            },
-            schema::{
-                ItemLineRow, ItemRow, ItemRowType, NameRow, RequisitionLineRow, RequisitionRow,
-                RequisitionRowType, StoreRow, TransactLineRow, TransactLineRowType, TransactRow,
-                TransactRowType, UserAccountRow,
-            },
+    use remote_server::database::{
+        repository::{
+            repository::get_repositories, CustomerInvoiceRepository, ItemLineRepository,
+            ItemRepository, NameRepository, RequisitionLineRepository, RequisitionRepository,
+            StoreRepository, TransactLineRepository, TransactRepository, UserAccountRepository,
         },
-        util::settings::{DatabaseSettings, ServerSettings, Settings, SyncSettings},
+        schema::{
+            ItemLineRow, ItemRow, ItemRowType, NameRow, RequisitionLineRow, RequisitionRow,
+            RequisitionRowType, StoreRow, TransactLineRow, TransactLineRowType, TransactRow,
+            TransactRowType, UserAccountRow,
+        },
     };
 
-    use crate::repository::test_db;
+    use remote_server::util::test_db;
 
     async fn requisition_test(repo: &RequisitionRepository) {
         let item1 = RequisitionRow {
@@ -245,30 +242,7 @@ mod repository_basic_test {
 
     #[tokio::test]
     async fn simple_repository_tests() {
-        let db_name = "omsupply-database-simple-repository-test";
-        // The following settings work for PG and Sqlite (username, password, host and port are
-        // ignored for the later)
-        let settings = Settings {
-            server: ServerSettings {
-                host: "localhost".to_string(),
-                port: 5432,
-            },
-            database: DatabaseSettings {
-                username: "postgres".to_string(),
-                password: "password".to_string(),
-                port: 5432,
-                host: "localhost".to_string(),
-                database_name: db_name.to_owned(),
-            },
-            sync: SyncSettings {
-                username: "postgres".to_string(),
-                password: "password".to_string(),
-                port: 5432,
-                host: "localhost".to_string(),
-                interval: 100000000,
-            },
-        };
-
+        let settings = test_db::get_test_settings("omsupply-database-simple-repository-test");
         // Initialise a new test database.
         test_db::setup(&settings.database).await;
         let repos = get_repositories(&settings).await;

--- a/tests/repository/basic.rs
+++ b/tests/repository/basic.rs
@@ -8,9 +8,9 @@ mod repository_basic_test {
             StoreRepository, TransactLineRepository, TransactRepository, UserAccountRepository,
         },
         schema::{
-            ItemLineRow, ItemRow, ItemRowType, NameRow, RequisitionLineRow, RequisitionRow,
-            RequisitionRowType, StoreRow, TransactLineRow, TransactLineRowType, TransactRow,
-            TransactRowType, UserAccountRow,
+            ItemLineRow, ItemRow, NameRow, RequisitionLineRow, RequisitionRow, RequisitionRowType,
+            StoreRow, TransactLineRow, TransactLineRowType, TransactRow, TransactRowType,
+            UserAccountRow,
         },
     };
 
@@ -81,8 +81,7 @@ mod repository_basic_test {
     async fn item_test(repo: &ItemRepository) {
         let item1 = ItemRow {
             id: "item1".to_string(),
-            item_name: "item-1".to_string(),
-            type_of: ItemRowType::General,
+            name: "item-1".to_string(),
         };
         repo.insert_one(&item1).await.unwrap();
         let loaded_item = repo.find_one_by_id(item1.id.as_str()).await.unwrap();
@@ -90,8 +89,7 @@ mod repository_basic_test {
 
         let item2 = ItemRow {
             id: "item2".to_string(),
-            item_name: "item-2".to_string(),
-            type_of: ItemRowType::Service,
+            name: "item-2".to_string(),
         };
         repo.insert_one(&item2).await.unwrap();
         let all_items = repo.find_all().await.unwrap();

--- a/tests/repository/basic.rs
+++ b/tests/repository/basic.rs
@@ -238,7 +238,7 @@ mod repository_basic_test {
         assert_eq!(item2, loaded_item);
     }
 
-    #[tokio::test]
+    #[actix_rt::test]
     async fn simple_repository_tests() {
         let settings = test_db::get_test_settings("omsupply-database-simple-repository-test");
         // Initialise a new test database.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,3 @@
 mod repository {
     mod basic;
-    mod test_db;
 }


### PR DESCRIPTION
This aims to implement the translaions as we discusses last time.

There are two things that I am not entirely happy with but couldn't fix to this point (because of Rust type and async issues).
1) After another discussion with Will we realized that Andrei and me probably planted to use something more closer to a DAO pattern and that DAO and repository pattern are complimentary (e.g. https://www.baeldung.com/java-dao-vs-repository). For this reason I did some experimenting using a DAO layer between ORM and Repository where the Repository layer is mostly independent from Diesel and only uses the DAO layer. However, I run into some further async issues and gave up on it. However, I think it might be an options to move the auxilary methods like `pub fn insert_one_tx(connection: &DBConnection, name_row: &NameRow)` out of the Repositories into something like `NameQueries` to keep the Repositories more tidy.

2) Upsert for sqlite is only supported in the upcoming Diesel 2.0 version. I wasn't manages to implement the upsert in a generic way, i.e. upsert for sqlite must be implemented multiple times and doing the raw queries is a bit error prone (easy to forget to add new table columns).

Closes #281