### PR TITLE
Flagless DB target differentiation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ async-graphql = { version = "2.9.8", features = ["dataloader"] }
 async-graphql-actix-web = "2.9.8"
 async-trait = "0.1.16"
 diesel = { version = "1.4.7", default-features = false, features = ["r2d2", "numeric"] }
-diesel-derive-enum = { version = "1.1.1", default-features = false, optional = true }
+diesel-derive-enum = { version = "1.1.1", default-features = false }
 diesel_migrations = "1.4.0"
 libsqlite3-sys = { version = "0.22.2", features = ["bundled"], optional = true }
 r2d2 = "0.8.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ anymap = "0.12"
 async-graphql = { version = "2.9.8", features = ["dataloader"] }
 async-graphql-actix-web = "2.9.8"
 async-trait = "0.1.16"
-diesel = { version = "1.4.7", default-features = false, features = ["sqlite", "postgres", "r2d2", "numeric"] }
-diesel-derive-enum = { version = "1.1.1", features = ["sqlite", "postgres"] }
+diesel = { version = "1.4.7", default-features = false, features = ["r2d2", "numeric"] }
+diesel-derive-enum = { version = "1.1.1", default-features = false, optional = true }
 diesel_migrations = "1.4.0"
-libsqlite3-sys = { version = "0.22.2", features = ["bundled"] }
+libsqlite3-sys = { version = "0.22.2", features = ["bundled"], optional = true }
 r2d2 = "0.8.9"
 config = "0.11.0"
 env_logger = "0.8.3"
@@ -40,6 +40,7 @@ uuid = { version = "0.8", features = ["v4"] }
 httpmock = "0.6"
 
 [features]
+default = ["postgres", "sqlite"]
+postgres = ["diesel/postgres" , "diesel-derive-enum/postgres"]
+sqlite = ["diesel/sqlite", "libsqlite3-sys", "diesel-derive-enum/sqlite"]
 mock = []
-postgres = []
-sqlite = []

--- a/src/database/loader/diesel.rs
+++ b/src/database/loader/diesel.rs
@@ -1,34 +1,13 @@
 use crate::{
-    database::{
-        loader::{
-            ItemLineLoader, ItemLoader, NameLoader, RequisitionLineLoader, RequisitionLoader,
-            StoreLoader, TransactLineLoader, TransactLoader, UserAccountLoader,
-        },
-        repository::{
-            ItemLineRepository, ItemRepository, NameRepository, RequisitionLineRepository,
-            RequisitionRepository, StoreRepository, TransactLineRepository, TransactRepository,
-            UserAccountRepository,
-        },
-    },
+    database::{loader::*, repository::*},
     server::data::LoaderMap,
     util::settings::Settings,
 };
 
 use async_graphql::dataloader::DataLoader;
 
-use diesel::r2d2::{ConnectionManager, Pool};
-
-#[cfg(feature = "postgres")]
-use diesel::PgConnection as DBBackendConnection;
-
-#[cfg(feature = "sqlite")]
-use diesel::SqliteConnection as DBBackendConnection;
-
 pub async fn get_loaders(settings: &Settings) -> LoaderMap {
-    let connection_manager =
-        ConnectionManager::<DBBackendConnection>::new(&settings.database.connection_string());
-    let pool = Pool::new(connection_manager).expect("Failed to connect to database");
-
+    let pool = DbConnectionPool::new(settings);
     let mut loaders: LoaderMap = LoaderMap::new();
 
     let item_repository = ItemRepository::new(pool.clone());

--- a/src/database/repository/diesel/database_wrapper/macros.rs
+++ b/src/database/repository/diesel/database_wrapper/macros.rs
@@ -35,6 +35,7 @@ macro_rules! sqlite_operation {
 macro_rules! database_operation_pool {
     ($pool:expr, $postgres_query:expr, $sqlite_query:expr, $operation:ident) => {
         match $pool {
+            #[allow(unused_variables)]
             crate::database::repository::DbConnectionPool::Sqlite(_) => {
                 crate::database::repository::macros::sqlite_operation!(
                     &*$pool.get_sqlite_connection()?,
@@ -42,6 +43,7 @@ macro_rules! database_operation_pool {
                     $operation
                 )
             }
+            #[allow(unused_variables)]
             crate::database::repository::DbConnectionPool::Pg(_) => {
                 crate::database::repository::macros::postgres_operation!(
                     &*$pool.get_pg_connection()?,
@@ -56,6 +58,7 @@ macro_rules! database_operation_pool {
 macro_rules! database_operation_connection {
     ($connection:expr, $postgres_query:expr, $sqlite_query:expr, $operation:ident) => {
         match $connection {
+            #[allow(unused_variables)]
             crate::database::repository::DbConnection::Sqlite(connection) => {
                 crate::database::repository::macros::sqlite_operation!(
                     &*connection,
@@ -63,6 +66,7 @@ macro_rules! database_operation_connection {
                     $operation
                 )
             }
+            #[allow(unused_variables)]
             crate::database::repository::DbConnection::Pg(connection) => {
                 crate::database::repository::macros::postgres_operation!(
                     &*connection,
@@ -202,11 +206,13 @@ macro_rules! sqlite_transaction {
 macro_rules! transaction {
     ($connection:expr, $transaction_content:expr) => {
         match $connection {
+            #[allow(unused_variables)]
             crate::database::repository::DbConnection::Sqlite(connection) => {
                 crate::database::repository::macros::sqlite_transaction!(
                     connection.transaction($transaction_content)
                 )
             }
+            #[allow(unused_variables)]
             crate::database::repository::DbConnection::Pg(connection) => {
                 crate::database::repository::macros::postgres_transaction!(
                     connection.transaction($transaction_content)

--- a/src/database/repository/diesel/database_wrapper/macros.rs
+++ b/src/database/repository/diesel/database_wrapper/macros.rs
@@ -1,4 +1,9 @@
 macro_rules! database_operation_pool {
+    ($pool:expr, $query:expr, $operation:ident) => {
+        $crate::database::repository::macros::database_operation_pool!(
+            $pool, $query, $query, $operation
+        )
+    };
     ($pool:expr, $postgres_query:expr, $sqlite_query:expr, $operation:ident) => {
         match &$pool {
             #[cfg(feature = "sqlite")]
@@ -16,6 +21,14 @@ macro_rules! database_operation_pool {
 }
 
 macro_rules! database_operation_connection {
+    ($connection:expr, $query:expr, $operation:ident) => {
+        $crate::database::repository::macros::database_operation_connection!(
+            $connection,
+            $query,
+            $query,
+            $operation
+        )
+    };
     ($connection:expr, $postgres_query:expr, $sqlite_query:expr, $operation:ident) => {
         match $connection {
             #[cfg(feature = "sqlite")]
@@ -32,100 +45,25 @@ macro_rules! database_operation_connection {
     };
 }
 
-macro_rules! execute_connection {
-    ($connection:expr, $query:expr) => {
-        $crate::database::repository::macros::database_operation_connection!(
-            $connection,
-            $query,
-            $query,
-            execute
-        )
-    };
-    ($connection:expr, $postgres_query:expr, $sqlite_query:expr) => {
-        $crate::database::repository::macros::database_operation_connection!(
-            $connection,
-            $postgres_query,
-            $sqlite_query,
-            execute
-        )
+#[rustfmt::skip] // https://github.com/rust-lang/rustfmt/issues/4609
+macro_rules! make_macro {
+    ($DOLLAR:tt, $macro_name:ident, $call_macro:ident, $arg:ident) => {
+        macro_rules! $macro_name {
+            ($DOLLAR($args:tt)*) => {
+                $crate::database::repository::macros::$call_macro!(
+                    $DOLLAR($args)*,
+                    $arg
+                )
+            };
+        }
     };
 }
 
-macro_rules! execute_pool {
-    ($connection:expr, $query:expr) => {
-        $crate::database::repository::macros::database_operation_pool!(
-            $connection,
-            $query,
-            $query,
-            execute
-        )
-    };
-    ($connection:expr, $postgres_query:expr,$sqlite_query:expr) => {
-        $crate::database::repository::macros::database_operation_pool!(
-            $connection,
-            $postgres_query,
-            $sqlite_query,
-            execute
-        )
-    };
-}
-
-macro_rules! load_pool {
-    ($connection:expr, $query:expr) => {
-        $crate::database::repository::macros::database_operation_pool!(
-            $connection,
-            $query,
-            $query,
-            load
-        )
-    };
-    ($connection:expr, $postgres_query:expr,$sqlite_query:expr) => {
-        $crate::database::repository::macros::database_operation_pool!(
-            $connection,
-            $postgres_query,
-            $sqlite_query,
-            load
-        )
-    };
-}
-
-macro_rules! first_pool {
-    ($connection:expr, $query:expr) => {
-        $crate::database::repository::macros::database_operation_pool!(
-            $connection,
-            $query,
-            $query,
-            first
-        )
-    };
-    ($connection:expr, $postgres_query:expr,$sqlite_query:expr) => {
-        $crate::database::repository::macros::database_operation_pool!(
-            $connection,
-            $postgres_query,
-            $sqlite_query,
-            first
-        )
-    };
-}
-
-macro_rules! get_results_pool {
-    ($connection:expr, $query:expr) => {
-        $crate::database::repository::macros::database_operation_pool!(
-            $connection,
-            $query,
-            $query,
-            get_results
-        )
-    };
-    ($connection:expr, $postgres_query:expr,$sqlite_query:expr) => {
-        $crate::database::repository::macros::database_operation_pool!(
-            $connection,
-            $postgres_query,
-            $sqlite_query,
-            get_results
-        )
-    };
-}
+make_macro!($, execute_connection, database_operation_connection, execute);
+make_macro!($, execute_pool, database_operation_pool, execute);
+make_macro!($, load_pool, database_operation_pool, load);
+make_macro!($, first_pool, database_operation_pool, first);
+make_macro!($, get_results_pool, database_operation_pool, load);
 
 pub(crate) use database_operation_connection;
 pub(crate) use database_operation_pool;

--- a/src/database/repository/diesel/database_wrapper/macros.rs
+++ b/src/database/repository/diesel/database_wrapper/macros.rs
@@ -127,23 +127,6 @@ macro_rules! get_results_pool {
     };
 }
 
-macro_rules! transaction {
-    ($connection:expr, $transaction_content:expr) => {
-        match $connection {
-            #[cfg(feature = "sqlite")]
-            #[allow(unused_variables)]
-            $crate::database::repository::DbConnection::Sqlite(connection) => {
-                connection.transaction($transaction_content)
-            }
-            #[cfg(feature = "postgres")]
-            #[allow(unused_variables)]
-            $crate::database::repository::DbConnection::Pg(connection) => {
-                connection.transaction($transaction_content)
-            }
-        }
-    };
-}
-
 pub(crate) use database_operation_connection;
 pub(crate) use database_operation_pool;
 pub(crate) use execute_connection;
@@ -151,4 +134,3 @@ pub(crate) use execute_pool;
 pub(crate) use first_pool;
 pub(crate) use get_results_pool;
 pub(crate) use load_pool;
-pub(crate) use transaction;

--- a/src/database/repository/diesel/database_wrapper/macros.rs
+++ b/src/database/repository/diesel/database_wrapper/macros.rs
@@ -1,13 +1,19 @@
 macro_rules! database_operation {
-    ($connectionish:expr, $query:expr, $operation:ident) => {
+    ($connectionish:expr, $query:expr, $(,)? $operation:ident) => {
         $crate::database::repository::macros::database_operation!(
             $connectionish,
-            $query,
-            $query,
+            postgres => $query,
+            sqlite => $query,
             $operation
         )
     };
-    ($connectionish:expr, $postgres_query:expr, $sqlite_query:expr, $operation:ident) => {
+    (
+        $connectionish:expr,
+        postgres => $postgres_query:expr,
+        sqlite => $sqlite_query:expr,
+        $(,)?
+        $operation:ident
+    ) => {
         $connectionish.with_connection(
             #[cfg(feature = "sqlite")]
             |connection| {

--- a/src/database/repository/diesel/database_wrapper/macros.rs
+++ b/src/database/repository/diesel/database_wrapper/macros.rs
@@ -24,6 +24,7 @@ macro_rules! database_operation {
         )
     };
 }
+pub(crate) use database_operation;
 
 #[rustfmt::skip] // https://github.com/rust-lang/rustfmt/issues/4609
 macro_rules! make_macro {
@@ -36,6 +37,7 @@ macro_rules! make_macro {
                 )
             };
         }
+        pub(crate) use $name;
     };
 }
 
@@ -43,10 +45,3 @@ make_macro!($, execute);
 make_macro!($, load);
 make_macro!($, first);
 make_macro!($, get_results);
-
-pub(crate) use database_operation;
-pub(crate) use execute as execute_connection;
-pub(crate) use execute as execute_pool;
-pub(crate) use first as first_pool;
-pub(crate) use get_results as get_results_pool;
-pub(crate) use load as load_pool;

--- a/src/database/repository/diesel/database_wrapper/macros.rs
+++ b/src/database/repository/diesel/database_wrapper/macros.rs
@@ -1,56 +1,16 @@
-#[cfg(feature = "postgres")]
-macro_rules! postgres_operation {
-    ($connection:expr, $query:expr, $operation:ident) => {
-        $query
-            .$operation($connection)
-            .map_err(|err| RepositoryError::from(err))
-    };
-}
-
-#[cfg(not(feature = "postgres"))]
-macro_rules! postgres_operation {
-    // How to match all ?
-    ($connection:expr, $query:expr, $operation:ident) => {
-        panic!("postgres flag is not enabled")
-    };
-}
-
-#[cfg(feature = "sqlite")]
-macro_rules! sqlite_operation {
-    ($connection:expr, $query:expr, $operation:ident) => {
-        $query
-            .$operation($connection)
-            .map_err(|err| RepositoryError::from(err))
-    };
-}
-
-#[cfg(not(feature = "sqlite"))]
-macro_rules! sqlite_operation {
-    // How to match all ?
-    ($connection:expr, $query:expr, $operation:ident) => {
-        panic!("sqlite flag is not enabled")
-    };
-}
-
 macro_rules! database_operation_pool {
     ($pool:expr, $postgres_query:expr, $sqlite_query:expr, $operation:ident) => {
-        match $pool {
+        match &$pool {
+            #[cfg(feature = "sqlite")]
             #[allow(unused_variables)]
-            crate::database::repository::DbConnectionPool::Sqlite(_) => {
-                crate::database::repository::macros::sqlite_operation!(
-                    &*$pool.get_sqlite_connection()?,
-                    $sqlite_query,
-                    $operation
-                )
-            }
+            $crate::database::repository::DbConnectionPool::Sqlite(pool) => $sqlite_query
+                .$operation(&*pool.get()?)
+                .map_err(RepositoryError::from),
+            #[cfg(feature = "postgres")]
             #[allow(unused_variables)]
-            crate::database::repository::DbConnectionPool::Pg(_) => {
-                crate::database::repository::macros::postgres_operation!(
-                    &*$pool.get_pg_connection()?,
-                    $postgres_query,
-                    $operation
-                )
-            }
+            $crate::database::repository::DbConnectionPool::Pg(pool) => $postgres_query
+                .$operation(&*pool.get()?)
+                .map_err(RepositoryError::from),
         }
     };
 }
@@ -58,37 +18,31 @@ macro_rules! database_operation_pool {
 macro_rules! database_operation_connection {
     ($connection:expr, $postgres_query:expr, $sqlite_query:expr, $operation:ident) => {
         match $connection {
+            #[cfg(feature = "sqlite")]
             #[allow(unused_variables)]
-            crate::database::repository::DbConnection::Sqlite(connection) => {
-                crate::database::repository::macros::sqlite_operation!(
-                    &*connection,
-                    $sqlite_query,
-                    $operation
-                )
-            }
+            $crate::database::repository::DbConnection::Sqlite(connection) => $sqlite_query
+                .$operation(&*connection)
+                .map_err(RepositoryError::from),
+            #[cfg(feature = "postgres")]
             #[allow(unused_variables)]
-            crate::database::repository::DbConnection::Pg(connection) => {
-                crate::database::repository::macros::postgres_operation!(
-                    &*connection,
-                    $postgres_query,
-                    $operation
-                )
-            }
+            $crate::database::repository::DbConnection::Pg(connection) => $postgres_query
+                .$operation(&*connection)
+                .map_err(RepositoryError::from),
         }
     };
 }
 
 macro_rules! execute_connection {
     ($connection:expr, $query:expr) => {
-        crate::database::repository::macros::database_operation_connection!(
+        $crate::database::repository::macros::database_operation_connection!(
             $connection,
             $query,
             $query,
             execute
         )
     };
-    ($connection:expr, $postgres_query:expr,$sqlite_query:expr) => {
-        crate::database::repository::macros::database_operation_connection!(
+    ($connection:expr, $postgres_query:expr, $sqlite_query:expr) => {
+        $crate::database::repository::macros::database_operation_connection!(
             $connection,
             $postgres_query,
             $sqlite_query,
@@ -99,7 +53,7 @@ macro_rules! execute_connection {
 
 macro_rules! execute_pool {
     ($connection:expr, $query:expr) => {
-        crate::database::repository::macros::database_operation_pool!(
+        $crate::database::repository::macros::database_operation_pool!(
             $connection,
             $query,
             $query,
@@ -107,7 +61,7 @@ macro_rules! execute_pool {
         )
     };
     ($connection:expr, $postgres_query:expr,$sqlite_query:expr) => {
-        crate::database::repository::macros::database_operation_pool!(
+        $crate::database::repository::macros::database_operation_pool!(
             $connection,
             $postgres_query,
             $sqlite_query,
@@ -118,7 +72,7 @@ macro_rules! execute_pool {
 
 macro_rules! load_pool {
     ($connection:expr, $query:expr) => {
-        crate::database::repository::macros::database_operation_pool!(
+        $crate::database::repository::macros::database_operation_pool!(
             $connection,
             $query,
             $query,
@@ -126,7 +80,7 @@ macro_rules! load_pool {
         )
     };
     ($connection:expr, $postgres_query:expr,$sqlite_query:expr) => {
-        crate::database::repository::macros::database_operation_pool!(
+        $crate::database::repository::macros::database_operation_pool!(
             $connection,
             $postgres_query,
             $sqlite_query,
@@ -137,7 +91,7 @@ macro_rules! load_pool {
 
 macro_rules! first_pool {
     ($connection:expr, $query:expr) => {
-        crate::database::repository::macros::database_operation_pool!(
+        $crate::database::repository::macros::database_operation_pool!(
             $connection,
             $query,
             $query,
@@ -145,7 +99,7 @@ macro_rules! first_pool {
         )
     };
     ($connection:expr, $postgres_query:expr,$sqlite_query:expr) => {
-        crate::database::repository::macros::database_operation_pool!(
+        $crate::database::repository::macros::database_operation_pool!(
             $connection,
             $postgres_query,
             $sqlite_query,
@@ -156,7 +110,7 @@ macro_rules! first_pool {
 
 macro_rules! get_results_pool {
     ($connection:expr, $query:expr) => {
-        crate::database::repository::macros::database_operation_pool!(
+        $crate::database::repository::macros::database_operation_pool!(
             $connection,
             $query,
             $query,
@@ -164,7 +118,7 @@ macro_rules! get_results_pool {
         )
     };
     ($connection:expr, $postgres_query:expr,$sqlite_query:expr) => {
-        crate::database::repository::macros::database_operation_pool!(
+        $crate::database::repository::macros::database_operation_pool!(
             $connection,
             $postgres_query,
             $sqlite_query,
@@ -173,50 +127,18 @@ macro_rules! get_results_pool {
     };
 }
 
-#[cfg(feature = "postgres")]
-macro_rules! postgres_transaction {
-    ($expression:expr) => {
-        $expression
-    };
-}
-
-#[cfg(not(feature = "postgres"))]
-macro_rules! postgres_transaction {
-    // How to match all ?
-    ($expression:expr) => {
-        panic!("postgres flag is not enabled")
-    };
-}
-
-#[cfg(feature = "sqlite")]
-macro_rules! sqlite_transaction {
-    ($expression:expr) => {
-        $expression
-    };
-}
-
-#[cfg(not(feature = "sqlite"))]
-macro_rules! sqlite_transaction {
-    // How to match all ?
-    ($expression:expr) => {
-        panic!("sqlite flag is not enabled")
-    };
-}
-
 macro_rules! transaction {
     ($connection:expr, $transaction_content:expr) => {
         match $connection {
+            #[cfg(feature = "sqlite")]
             #[allow(unused_variables)]
-            crate::database::repository::DbConnection::Sqlite(connection) => {
-                crate::database::repository::macros::sqlite_transaction!(
-                    connection.transaction($transaction_content)
-                )
+            $crate::database::repository::DbConnection::Sqlite(connection) => {
+                connection.transaction($transaction_content)
             }
+            #[cfg(feature = "postgres")]
             #[allow(unused_variables)]
-            crate::database::repository::DbConnection::Pg(connection) => {
-                crate::database::repository::macros::postgres_transaction!(
-                    connection.transaction($transaction_content)
-                )
+            $crate::database::repository::DbConnection::Pg(connection) => {
+                connection.transaction($transaction_content)
             }
         }
     };
@@ -229,8 +151,4 @@ pub(crate) use execute_pool;
 pub(crate) use first_pool;
 pub(crate) use get_results_pool;
 pub(crate) use load_pool;
-pub(crate) use postgres_operation;
-pub(crate) use postgres_transaction;
-pub(crate) use sqlite_operation;
-pub(crate) use sqlite_transaction;
 pub(crate) use transaction;

--- a/src/database/repository/diesel/database_wrapper/macros.rs
+++ b/src/database/repository/diesel/database_wrapper/macros.rs
@@ -1,0 +1,84 @@
+macro_rules! execute_connection {
+    ($connection:expr, $query:expr) => {
+        match $connection {
+            crate::database::repository::DbConnection::Sqlite(connection) => {
+                $query.execute(&*connection)
+            }
+            crate::database::repository::DbConnection::Pg(connection) => {
+                $query.execute(&*connection)
+            }
+        }
+    };
+}
+
+macro_rules! execute_pool {
+    ($pool:expr, $query:expr) => {
+        match $pool {
+            crate::database::repository::DbConnectionPool::Sqlite(_) => $query
+                .execute(&*$pool.get_sqlite_connection()?)
+                .map_err(|err| RepositoryError::from(err)),
+            crate::database::repository::DbConnectionPool::Pg(_) => $query
+                .execute(&*$pool.get_pg_connection()?)
+                .map_err(|err| RepositoryError::from(err)),
+        }
+    };
+}
+
+macro_rules! load_pool {
+    ($pool:expr, $query:expr) => {
+        match $pool {
+            crate::database::repository::DbConnectionPool::Sqlite(_) => $query
+                .load(&*$pool.get_sqlite_connection()?)
+                .map_err(|err| RepositoryError::from(err)),
+            crate::database::repository::DbConnectionPool::Pg(_) => $query
+                .load(&*$pool.get_pg_connection()?)
+                .map_err(|err| RepositoryError::from(err)),
+        }
+    };
+}
+
+macro_rules! first_pool {
+    ($pool:expr, $query:expr) => {
+        match $pool {
+            crate::database::repository::DbConnectionPool::Sqlite(_) => $query
+                .first(&*$pool.get_sqlite_connection()?)
+                .map_err(|err| RepositoryError::from(err)),
+            crate::database::repository::DbConnectionPool::Pg(_) => $query
+                .first(&*$pool.get_pg_connection()?)
+                .map_err(|err| RepositoryError::from(err)),
+        }
+    };
+}
+
+macro_rules! get_results_pool {
+    ($pool:expr, $query:expr) => {
+        match $pool {
+            crate::database::repository::DbConnectionPool::Sqlite(_) => $query
+                .get_results(&*$pool.get_sqlite_connection()?)
+                .map_err(|err| RepositoryError::from(err)),
+            crate::database::repository::DbConnectionPool::Pg(_) => $query
+                .get_results(&*$pool.get_pg_connection()?)
+                .map_err(|err| RepositoryError::from(err)),
+        }
+    };
+}
+
+macro_rules! transaction {
+    ($connection:expr, $transaction_content:expr) => {
+        match $connection {
+            crate::database::repository::DbConnection::Sqlite(connection) => {
+                connection.transaction($transaction_content)
+            }
+            crate::database::repository::DbConnection::Pg(connection) => {
+                connection.transaction($transaction_content)
+            }
+        }
+    };
+}
+
+pub(crate) use execute_connection;
+pub(crate) use execute_pool;
+pub(crate) use first_pool;
+pub(crate) use get_results_pool;
+pub(crate) use load_pool;
+pub(crate) use transaction;

--- a/src/database/repository/diesel/database_wrapper/macros.rs
+++ b/src/database/repository/diesel/database_wrapper/macros.rs
@@ -1,65 +1,201 @@
-macro_rules! execute_connection {
-    ($connection:expr, $query:expr) => {
-        match $connection {
-            crate::database::repository::DbConnection::Sqlite(connection) => {
-                $query.execute(&*connection)
+#[cfg(feature = "postgres")]
+macro_rules! postgres_operation {
+    ($connection:expr, $query:expr, $operation:ident) => {
+        $query
+            .$operation($connection)
+            .map_err(|err| RepositoryError::from(err))
+    };
+}
+
+#[cfg(not(feature = "postgres"))]
+macro_rules! postgres_operation {
+    // How to match all ?
+    ($connection:expr, $query:expr, $operation:ident) => {
+        panic!("postgres flag is not enabled")
+    };
+}
+
+#[cfg(feature = "sqlite")]
+macro_rules! sqlite_operation {
+    ($connection:expr, $query:expr, $operation:ident) => {
+        $query
+            .$operation($connection)
+            .map_err(|err| RepositoryError::from(err))
+    };
+}
+
+#[cfg(not(feature = "sqlite"))]
+macro_rules! sqlite_operation {
+    // How to match all ?
+    ($connection:expr, $query:expr, $operation:ident) => {
+        panic!("sqlite flag is not enabled")
+    };
+}
+
+macro_rules! database_operation_pool {
+    ($pool:expr, $postgres_query:expr, $sqlite_query:expr, $operation:ident) => {
+        match $pool {
+            crate::database::repository::DbConnectionPool::Sqlite(_) => {
+                crate::database::repository::macros::sqlite_operation!(
+                    &*$pool.get_sqlite_connection()?,
+                    $sqlite_query,
+                    $operation
+                )
             }
-            crate::database::repository::DbConnection::Pg(connection) => {
-                $query.execute(&*connection)
+            crate::database::repository::DbConnectionPool::Pg(_) => {
+                crate::database::repository::macros::postgres_operation!(
+                    &*$pool.get_pg_connection()?,
+                    $postgres_query,
+                    $operation
+                )
             }
         }
+    };
+}
+
+macro_rules! database_operation_connection {
+    ($connection:expr, $postgres_query:expr, $sqlite_query:expr, $operation:ident) => {
+        match $connection {
+            crate::database::repository::DbConnection::Sqlite(connection) => {
+                crate::database::repository::macros::sqlite_operation!(
+                    &*connection,
+                    $sqlite_query,
+                    $operation
+                )
+            }
+            crate::database::repository::DbConnection::Pg(connection) => {
+                crate::database::repository::macros::postgres_operation!(
+                    &*connection,
+                    $postgres_query,
+                    $operation
+                )
+            }
+        }
+    };
+}
+
+macro_rules! execute_connection {
+    ($connection:expr, $query:expr) => {
+        crate::database::repository::macros::database_operation_connection!(
+            $connection,
+            $query,
+            $query,
+            execute
+        )
+    };
+    ($connection:expr, $postgres_query:expr,$sqlite_query:expr) => {
+        crate::database::repository::macros::database_operation_connection!(
+            $connection,
+            $postgres_query,
+            $sqlite_query,
+            execute
+        )
     };
 }
 
 macro_rules! execute_pool {
-    ($pool:expr, $query:expr) => {
-        match $pool {
-            crate::database::repository::DbConnectionPool::Sqlite(_) => $query
-                .execute(&*$pool.get_sqlite_connection()?)
-                .map_err(|err| RepositoryError::from(err)),
-            crate::database::repository::DbConnectionPool::Pg(_) => $query
-                .execute(&*$pool.get_pg_connection()?)
-                .map_err(|err| RepositoryError::from(err)),
-        }
+    ($connection:expr, $query:expr) => {
+        crate::database::repository::macros::database_operation_pool!(
+            $connection,
+            $query,
+            $query,
+            execute
+        )
+    };
+    ($connection:expr, $postgres_query:expr,$sqlite_query:expr) => {
+        crate::database::repository::macros::database_operation_pool!(
+            $connection,
+            $postgres_query,
+            $sqlite_query,
+            execute
+        )
     };
 }
 
 macro_rules! load_pool {
-    ($pool:expr, $query:expr) => {
-        match $pool {
-            crate::database::repository::DbConnectionPool::Sqlite(_) => $query
-                .load(&*$pool.get_sqlite_connection()?)
-                .map_err(|err| RepositoryError::from(err)),
-            crate::database::repository::DbConnectionPool::Pg(_) => $query
-                .load(&*$pool.get_pg_connection()?)
-                .map_err(|err| RepositoryError::from(err)),
-        }
+    ($connection:expr, $query:expr) => {
+        crate::database::repository::macros::database_operation_pool!(
+            $connection,
+            $query,
+            $query,
+            load
+        )
+    };
+    ($connection:expr, $postgres_query:expr,$sqlite_query:expr) => {
+        crate::database::repository::macros::database_operation_pool!(
+            $connection,
+            $postgres_query,
+            $sqlite_query,
+            load
+        )
     };
 }
 
 macro_rules! first_pool {
-    ($pool:expr, $query:expr) => {
-        match $pool {
-            crate::database::repository::DbConnectionPool::Sqlite(_) => $query
-                .first(&*$pool.get_sqlite_connection()?)
-                .map_err(|err| RepositoryError::from(err)),
-            crate::database::repository::DbConnectionPool::Pg(_) => $query
-                .first(&*$pool.get_pg_connection()?)
-                .map_err(|err| RepositoryError::from(err)),
-        }
+    ($connection:expr, $query:expr) => {
+        crate::database::repository::macros::database_operation_pool!(
+            $connection,
+            $query,
+            $query,
+            first
+        )
+    };
+    ($connection:expr, $postgres_query:expr,$sqlite_query:expr) => {
+        crate::database::repository::macros::database_operation_pool!(
+            $connection,
+            $postgres_query,
+            $sqlite_query,
+            first
+        )
     };
 }
 
 macro_rules! get_results_pool {
-    ($pool:expr, $query:expr) => {
-        match $pool {
-            crate::database::repository::DbConnectionPool::Sqlite(_) => $query
-                .get_results(&*$pool.get_sqlite_connection()?)
-                .map_err(|err| RepositoryError::from(err)),
-            crate::database::repository::DbConnectionPool::Pg(_) => $query
-                .get_results(&*$pool.get_pg_connection()?)
-                .map_err(|err| RepositoryError::from(err)),
-        }
+    ($connection:expr, $query:expr) => {
+        crate::database::repository::macros::database_operation_pool!(
+            $connection,
+            $query,
+            $query,
+            get_results
+        )
+    };
+    ($connection:expr, $postgres_query:expr,$sqlite_query:expr) => {
+        crate::database::repository::macros::database_operation_pool!(
+            $connection,
+            $postgres_query,
+            $sqlite_query,
+            get_results
+        )
+    };
+}
+
+#[cfg(feature = "postgres")]
+macro_rules! postgres_transaction {
+    ($expression:expr) => {
+        $expression
+    };
+}
+
+#[cfg(not(feature = "postgres"))]
+macro_rules! postgres_transaction {
+    // How to match all ?
+    ($expression:expr) => {
+        panic!("postgres flag is not enabled")
+    };
+}
+
+#[cfg(feature = "sqlite")]
+macro_rules! sqlite_transaction {
+    ($expression:expr) => {
+        $expression
+    };
+}
+
+#[cfg(not(feature = "sqlite"))]
+macro_rules! sqlite_transaction {
+    // How to match all ?
+    ($expression:expr) => {
+        panic!("sqlite flag is not enabled")
     };
 }
 
@@ -67,18 +203,28 @@ macro_rules! transaction {
     ($connection:expr, $transaction_content:expr) => {
         match $connection {
             crate::database::repository::DbConnection::Sqlite(connection) => {
-                connection.transaction($transaction_content)
+                crate::database::repository::macros::sqlite_transaction!(
+                    connection.transaction($transaction_content)
+                )
             }
             crate::database::repository::DbConnection::Pg(connection) => {
-                connection.transaction($transaction_content)
+                crate::database::repository::macros::postgres_transaction!(
+                    connection.transaction($transaction_content)
+                )
             }
         }
     };
 }
 
+pub(crate) use database_operation_connection;
+pub(crate) use database_operation_pool;
 pub(crate) use execute_connection;
 pub(crate) use execute_pool;
 pub(crate) use first_pool;
 pub(crate) use get_results_pool;
 pub(crate) use load_pool;
+pub(crate) use postgres_operation;
+pub(crate) use postgres_transaction;
+pub(crate) use sqlite_operation;
+pub(crate) use sqlite_transaction;
 pub(crate) use transaction;

--- a/src/database/repository/diesel/database_wrapper/macros.rs
+++ b/src/database/repository/diesel/database_wrapper/macros.rs
@@ -9,12 +9,12 @@ macro_rules! database_operation_pool {
             #[cfg(feature = "sqlite")]
             #[allow(unused_variables)]
             $crate::database::repository::DbConnectionPool::Sqlite(pool) => $sqlite_query
-                .$operation(&*pool.get()?)
+                .$operation(&pool.get()?)
                 .map_err(RepositoryError::from),
             #[cfg(feature = "postgres")]
             #[allow(unused_variables)]
             $crate::database::repository::DbConnectionPool::Pg(pool) => $postgres_query
-                .$operation(&*pool.get()?)
+                .$operation(&pool.get()?)
                 .map_err(RepositoryError::from),
         }
     };

--- a/src/database/repository/diesel/database_wrapper/mod.rs
+++ b/src/database/repository/diesel/database_wrapper/mod.rs
@@ -1,0 +1,88 @@
+pub mod macros;
+use diesel::{
+    r2d2::{ConnectionManager, Pool, PooledConnection},
+    PgConnection, SqliteConnection,
+};
+use serde::Deserialize;
+
+use crate::{database::repository::RepositoryError, util::settings::Settings};
+
+#[derive(Debug, Clone, Deserialize)]
+pub enum ConnectionType {
+    Pg,
+    Sqlite,
+}
+
+pub enum DbConnectionPool {
+    Pg(Pool<ConnectionManager<PgConnection>>),
+    Sqlite(Pool<ConnectionManager<SqliteConnection>>),
+}
+
+pub enum DbConnection {
+    Pg(PooledConnection<ConnectionManager<PgConnection>>),
+    Sqlite(PooledConnection<ConnectionManager<SqliteConnection>>),
+}
+
+impl From<r2d2::Error> for RepositoryError {
+    fn from(err: r2d2::Error) -> Self {
+        RepositoryError::OtherConnectionError(err.to_string())
+    }
+}
+
+impl DbConnectionPool {
+    pub fn new(settings: &Settings) -> DbConnectionPool {
+        match settings.database.database_type {
+            ConnectionType::Pg => DbConnectionPool::new_pg(&settings.database.connection_string()),
+            ConnectionType::Sqlite => {
+                DbConnectionPool::new_sqlite(&settings.database.connection_string())
+            }
+        }
+    }
+
+    pub fn new_pg(connection_string: &str) -> DbConnectionPool {
+        let connection_manager = ConnectionManager::<PgConnection>::new(connection_string);
+        DbConnectionPool::Pg(Pool::new(connection_manager).expect("Failed to connect to database"))
+    }
+
+    pub fn new_sqlite(connection_string: &str) -> DbConnectionPool {
+        let connection_manager = ConnectionManager::<SqliteConnection>::new(connection_string);
+        DbConnectionPool::Sqlite(
+            Pool::new(connection_manager).expect("Failed to connect to database"),
+        )
+    }
+
+    pub fn get_pg_connection(
+        &self,
+    ) -> Result<PooledConnection<ConnectionManager<diesel::PgConnection>>, RepositoryError> {
+        match self {
+            DbConnectionPool::Pg(pool) => Ok(pool.get()?),
+            _ => Err(RepositoryError::ConnectionDoesntExist(ConnectionType::Pg)),
+        }
+    }
+
+    pub fn get_sqlite_connection(
+        &self,
+    ) -> Result<PooledConnection<ConnectionManager<diesel::SqliteConnection>>, RepositoryError>
+    {
+        match self {
+            DbConnectionPool::Sqlite(pool) => Ok(pool.get()?),
+            _ => Err(RepositoryError::ConnectionDoesntExist(
+                ConnectionType::Sqlite,
+            )),
+        }
+    }
+
+    pub fn get_connection(&self) -> Result<DbConnection, RepositoryError> {
+        match self {
+            DbConnectionPool::Pg(pool) => Ok(DbConnection::Pg(pool.get()?)),
+            DbConnectionPool::Sqlite(pool) => Ok(DbConnection::Sqlite(pool.get()?)),
+        }
+    }
+
+    pub fn clone(&self) -> DbConnectionPool {
+        match self {
+            DbConnectionPool::Pg(pool) => DbConnectionPool::Pg(pool.clone()),
+            DbConnectionPool::Sqlite(pool) => DbConnectionPool::Sqlite(pool.clone()),
+        }
+    }
+}

--- a/src/database/repository/diesel/database_wrapper/mod.rs
+++ b/src/database/repository/diesel/database_wrapper/mod.rs
@@ -75,7 +75,7 @@ impl DbConnectionPool {
     }
 
     #[cfg(not(feature = "postgres"))]
-    pub fn new_pg(connection_string: &str) -> DbConnectionPool {
+    pub fn new_pg(_: &str) -> DbConnectionPool {
         panic!("postgres flag is not enabled")
     }
 
@@ -88,7 +88,7 @@ impl DbConnectionPool {
     }
 
     #[cfg(not(feature = "sqlite"))]
-    pub fn new_sqlite(connection_string: &str) -> DbConnectionPool {
+    pub fn new_sqlite(_: &str) -> DbConnectionPool {
         panic!("sqlite flag is not enabled")
     }
 

--- a/src/database/repository/diesel/item.rs
+++ b/src/database/repository/diesel/item.rs
@@ -1,6 +1,6 @@
 use crate::database::{
     repository::{
-        macros::{execute_connection, first_pool, load_pool},
+        macros::{execute, first, load},
         DbConnection, DbConnectionPool, RepositoryError,
     },
     schema::{diesel_schema::item::dsl::*, ItemRow},
@@ -20,7 +20,7 @@ impl ItemRepository {
         connection: &DbConnection,
         item_row: &ItemRow,
     ) -> Result<(), RepositoryError> {
-        execute_connection!(
+        execute!(
             connection,
             // Postgres
             diesel::insert_into(item)
@@ -39,7 +39,7 @@ impl ItemRepository {
         connection: &DbConnection,
         item_row: &ItemRow,
     ) -> Result<(), RepositoryError> {
-        execute_connection!(connection, diesel::insert_into(item).values(item_row))?;
+        execute!(connection, diesel::insert_into(item).values(item_row))?;
         Ok(())
     }
 
@@ -48,14 +48,14 @@ impl ItemRepository {
     }
 
     pub async fn find_all(&self) -> Result<Vec<ItemRow>, RepositoryError> {
-        load_pool!(self.pool, item)
+        load!(self.pool, item)
     }
 
     pub async fn find_one_by_id(&self, item_id: &str) -> Result<ItemRow, RepositoryError> {
-        first_pool!(self.pool, item.filter(id.eq(item_id)))
+        first!(self.pool, item.filter(id.eq(item_id)))
     }
 
     pub async fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<ItemRow>, RepositoryError> {
-        load_pool!(self.pool, item.filter(id.eq_any(ids)))
+        load!(self.pool, item.filter(id.eq_any(ids)))
     }
 }

--- a/src/database/repository/diesel/item.rs
+++ b/src/database/repository/diesel/item.rs
@@ -22,14 +22,12 @@ impl ItemRepository {
     ) -> Result<(), RepositoryError> {
         execute!(
             connection,
-            // Postgres
-            diesel::insert_into(item)
+            postgres => diesel::insert_into(item)
                 .values(item_row)
                 .on_conflict(id)
                 .do_update()
                 .set(item_row),
-            // Sqlite
-            diesel::replace_into(item).values(item_row)
+            sqlite => diesel::replace_into(item).values(item_row),
         )?;
 
         Ok(())

--- a/src/database/repository/diesel/item.rs
+++ b/src/database/repository/diesel/item.rs
@@ -20,17 +20,17 @@ impl ItemRepository {
         connection: &DbConnection,
         item_row: &ItemRow,
     ) -> Result<(), RepositoryError> {
-        match connection {
-            DbConnection::Pg(pg_connection) => diesel::insert_into(item)
+        execute_connection!(
+            connection,
+            // Postgres
+            diesel::insert_into(item)
                 .values(item_row)
                 .on_conflict(id)
                 .do_update()
-                .set(item_row)
-                .execute(&**pg_connection),
-            DbConnection::Sqlite(sqlite_connection) => diesel::replace_into(item)
-                .values(item_row)
-                .execute(&**sqlite_connection),
-        }?;
+                .set(item_row),
+            // Sqlite
+            diesel::replace_into(item).values(item_row)
+        )?;
 
         Ok(())
     }

--- a/src/database/repository/diesel/item_line.rs
+++ b/src/database/repository/diesel/item_line.rs
@@ -1,6 +1,6 @@
 use crate::database::{
     repository::{
-        macros::{execute_pool, first_pool, load_pool},
+        macros::{execute, first, load},
         DbConnectionPool, RepositoryError,
     },
     schema::{diesel_schema::item_line::dsl::*, ItemLineRow},
@@ -16,7 +16,7 @@ impl ItemLineRepository {
     }
 
     pub async fn insert_one(&self, item_line_row: &ItemLineRow) -> Result<(), RepositoryError> {
-        execute_pool!(
+        execute!(
             self.pool,
             diesel::insert_into(item_line).values(item_line_row)
         )?;
@@ -25,13 +25,13 @@ impl ItemLineRepository {
     }
 
     pub async fn find_one_by_id(&self, item_line_id: &str) -> Result<ItemLineRow, RepositoryError> {
-        first_pool!(self.pool, item_line.filter(id.eq(item_line_id)))
+        first!(self.pool, item_line.filter(id.eq(item_line_id)))
     }
 
     pub async fn find_many_by_id(
         &self,
         ids: &[String],
     ) -> Result<Vec<ItemLineRow>, RepositoryError> {
-        load_pool!(self.pool, item_line.filter(id.eq_any(ids)))
+        load!(self.pool, item_line.filter(id.eq_any(ids)))
     }
 }

--- a/src/database/repository/diesel/name.rs
+++ b/src/database/repository/diesel/name.rs
@@ -29,14 +29,12 @@ impl NameRepository {
     ) -> Result<(), RepositoryError> {
         execute!(
             connection,
-            // Postgres
-            diesel::insert_into(name_table)
+            postgres => diesel::insert_into(name_table)
                 .values(name_row)
                 .on_conflict(id)
                 .do_update()
                 .set(name_row),
-            // Sqlite
-            diesel::replace_into(name_table).values(name_row)
+            sqlite => diesel::replace_into(name_table).values(name_row),
         )?;
 
         Ok(())

--- a/src/database/repository/diesel/name.rs
+++ b/src/database/repository/diesel/name.rs
@@ -1,6 +1,6 @@
 use crate::database::{
     repository::{
-        macros::{execute_connection, first_pool, load_pool},
+        macros::{execute, first, load},
         DbConnection, DbConnectionPool, RepositoryError,
     },
     schema::{diesel_schema::name_table::dsl::*, NameRow},
@@ -19,7 +19,7 @@ impl NameRepository {
         connection: &DbConnection,
         name_row: &NameRow,
     ) -> Result<(), RepositoryError> {
-        execute_connection!(connection, diesel::insert_into(name_table).values(name_row))?;
+        execute!(connection, diesel::insert_into(name_table).values(name_row))?;
         Ok(())
     }
 
@@ -27,7 +27,7 @@ impl NameRepository {
         connection: &DbConnection,
         name_row: &NameRow,
     ) -> Result<(), RepositoryError> {
-        execute_connection!(
+        execute!(
             connection,
             // Postgres
             diesel::insert_into(name_table)
@@ -48,10 +48,10 @@ impl NameRepository {
     }
 
     pub async fn find_one_by_id(&self, name_id: &str) -> Result<NameRow, RepositoryError> {
-        first_pool!(self.pool, name_table.filter(id.eq(name_id)))
+        first!(self.pool, name_table.filter(id.eq(name_id)))
     }
 
     pub async fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<NameRow>, RepositoryError> {
-        load_pool!(self.pool, name_table.filter(id.eq_any(ids)))
+        load!(self.pool, name_table.filter(id.eq_any(ids)))
     }
 }

--- a/src/database/repository/diesel/name.rs
+++ b/src/database/repository/diesel/name.rs
@@ -27,17 +27,17 @@ impl NameRepository {
         connection: &DbConnection,
         name_row: &NameRow,
     ) -> Result<(), RepositoryError> {
-        match connection {
-            DbConnection::Pg(pg_connection) => diesel::insert_into(name_table)
+        execute_connection!(
+            connection,
+            // Postgres
+            diesel::insert_into(name_table)
                 .values(name_row)
                 .on_conflict(id)
                 .do_update()
-                .set(name_row)
-                .execute(&**pg_connection),
-            DbConnection::Sqlite(sqlite_connection) => diesel::replace_into(name_table)
-                .values(name_row)
-                .execute(&**sqlite_connection),
-        }?;
+                .set(name_row),
+            // Sqlite
+            diesel::replace_into(name_table).values(name_row)
+        )?;
 
         Ok(())
     }

--- a/src/database/repository/diesel/requisition.rs
+++ b/src/database/repository/diesel/requisition.rs
@@ -1,6 +1,6 @@
 use crate::database::{
     repository::{
-        macros::{execute_pool, first_pool, load_pool},
+        macros::{execute, first, load},
         DbConnectionPool, RepositoryError,
     },
     schema::{diesel_schema::requisition::dsl::*, RequisitionRow},
@@ -19,7 +19,7 @@ impl RequisitionRepository {
         &self,
         requisition_row: &RequisitionRow,
     ) -> Result<(), RepositoryError> {
-        execute_pool!(
+        execute!(
             self.pool,
             diesel::insert_into(requisition).values(requisition_row)
         )?;
@@ -30,13 +30,13 @@ impl RequisitionRepository {
         &self,
         requisition_id: &str,
     ) -> Result<RequisitionRow, RepositoryError> {
-        first_pool!(self.pool, requisition.filter(id.eq(requisition_id)))
+        first!(self.pool, requisition.filter(id.eq(requisition_id)))
     }
 
     pub async fn find_many_by_id(
         &self,
         ids: &[String],
     ) -> Result<Vec<RequisitionRow>, RepositoryError> {
-        load_pool!(self.pool, requisition.filter(id.eq_any(ids)))
+        load!(self.pool, requisition.filter(id.eq_any(ids)))
     }
 }

--- a/src/database/repository/diesel/requisition_line.rs
+++ b/src/database/repository/diesel/requisition_line.rs
@@ -1,6 +1,6 @@
 use crate::database::{
     repository::{
-        macros::{execute_pool, first_pool, load_pool},
+        macros::{execute, first, load},
         DbConnectionPool, RepositoryError,
     },
     schema::{diesel_schema::requisition_line::dsl::*, RequisitionLineRow},
@@ -20,7 +20,7 @@ impl RequisitionLineRepository {
         &self,
         requisition_line_row: &RequisitionLineRow,
     ) -> Result<(), RepositoryError> {
-        execute_pool!(
+        execute!(
             self.pool,
             diesel::insert_into(requisition_line).values(requisition_line_row)
         )?;
@@ -31,21 +31,21 @@ impl RequisitionLineRepository {
         &self,
         row_id: &str,
     ) -> Result<RequisitionLineRow, RepositoryError> {
-        first_pool!(self.pool, requisition_line.filter(id.eq(row_id)))
+        first!(self.pool, requisition_line.filter(id.eq(row_id)))
     }
 
     pub async fn find_many_by_id(
         &self,
         ids: &[String],
     ) -> Result<Vec<RequisitionLineRow>, RepositoryError> {
-        load_pool!(self.pool, requisition_line.filter(id.eq_any(ids)))
+        load!(self.pool, requisition_line.filter(id.eq_any(ids)))
     }
 
     pub async fn find_many_by_requisition_id(
         &self,
         req_id: &str,
     ) -> Result<Vec<RequisitionLineRow>, RepositoryError> {
-        load_pool!(
+        load!(
             self.pool,
             requisition_line.filter(requisition_id.eq(req_id))
         )

--- a/src/database/repository/diesel/store.rs
+++ b/src/database/repository/diesel/store.rs
@@ -1,6 +1,6 @@
 use crate::database::{
     repository::{
-        macros::{execute_pool, first_pool, load_pool},
+        macros::{execute, first, load},
         DbConnectionPool, RepositoryError,
     },
     schema::{diesel_schema::store::dsl::*, StoreRow},
@@ -16,15 +16,15 @@ impl StoreRepository {
     }
 
     pub async fn insert_one(&self, store_row: &StoreRow) -> Result<(), RepositoryError> {
-        execute_pool!(self.pool, diesel::insert_into(store).values(store_row))?;
+        execute!(self.pool, diesel::insert_into(store).values(store_row))?;
         Ok(())
     }
 
     pub async fn find_one_by_id(&self, store_id: &str) -> Result<StoreRow, RepositoryError> {
-        first_pool!(self.pool, store.filter(id.eq(store_id)))
+        first!(self.pool, store.filter(id.eq(store_id)))
     }
 
     pub async fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<StoreRow>, RepositoryError> {
-        load_pool!(self.pool, store.filter(id.eq_any(ids)))
+        load!(self.pool, store.filter(id.eq_any(ids)))
     }
 }

--- a/src/database/repository/diesel/store.rs
+++ b/src/database/repository/diesel/store.rs
@@ -1,45 +1,30 @@
-use super::DBBackendConnection;
-
 use crate::database::{
-    repository::{repository::get_connection, RepositoryError},
-    schema::StoreRow,
+    repository::{
+        macros::{execute_pool, first_pool, load_pool},
+        DbConnectionPool, RepositoryError,
+    },
+    schema::{diesel_schema::store::dsl::*, StoreRow},
 };
-
-use diesel::{
-    prelude::*,
-    r2d2::{ConnectionManager, Pool},
-};
-
-#[derive(Clone)]
+use diesel::prelude::*;
 pub struct StoreRepository {
-    pool: Pool<ConnectionManager<DBBackendConnection>>,
+    pool: DbConnectionPool,
 }
 
 impl StoreRepository {
-    pub fn new(pool: Pool<ConnectionManager<DBBackendConnection>>) -> StoreRepository {
+    pub fn new(pool: DbConnectionPool) -> StoreRepository {
         StoreRepository { pool }
     }
 
     pub async fn insert_one(&self, store_row: &StoreRow) -> Result<(), RepositoryError> {
-        use crate::database::schema::diesel_schema::store::dsl::*;
-        let connection = get_connection(&self.pool)?;
-        diesel::insert_into(store)
-            .values(store_row)
-            .execute(&connection)?;
+        execute_pool!(self.pool, diesel::insert_into(store).values(store_row))?;
         Ok(())
     }
 
     pub async fn find_one_by_id(&self, store_id: &str) -> Result<StoreRow, RepositoryError> {
-        use crate::database::schema::diesel_schema::store::dsl::*;
-        let connection = get_connection(&self.pool)?;
-        let result = store.filter(id.eq(store_id)).first(&connection)?;
-        Ok(result)
+        first_pool!(self.pool, store.filter(id.eq(store_id)))
     }
 
     pub async fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<StoreRow>, RepositoryError> {
-        use crate::database::schema::diesel_schema::store::dsl::*;
-        let connection = get_connection(&self.pool)?;
-        let result = store.filter(id.eq_any(ids)).load(&connection)?;
-        Ok(result)
+        load_pool!(self.pool, store.filter(id.eq_any(ids)))
     }
 }

--- a/src/database/repository/diesel/sync.rs
+++ b/src/database/repository/diesel/sync.rs
@@ -1,11 +1,7 @@
 use crate::database::{
-    repository::{
-        macros::transaction, DbConnectionPool, ItemRepository, NameRepository, RepositoryError,
-    },
+    repository::{DbConnectionPool, ItemRepository, NameRepository, RepositoryError},
     schema::{ItemRow, NameRow},
 };
-
-use diesel::prelude::*;
 
 pub enum IntegrationUpsertRecord {
     Name(NameRow),
@@ -30,7 +26,7 @@ impl SyncRepository {
         integration_records: &IntegrationRecord,
     ) -> Result<(), RepositoryError> {
         let connection = self.pool.get_connection()?;
-        transaction!(&connection, || {
+        connection.transaction(|| {
             for record in &integration_records.upserts {
                 match &record {
                     IntegrationUpsertRecord::Name(record) => {

--- a/src/database/repository/diesel/transact.rs
+++ b/src/database/repository/diesel/transact.rs
@@ -1,6 +1,6 @@
 use crate::database::{
     repository::{
-        macros::{execute_pool, first_pool, get_results_pool, load_pool},
+        macros::{execute, first, get_results, load},
         DbConnectionPool, RepositoryError,
     },
     schema::{diesel_schema::transact::dsl::*, TransactRow, TransactRowType},
@@ -18,7 +18,7 @@ impl TransactRepository {
     }
 
     pub async fn insert_one(&self, transact_row: &TransactRow) -> Result<(), RepositoryError> {
-        execute_pool!(
+        execute!(
             self.pool,
             diesel::insert_into(transact).values(transact_row)
         )?;
@@ -26,14 +26,14 @@ impl TransactRepository {
     }
 
     pub async fn find_one_by_id(&self, transact_id: &str) -> Result<TransactRow, RepositoryError> {
-        first_pool!(self.pool, transact.filter(id.eq(transact_id)))
+        first!(self.pool, transact.filter(id.eq(transact_id)))
     }
 
     pub async fn find_many_by_id(
         &self,
         ids: &[String],
     ) -> Result<Vec<TransactRow>, RepositoryError> {
-        load_pool!(self.pool, transact.filter(id.eq_any(ids)))
+        load!(self.pool, transact.filter(id.eq_any(ids)))
     }
 }
 
@@ -50,7 +50,7 @@ impl CustomerInvoiceRepository {
         &self,
         name: &str,
     ) -> Result<Vec<TransactRow>, RepositoryError> {
-        get_results_pool!(
+        get_results!(
             self.pool,
             transact.filter(
                 type_of
@@ -64,7 +64,7 @@ impl CustomerInvoiceRepository {
         &self,
         store: &str,
     ) -> Result<Vec<TransactRow>, RepositoryError> {
-        get_results_pool!(
+        get_results!(
             self.pool,
             transact.filter(
                 type_of

--- a/src/database/repository/diesel/transact_line.rs
+++ b/src/database/repository/diesel/transact_line.rs
@@ -1,6 +1,6 @@
 use crate::database::{
     repository::{
-        macros::{execute_pool, first_pool, get_results_pool, load_pool},
+        macros::{execute, first, get_results, load},
         RepositoryError,
     },
     schema::{diesel_schema::transact_line::dsl::*, TransactLineRow},
@@ -22,7 +22,7 @@ impl TransactLineRepository {
         &self,
         transact_line_row: &TransactLineRow,
     ) -> Result<(), RepositoryError> {
-        execute_pool!(
+        execute!(
             self.pool,
             diesel::insert_into(transact_line).values(transact_line_row)
         )?;
@@ -30,20 +30,20 @@ impl TransactLineRepository {
     }
 
     pub async fn find_one_by_id(&self, row_id: &str) -> Result<TransactLineRow, RepositoryError> {
-        first_pool!(self.pool, transact_line.filter(id.eq(row_id)))
+        first!(self.pool, transact_line.filter(id.eq(row_id)))
     }
 
     pub async fn find_many_by_id(
         &self,
         ids: &[String],
     ) -> Result<Vec<TransactLineRow>, RepositoryError> {
-        load_pool!(self.pool, transact_line.filter(id.eq_any(ids)))
+        load!(self.pool, transact_line.filter(id.eq_any(ids)))
     }
 
     pub async fn find_many_by_transact_id(
         &self,
         trans_id: &str,
     ) -> Result<Vec<TransactLineRow>, RepositoryError> {
-        get_results_pool!(self.pool, transact_line.filter(transact_id.eq(trans_id)))
+        get_results!(self.pool, transact_line.filter(transact_id.eq(trans_id)))
     }
 }

--- a/src/database/repository/diesel/user_account.rs
+++ b/src/database/repository/diesel/user_account.rs
@@ -1,6 +1,6 @@
 use crate::database::{
     repository::{
-        macros::{execute_pool, first_pool, load_pool},
+        macros::{execute, first, load},
         RepositoryError,
     },
     schema::{diesel_schema::user_account::dsl::*, UserAccountRow},
@@ -22,7 +22,7 @@ impl UserAccountRepository {
         &self,
         user_account_row: &UserAccountRow,
     ) -> Result<(), RepositoryError> {
-        execute_pool!(
+        execute!(
             self.pool,
             diesel::insert_into(user_account).values(user_account_row)
         )?;
@@ -33,13 +33,13 @@ impl UserAccountRepository {
         &self,
         account_id: &str,
     ) -> Result<UserAccountRow, RepositoryError> {
-        first_pool!(self.pool, user_account.filter(id.eq(account_id)))
+        first!(self.pool, user_account.filter(id.eq(account_id)))
     }
 
     pub async fn find_many_by_id(
         &self,
         ids: &[String],
     ) -> Result<Vec<UserAccountRow>, RepositoryError> {
-        load_pool!(self.pool, user_account.filter(id.eq_any(ids)))
+        load!(self.pool, user_account.filter(id.eq_any(ids)))
     }
 }

--- a/src/database/repository/mod.rs
+++ b/src/database/repository/mod.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-#[derive(Clone, Error, Debug)]
+#[derive(Error, Clone, Debug)]
 pub enum RepositoryError {
     /// Row not found but expected at least one row
     #[error("row not found but expected at least one row")]
@@ -8,6 +8,12 @@ pub enum RepositoryError {
     /// Row already exists
     #[error("row already exists")]
     UniqueViolation,
+    // Connection doesn't exist
+    #[error("connection does not exist")]
+    ConnectionDoesntExist(ConnectionType),
+    // Other connection error
+    #[error("r2d2 connection error")]
+    OtherConnectionError(String),
     /// Foreign key constraint is violated
     #[error("foreign key constraint is violated")]
     ForeignKeyViolation,
@@ -16,16 +22,5 @@ pub enum RepositoryError {
     DBError { msg: String },
 }
 
-#[cfg_attr(any(feature = "sqlite", feature = "postgres"), path = "diesel/mod.rs")]
-#[cfg_attr(
-    not(any(feature = "sqlite", feature = "postgres")),
-    path = "mock/mod.rs"
-)]
-pub mod repository;
-
-pub use repository::{
-    get_repositories, CustomerInvoiceRepository, IntegrationRecord, ItemLineRepository,
-    ItemRepository, NameRepository, RequisitionLineRepository, RequisitionRepository,
-    StoreRepository, SyncRepository, TransactLineRepository, TransactRepository,
-    UserAccountRepository,
-};
+pub mod diesel;
+pub use self::diesel::*;

--- a/src/database/schema/diesel_schema.rs
+++ b/src/database/schema/diesel_schema.rs
@@ -52,7 +52,6 @@ table! {
 table! {
     sync_out (id) {
         id -> Text,
-        created_at -> Date,
         table_name -> crate::database::schema::sync_out::SyncOutRowTableNameTypeMapping,
         record_id -> Text,
         store_id -> Text,

--- a/src/database/schema/sync_out.rs
+++ b/src/database/schema/sync_out.rs
@@ -25,7 +25,6 @@ pub enum SyncOutRowActionType {
 #[table_name = "sync_out"]
 pub struct SyncOutRow {
     pub id: String,
-    pub created_at: String,
     pub table_name: SyncOutRowTableNameType,
     pub record_id: String,
     pub store_id: String,

--- a/src/server/data/repository.rs
+++ b/src/server/data/repository.rs
@@ -1,14 +1,14 @@
-use anymap::{any::CloneAny, Map};
+use anymap::{any::Any, Map};
 
 pub type RepositoryMap = Map<AnyRepository>;
-pub type AnyRepository = dyn CloneAny + Send + Sync;
+pub type AnyRepository = dyn Any + Send + Sync;
 
 pub struct RepositoryRegistry {
     pub repositories: RepositoryMap,
 }
 
 impl RepositoryRegistry {
-    pub fn get<T: anymap::any::CloneAny + Send + Sync>(&self) -> &T {
+    pub fn get<T: anymap::any::Any + Send + Sync>(&self) -> &T {
         match self.repositories.get::<T>() {
             Some(repository) => repository,
             None => unreachable!("{} not found", std::any::type_name::<T>()),

--- a/src/server/service/graphql/mod.rs
+++ b/src/server/service/graphql/mod.rs
@@ -10,12 +10,12 @@ use crate::server::data::{LoaderRegistry, RepositoryRegistry};
 
 // Sugar that helps make things neater and avoid errors that would only crop up at runtime.
 trait ContextExt {
-    fn get_repository<T: anymap::any::CloneAny + Send + Sync>(&self) -> &T;
+    fn get_repository<T: anymap::any::Any + Send + Sync>(&self) -> &T;
     fn get_loader<T: anymap::any::Any + Send + Sync>(&self) -> &T;
 }
 
 impl<'a> ContextExt for Context<'a> {
-    fn get_repository<T: anymap::any::CloneAny + Send + Sync>(&self) -> &T {
+    fn get_repository<T: anymap::any::Any + Send + Sync>(&self) -> &T {
         self.data_unchecked::<Data<RepositoryRegistry>>().get::<T>()
     }
 

--- a/src/server/service/graphql/schema/mutations.rs
+++ b/src/server/service/graphql/schema/mutations.rs
@@ -1,10 +1,6 @@
-use crate::database::repository::{
-    ItemRepository, RequisitionLineRepository, RequisitionRepository,
-};
-use crate::database::schema::{ItemRow, RequisitionLineRow, RequisitionRow};
-use crate::server::service::graphql::schema::types::{
-    InputRequisitionLine, Item, Requisition, RequisitionType,
-};
+use crate::database::repository::*;
+use crate::database::schema::*;
+use crate::server::service::graphql::schema::types::*;
 use crate::server::service::graphql::ContextExt;
 
 use async_graphql::{Context, Object};

--- a/src/server/service/graphql/schema/queries.rs
+++ b/src/server/service/graphql/schema/queries.rs
@@ -1,10 +1,5 @@
-use crate::database::repository::{
-    ItemLineRepository, ItemRepository, NameRepository, RequisitionRepository, StoreRepository,
-    TransactLineRepository, TransactRepository,
-};
-use crate::database::schema::{
-    ItemLineRow, ItemRow, NameRow, RequisitionRow, StoreRow, TransactLineRow, TransactRow,
-};
+use crate::database::repository::*;
+use crate::database::schema::*;
 use crate::server::service::graphql::schema::types::{
     Item, ItemLine, Name, Requisition, Store, Transact, TransactLine,
 };

--- a/src/server/service/graphql/schema/types.rs
+++ b/src/server/service/graphql/schema/types.rs
@@ -1,14 +1,5 @@
 use crate::{
-    database::{
-        loader::{ItemLineLoader, ItemLoader, NameLoader, StoreLoader, TransactLoader},
-        repository::{
-            CustomerInvoiceRepository, RequisitionLineRepository, TransactLineRepository,
-        },
-        schema::{
-            ItemLineRow, ItemRow, NameRow, RequisitionLineRow, RequisitionRow, RequisitionRowType,
-            StoreRow, TransactLineRow, TransactRow, TransactRowType,
-        },
-    },
+    database::{loader::*, repository::*, schema::*},
     server::service::graphql::ContextExt,
 };
 

--- a/src/util/settings.rs
+++ b/src/util/settings.rs
@@ -5,6 +5,8 @@ use std::{
     io::Error as IoError,
 };
 
+use crate::database::repository::ConnectionType;
+
 #[derive(serde::Deserialize)]
 pub struct Settings {
     pub server: ServerSettings,
@@ -40,33 +42,28 @@ pub struct DatabaseSettings {
     pub port: u16,
     pub host: String,
     pub database_name: String,
+    pub database_type: ConnectionType,
 }
 
-#[cfg(not(feature = "sqlite"))]
 impl DatabaseSettings {
     pub fn connection_string(&self) -> String {
-        format!(
-            "postgres://{}:{}@{}:{}/{}",
-            self.username, self.password, self.host, self.port, self.database_name
-        )
+        match self.database_type {
+            ConnectionType::Pg => format!(
+                "postgres://{}:{}@{}:{}/{}",
+                self.username, self.password, self.host, self.port, self.database_name
+            ),
+            ConnectionType::Sqlite => format!("{}.sqlite", self.database_name),
+        }
     }
 
     pub fn connection_string_without_db(&self) -> String {
-        format!(
-            "postgres://{}:{}@{}:{}",
-            self.username, self.password, self.host, self.port
-        )
-    }
-}
-
-#[cfg(feature = "sqlite")]
-impl DatabaseSettings {
-    pub fn connection_string(&self) -> String {
-        format!("{}.sqlite", self.database_name)
-    }
-
-    pub fn connection_string_without_db(&self) -> String {
-        return self.connection_string();
+        match self.database_type {
+            ConnectionType::Pg => format!(
+                "postgres://{}:{}@{}:{}",
+                self.username, self.password, self.host, self.port
+            ),
+            ConnectionType::Sqlite => format!("{}.sqlite", self.database_name),
+        }
     }
 }
 

--- a/src/util/sync/mod.rs
+++ b/src/util/sync/mod.rs
@@ -1,3 +1,7 @@
+// FIXME(chris-morgan, 2021-09-15): don’t *have* dead code. But for now these warnings distract
+// from *real* warnings.
+#![allow(dead_code)]
+
 mod connection;
 mod credentials;
 mod queue;

--- a/src/util/sync/translation/item.rs
+++ b/src/util/sync/translation/item.rs
@@ -110,6 +110,7 @@ mod tests {
     };
 
     #[actix_rt::test]
+    #[cfg_attr(not(feature = "sqlite"), ignore)]
     async fn test_item_translation() {
         let settings = test_db::get_test_settings(
             "omsupply-database-item-translation",

--- a/src/util/sync/translation/item.rs
+++ b/src/util/sync/translation/item.rs
@@ -101,7 +101,7 @@ impl LegacyItemRow {
 #[cfg(test)]
 mod tests {
     use crate::{
-        database::repository::{repository::get_repositories, ItemRepository},
+        database::repository::{get_repositories, ConnectionType, ItemRepository},
         server::data::RepositoryRegistry,
         util::{
             sync::translation::{import_sync_records, SyncRecord, SyncType},
@@ -111,7 +111,10 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_item_translation() {
-        let settings = test_db::get_test_settings("omsupply-database-item-translation");
+        let settings = test_db::get_test_settings(
+            "omsupply-database-item-translation",
+            ConnectionType::Sqlite,
+        );
         test_db::setup(&settings.database).await;
         let repositories = get_repositories(&settings).await;
         let registry = RepositoryRegistry { repositories };

--- a/src/util/sync/translation/mod.rs
+++ b/src/util/sync/translation/mod.rs
@@ -2,9 +2,7 @@ mod item;
 mod name;
 
 use crate::{
-    database::repository::{
-        repository::IntegrationUpsertRecord, IntegrationRecord, SyncRepository,
-    },
+    database::repository::{IntegrationRecord, IntegrationUpsertRecord, SyncRepository},
     server::data::RepositoryRegistry,
 };
 

--- a/src/util/sync/translation/name.rs
+++ b/src/util/sync/translation/name.rs
@@ -128,7 +128,7 @@ impl LegacyNameTable {
 #[cfg(test)]
 mod tests {
     use crate::{
-        database::repository::{repository::get_repositories, NameRepository},
+        database::repository::{get_repositories, ConnectionType, NameRepository},
         server::data::RepositoryRegistry,
         util::{
             sync::translation::{import_sync_records, SyncRecord, SyncType},
@@ -138,7 +138,10 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_name_translation() {
-        let settings = test_db::get_test_settings("omsupply-database-name-translation");
+        let settings = test_db::get_test_settings(
+            "omsupply-database-name-translation",
+            ConnectionType::Sqlite,
+        );
         test_db::setup(&settings.database).await;
         let repositories = get_repositories(&settings).await;
         let registry = RepositoryRegistry { repositories };

--- a/src/util/sync/translation/name.rs
+++ b/src/util/sync/translation/name.rs
@@ -137,6 +137,7 @@ mod tests {
     };
 
     #[actix_rt::test]
+    #[cfg_attr(not(feature = "sqlite"), ignore)]
     async fn test_name_translation() {
         let settings = test_db::get_test_settings(
             "omsupply-database-name-translation",

--- a/src/util/test_db.rs
+++ b/src/util/test_db.rs
@@ -12,7 +12,7 @@ pub async fn setup(db_settings: &DatabaseSettings) {
 }
 
 #[cfg(not(feature = "postgres"))]
-async fn setup_pg(db_settings: &DatabaseSettings) {
+async fn setup_pg(_: &DatabaseSettings) {
     panic!("postgres flag is not enabled")
 }
 
@@ -61,7 +61,7 @@ async fn setup_pg(db_settings: &DatabaseSettings) {
     }
 }
 #[cfg(not(feature = "sqlite"))]
-async fn setup_sqlite(db_settings: &DatabaseSettings) {
+async fn setup_sqlite(_: &DatabaseSettings) {
     panic!("sqlite flag is not enabled")
 }
 #[cfg(feature = "sqlite")]

--- a/src/util/test_db.rs
+++ b/src/util/test_db.rs
@@ -11,6 +11,12 @@ pub async fn setup(db_settings: &DatabaseSettings) {
     }
 }
 
+#[cfg(not(feature = "postgres"))]
+async fn setup_pg(db_settings: &DatabaseSettings) {
+    panic!("postgres flag is not enabled")
+}
+
+#[cfg(feature = "postgres")]
 async fn setup_pg(db_settings: &DatabaseSettings) {
     use diesel::{
         r2d2::{ConnectionManager, Pool},
@@ -54,7 +60,11 @@ async fn setup_pg(db_settings: &DatabaseSettings) {
         migration.run(&connection).unwrap();
     }
 }
-
+#[cfg(not(feature = "sqlite"))]
+async fn setup_sqlite(db_settings: &DatabaseSettings) {
+    panic!("sqlite flag is not enabled")
+}
+#[cfg(feature = "sqlite")]
 async fn setup_sqlite(db_settings: &DatabaseSettings) {
     use diesel::{Connection, SqliteConnection};
     use std::fs;

--- a/tests/repository/basic.rs
+++ b/tests/repository/basic.rs
@@ -1,18 +1,7 @@
 #[cfg(test)]
 mod repository_basic_test {
 
-    use remote_server::database::{
-        repository::{
-            repository::get_repositories, CustomerInvoiceRepository, ItemLineRepository,
-            ItemRepository, NameRepository, RequisitionLineRepository, RequisitionRepository,
-            StoreRepository, TransactLineRepository, TransactRepository, UserAccountRepository,
-        },
-        schema::{
-            ItemLineRow, ItemRow, NameRow, RequisitionLineRow, RequisitionRow, RequisitionRowType,
-            StoreRow, TransactLineRow, TransactLineRowType, TransactRow, TransactRowType,
-            UserAccountRow,
-        },
-    };
+    use remote_server::database::{repository::*, schema::*};
 
     use remote_server::util::test_db;
 
@@ -240,7 +229,10 @@ mod repository_basic_test {
 
     #[actix_rt::test]
     async fn simple_repository_tests() {
-        let settings = test_db::get_test_settings("omsupply-database-simple-repository-test");
+        let settings = test_db::get_test_settings(
+            "omsupply-database-simple-repository-test",
+            ConnectionType::Sqlite,
+        );
         // Initialise a new test database.
         test_db::setup(&settings.database).await;
         let repos = get_repositories(&settings).await;

--- a/tests/repository/basic.rs
+++ b/tests/repository/basic.rs
@@ -228,6 +228,7 @@ mod repository_basic_test {
     }
 
     #[actix_rt::test]
+    #[cfg_attr(not(feature = "sqlite"), ignore)]
     async fn simple_repository_tests() {
         let settings = test_db::get_test_settings(
             "omsupply-database-simple-repository-test",


### PR DESCRIPTION
This is out of scope for M1, but it's done in my own time. Please have a look.

Actually ended up being less code (but that's probably due to cleaning up existing 'wet' code). Also removed the need to use `Clone`

### Motivations

I didn't like using cfg flags to differentiate between connection types, main concern:
* not being able to see compilation errors for both targets at the same time. 
* needing to set flags in dev environment (and change between them to see if compiles for both targets).
* i think it's hard to read code behind cfg flags, and I think if they are used they should be used at entry point, but since we have target specific queries they will be scattered throughout the code
* would like to see a test for both DB's run at once.

### How does the this way work ?

Differentiate between database with enum, and create a wrapper for both pool and pooled connection, this would of course mean we would have to do the following:

``` rust
// let query = ...;

match connection_wrapper.db_type {
   Sqlite(connection) => query.execute(connection),
   Pg(connection) => query.execute(connection)
}
```

this is done with macros, i.e.:

```rust
macro_rules! execute_pool {
    ($pool:expr, $query:expr) => {
        match $pool {
            crate::database::repository::DbConnectionPool::Sqlite(_) => $query
                .execute(&*$pool.get_sqlite_connection()?)
                .map_err(|err| RepositoryError::from(err)),
            crate::database::repository::DbConnectionPool::Pg(_) => $query
                .execute(&*$pool.get_pg_connection()?)
                .map_err(|err| RepositoryError::from(err)),
        }
    };
}
// ....

// let query = ...;
execute_pool!(pool_wrapper, query)?
```

### Review suggestion

have a look at: `repository/database_wrapper` code.

and check out how it's used in `diesel/item.rs` (or any other repository)

see what macros expand to: `cargo expand database::repository::diesel::item --lib`

### Extras

We can possibly use generic to achieve the same thing, but it would be much harder and code would be a lot more complex.

I think changes in this PR will save developers a bit of time overall.

If you are happy with it, we can talk about merging this in in strategic way (to reduce load of conflicts in existing PRs)

### Building and bundling

Latest commit: https://github.com/openmsupply/remote-server/pull/323/commits/51623d1b2f90fa7ce57bd5bc46ef099ea2ec665b, adds cfg flags in wrapper and db initialisation only (so we can still conditionally compile when needed).

no explicit flags will result in compilation for both.

for sqlite only: 
`cargo check --no-default-features --features sqlite`
for postgres only: 
`cargo check --no-default-features --features postgres`

if you want to see what things expand to (get cargo expand first):
`cargo expand database::repository::diesel::item --lib --no-default-features --features sqlite`
`cargo expand database::repository::diesel::item --lib --no-default-features --features postgres`

note, we can write different queries for different db target (without cfg flags, although they are there but in one place in macros)

```rust
    pub fn upsert_one_tx(
        connection: &DbConnection,
        item_row: &ItemRow,
    ) -> Result<(), RepositoryError> {
        execute_connection!(
            connection,
            // Postgres
            diesel::insert_into(item)
                .values(item_row)
                .on_conflict(id)
                .do_update()
                .set(item_row),
            // Sqlite
            diesel::replace_into(item).values(item_row)
        )?;

        Ok(())
    }
```

this expands to this with default flags:
`cargo expand database::repository::diesel::item --lib`
```rust
   pub fn upsert_one_tx(
            connection: &DbConnection,
            item_row: &ItemRow,
        ) -> Result<(), RepositoryError> {
            match connection {
                #[allow(unused_variables)]
                crate::database::repository::DbConnection::Sqlite(connection) => {
                    diesel::replace_into(item)
                        .values(item_row)
                        .execute(&*connection)
                        .map_err(|err| RepositoryError::from(err))
                }
                #[allow(unused_variables)]
                crate::database::repository::DbConnection::Pg(connection) => {
                    diesel::insert_into(item)
                        .values(item_row)
                        .on_conflict(id)
                        .do_update()
                        .set(item_row)
                        .execute(&*connection)
                        .map_err(|err| RepositoryError::from(err))
                }
            }?;
            Ok(())
        }
```

and with `sqlite` flags:

`cargo expand database::repository::diesel::item --lib --no-default-features --features sqlite`

```rust
  pub fn upsert_one_tx(
            connection: &DbConnection,
            item_row: &ItemRow,
        ) -> Result<(), RepositoryError> {
            match connection {
                #[allow(unused_variables)]
                crate::database::repository::DbConnection::Sqlite(connection) => {
                    diesel::replace_into(item)
                        .values(item_row)
                        .execute(&*connection)
                        .map_err(|err| RepositoryError::from(err))
                }
                #[allow(unused_variables)]
                crate::database::repository::DbConnection::Pg(connection) => {
                    ::std::rt::begin_panic("postgres flag is not enabled")
                }
            }?;
            Ok(())
        }
```

expressions can also be 'blocks'




