### PR TITLE
Use a "SyncSession" to integrate all records in a single tx

### DIFF
--- a/src/database/repository/diesel/mod.rs
+++ b/src/database/repository/diesel/mod.rs
@@ -27,7 +27,7 @@ pub use name::NameRepository;
 pub use requisition::RequisitionRepository;
 pub use requisition_line::RequisitionLineRepository;
 pub use store::StoreRepository;
-pub use sync::{IntegrationRecord, IntegrationUpsertRecord, SyncRepository};
+pub use sync::{IntegrationRecord, IntegrationUpsertRecord, SyncRepository, SyncSession};
 pub use transact::{CustomerInvoiceRepository, TransactRepository};
 pub use transact_line::TransactLineRepository;
 pub use user_account::UserAccountRepository;


### PR DESCRIPTION
Instead of putting more logic into the SyncRepository I introduced a SyncSession and all records integrated in the same SyncSession are stored in a single transaction.

Let me know what you think...