### PR TITLE
api error handling example

### DIFF
--- a/src/database/repository/diesel/mod.rs
+++ b/src/database/repository/diesel/mod.rs
@@ -37,7 +37,7 @@ pub use requisition::RequisitionRepository;
 pub use requisition_line::RequisitionLineRepository;
 pub use stock_line::StockLineRepository;
 pub use store::StoreRepository;
-pub use sync::{IntegrationRecord, IntegrationUpsertRecord, SyncRepository, SyncSession};
+pub use sync::{IntegrationRecord, IntegrationUpsertRecord, SyncRepository};
 pub use user_account::UserAccountRepository;
 
 use diesel::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,9 +72,6 @@ async fn main() -> std::io::Result<()> {
     tokio::select! {
         result = http_server => result,
         () = async {
-          sync_sender.schedule_send(Duration::from_secs(settings.sync.interval)).await;
-        } => unreachable!("Sync receiver unexpectedly died!?"),
-        () = async {
           sync_receiver.listen(repository_registry_sync_data).await;
         } => unreachable!("Sync scheduler unexpectedly died!?"),
     }

--- a/src/server/service/graphql/schema/queries/mod.rs
+++ b/src/server/service/graphql/schema/queries/mod.rs
@@ -7,8 +7,8 @@ use crate::database::schema::{InvoiceLineRow, InvoiceRow, RequisitionRow, StoreR
 use crate::server::service::graphql::schema::types::{Invoice, InvoiceLine, Requisition, Store};
 use crate::server::service::graphql::ContextExt;
 
-use super::types::{ItemList, NameList};
-use async_graphql::{Context, Object};
+use super::types::{ItemList, NameListWithError};
+use async_graphql::*;
 use pagination::Pagination;
 pub struct Queries;
 
@@ -23,8 +23,8 @@ impl Queries {
         &self,
         _ctx: &Context<'_>,
         #[graphql(desc = "pagination (first and offset)")] page: Option<Pagination>,
-    ) -> NameList {
-        NameList { pagination: page }
+    ) -> NameListWithError {
+        NameListWithError::new(page)
     }
 
     pub async fn items(

--- a/src/server/service/graphql/schema/queries/pagination.rs
+++ b/src/server/service/graphql/schema/queries/pagination.rs
@@ -3,7 +3,7 @@ use async_graphql::InputObject;
 #[derive(InputObject)]
 pub struct Pagination {
     pub first: Option<u32>,
-    pub offset: Option<u32>,
+    pub offset: Option<i32>,
 }
 
 pub trait PaginationOption {
@@ -12,6 +12,7 @@ pub trait PaginationOption {
 }
 
 pub const DEFAULT_PAGE_SIZE: u32 = 100;
+pub const MAX_PAGE_SIZE: u32 = 200;
 
 impl PaginationOption for Option<Pagination> {
     fn first(&self) -> i64 {

--- a/src/server/service/graphql/schema/types/name.rs
+++ b/src/server/service/graphql/schema/types/name.rs
@@ -1,6 +1,9 @@
 use crate::database::repository::NameQueryRepository;
+use crate::server::service::graphql::schema::queries::pagination::{
+    PaginationOption, MAX_PAGE_SIZE,
+};
 use crate::server::service::graphql::{schema::queries::pagination::Pagination, ContextExt};
-use async_graphql::{Context, Object, SimpleObject};
+use async_graphql::*;
 
 #[derive(SimpleObject, PartialEq, Debug)]
 #[graphql(name = "Name")]
@@ -11,6 +14,85 @@ pub struct NameQuery {
     // Below are from name_store_join
     pub is_customer: bool,
     pub is_supplier: bool,
+}
+
+pub struct FirstError(pub i64);
+
+#[Object]
+impl FirstError {
+    pub async fn description(&self) -> &'static str {
+        if self.0 < 1 {
+            "First must be at least one"
+        } else {
+            "First is too large"
+        }
+    }
+
+    pub async fn first(&self) -> i64 {
+        self.0
+    }
+
+    pub async fn min_first(&self) -> i64 {
+        1
+    }
+
+    pub async fn max_first(&self) -> u32 {
+        MAX_PAGE_SIZE
+    }
+}
+
+pub struct OffsetError(pub i64);
+
+#[Object]
+impl OffsetError {
+    pub async fn description(&self) -> &'static str {
+        "Offset must not be negative"
+    }
+
+    pub async fn offset(&self) -> i64 {
+        self.0
+    }
+}
+
+#[derive(Interface)]
+#[graphql(field(name = "description", type = "&str"))]
+pub enum Error {
+    FirstError(FirstError),
+    OffsetError(OffsetError),
+}
+
+pub struct NameListError(pub Error);
+
+#[Object]
+impl NameListError {
+    async fn error(&self) -> &Error {
+        &self.0
+    }
+}
+
+#[derive(Union)]
+pub enum NameListWithError {
+    NameList(NameList),
+    NameListError(NameListError),
+}
+
+impl NameListWithError {
+    pub fn new(pagination: Option<Pagination>) -> NameListWithError {
+        match NameListWithError::check_error(&pagination) {
+            Some(error) => NameListWithError::NameListError(NameListError(error)),
+            None => NameListWithError::NameList(NameList { pagination }),
+        }
+    }
+
+    pub fn check_error(pagination: &impl PaginationOption) -> Option<Error> {
+        if pagination.offset() < 0 {
+            Some(Error::OffsetError(OffsetError(pagination.offset())))
+        } else if pagination.first() < 1 || pagination.first() > MAX_PAGE_SIZE.into() {
+            Some(Error::FirstError(FirstError(pagination.first())))
+        } else {
+            None
+        }
+    }
 }
 
 pub struct NameList {


### PR DESCRIPTION
After and idea from @joshxg  (that somewhat extends on the idea form @wlthomson [of including error in query](https://github.com/openmsupply/org-issues/discussions/25#discussioncomment-1257711), and [this article](https://blog.logrocket.com/handling-graphql-errors-like-a-champ-with-unions-and-interfaces/)) and some research into how unions work and interfaces work in async graphql, i think we have a pretty robust solution, shown in this PR.

`... on ` graphQL syntax is type narrowing of sorts. 

To make sure front end gets an error alway, an interface is used `Error`, you can see in below example and output that OffsetError is actually missing from in the third query, but it's still present in response (not fully but it's there). 

This also allows for type introspection to be translate into generated types in front end (otherwise errors would have to be either self types or another root query with all of the error)

```graphql
query names {
  # Just one offset error
  error1: names(page: { offset: -1 }) {
    ... on NameList {
      totalCount
      nodes {
        id
        name
      }
    }
    ... on NameListError {
      errors {
        ... on Error {
          __typename
          description
        }
        ... on FirstError {
          first
          minFirst
          maxFirst
        }
        ... on OffsetError {
          offset
        }
      }
    }
  }
  # Both offset and first error
  error2: names(page: { first: 300, offset: -1 }) {
    ... on NameList {
      totalCount
      nodes {
        id
        name
      }
    }
    ... on NameListError {
      errors {
        ... on Error {
          __typename
          description
        }
        ... on FirstError {
          first
          minFirst
          maxFirst
        }
        ... on OffsetError {
          offset
        }
      }
    }
  }
  # Both errors but offset error not specified in query
  error3: names(page: { first: 300, offset: -1 }) {
    ... on NameList {
      totalCount
      nodes {
        id
        name
      }
    }
    ... on NameListError {
      errors {
        ... on Error {
          __typename
          description
        }
        ... on FirstError {
          first
          minFirst
          maxFirst
        }
      }
    }
  }
}
```
result

```JSON
{
  "data": {
    "error1": {
      "errors": [
        {
          "__typename": "OffsetError",
          "description": "Offset must not be negative",
          "offset": -1
        }
      ]
    },
    "error2": {
      "errors": [
        {
          "__typename": "OffsetError",
          "description": "Offset must not be negative",
          "offset": -1
        },
        {
          "__typename": "FirstError",
          "description": "First is too large",
          "first": 300,
          "maxFirst": 200,
          "minFirst": 1
        }
      ]
    },
    "error3": {
      "errors": [
        {
          "__typename": "OffsetError",
          "description": "Offset must not be negative"
        },
        {
          "__typename": "FirstError",
          "description": "First is too large",
          "first": 300,
          "maxFirst": 200,
          "minFirst": 1
        }
      ]
    }
  }
}
```