### PR TITLE
Fix sync transaction

### DIFF
--- a/src/util/sync/mod.rs
+++ b/src/util/sync/mod.rs
@@ -29,7 +29,7 @@ use tokio::{
     time::{self, Duration, Interval},
 };
 
-use self::translation::{import_sync_records, SyncRecord, SyncType, TRANSLATION_RECORDS};
+use translation::{import_sync_records, SyncRecord, SyncType, TRANSLATION_RECORDS};
 
 pub fn get_sync_actors(connection: SyncConnection) -> (SyncSenderActor, SyncReceiverActor) {
     // We use a single-element channel so that we can only have one sync pending at a time.


### PR DESCRIPTION
Sync was actually spread over multiple transactions...

Not 100% happy about the current API but I tried to keep it simple, e.g. SyncSession does the transaction and is passed as an argument to the SyncRepository import method... 