### PR TITLE
365 base supplier invoice update mutation

### DIFF
--- a/src/business/supplier_invoice/check_invoice.rs
+++ b/src/business/supplier_invoice/check_invoice.rs
@@ -1,5 +1,11 @@
-use super::InsertSupplierInvoiceError;
-use crate::database::repository::{InvoiceRepository, RepositoryError};
+use super::{InsertSupplierInvoiceError, UpdateSupplierInvoiceError};
+use crate::{
+    database::{
+        repository::{InvoiceRepository, RepositoryError},
+        schema::{InvoiceRow, InvoiceRowStatus, InvoiceRowType},
+    },
+    server::service::graphql::schema::types::InvoiceStatus,
+};
 
 pub async fn check_invoice_insert(
     invoice_respository: &InvoiceRepository,
@@ -11,6 +17,46 @@ pub async fn check_invoice_insert(
         Ok(_) => Err(InvoiceExists),
         Err(error) => match &error {
             RepositoryError::NotFound => Ok(()),
+            _ => Err(DBError(error)),
+        },
+    }
+}
+
+pub fn check_invoice_update(
+    invoice_row: &InvoiceRow,
+    new_status: &Option<InvoiceStatus>,
+) -> Result<(), UpdateSupplierInvoiceError> {
+    use self::UpdateSupplierInvoiceError::*;
+
+    if invoice_row.r#type != InvoiceRowType::SupplierInvoice {
+        return Err(NotASupplierInvoice);
+    };
+
+    if invoice_row.status == InvoiceRowStatus::Finalised {
+        return Err(CannotEditFinalisedInvoice);
+    };
+
+    if let Some(InvoiceStatus::Draft) = new_status {
+        if invoice_row.status != InvoiceRowStatus::Draft {
+            return Err(CannoChangeInvoiceBackToDraft);
+        }
+    };
+
+    // InvoiceDoesNotBelongToCurrentStore
+
+    Ok(())
+}
+
+pub async fn invoice_row(
+    invoice_respository: &InvoiceRepository,
+    invoice_id: &str,
+) -> Result<InvoiceRow, UpdateSupplierInvoiceError> {
+    use self::UpdateSupplierInvoiceError::*;
+
+    match invoice_respository.find_one_by_id(invoice_id).await {
+        Ok(invoice_row) => Ok(invoice_row),
+        Err(error) => match &error {
+            RepositoryError::NotFound => Err(InvoiceDoesNotExist),
             _ => Err(DBError(error)),
         },
     }

--- a/src/business/supplier_invoice/check_other_party.rs
+++ b/src/business/supplier_invoice/check_other_party.rs
@@ -1,21 +1,69 @@
-use super::InsertSupplierInvoiceError;
-use crate::database::repository::{NameQueryRepository, RepositoryError};
+use super::{InsertSupplierInvoiceError, UpdateSupplierInvoiceError};
+use crate::{
+    database::repository::{NameQueryRepository, RepositoryError},
+    server::service::graphql::schema::types::NameQuery,
+};
 
-pub async fn check_other_party(
+enum CheckOtherParty {
+    DBError(RepositoryError),
+    NotASupplier(NameQuery),
+    NotFound(String),
+}
+
+pub async fn check_other_party_insert(
     name_query_repository: &NameQueryRepository,
     other_party_id: &str,
 ) -> Result<(), InsertSupplierInvoiceError> {
-    use self::InsertSupplierInvoiceError::*;
+    Ok(check_other_party(name_query_repository, other_party_id)?)
+}
+
+pub async fn check_other_party_update(
+    name_query_repository: &NameQueryRepository,
+    other_party_id: &Option<String>,
+) -> Result<(), UpdateSupplierInvoiceError> {
+    match other_party_id {
+        Some(other_party_id) => Ok(check_other_party(name_query_repository, &other_party_id)?),
+        None => Ok(()),
+    }
+}
+
+fn check_other_party(
+    name_query_repository: &NameQueryRepository,
+    other_party_id: &str,
+) -> Result<(), CheckOtherParty> {
+    use self::CheckOtherParty::*;
 
     let name_query = name_query_repository
         .one(other_party_id)
         .map_err(|error| match &error {
-            RepositoryError::NotFound => OtherPartyNotFound(other_party_id.to_string()),
+            RepositoryError::NotFound => NotFound(other_party_id.to_string()),
             _ => DBError(error),
         })?;
 
     match name_query.is_supplier {
         true => Ok(()),
-        false => Err(OtherPartyIsNotASupplier(name_query)),
+        false => Err(NotASupplier(name_query)),
+    }
+}
+
+impl From<CheckOtherParty> for InsertSupplierInvoiceError {
+    fn from(error: CheckOtherParty) -> Self {
+        use self::InsertSupplierInvoiceError::*;
+        match error {
+            CheckOtherParty::DBError(error) => DBError(error),
+            CheckOtherParty::NotASupplier(name_query) => OtherPartyIsNotASupplier(name_query),
+            CheckOtherParty::NotFound(other_party_id) => OtherPartyNotFound(other_party_id),
+        }
+    }
+}
+
+impl From<CheckOtherParty> for UpdateSupplierInvoiceError {
+    fn from(error: CheckOtherParty) -> Self {
+        use self::UpdateSupplierInvoiceError::*;
+        match error {
+            CheckOtherParty::DBError(error) => DBError(error),
+            CheckOtherParty::NotASupplier(name_query) => OtherPartyIsNotASupplier(name_query),
+            CheckOtherParty::NotFound(other_party_id) => OtherPartyNotFound(other_party_id),
+        }
     }
 }

--- a/src/business/supplier_invoice/mod.rs
+++ b/src/business/supplier_invoice/mod.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDateTime;
+use chrono::{NaiveDateTime, Utc};
 
 use crate::{
     database::{
@@ -20,6 +20,9 @@ pub use self::check_store::*;
 pub mod insert;
 pub use self::insert::*;
 
+pub mod update;
+pub use self::update::*;
+
 pub struct FullInvoice {
     pub id: String,
     pub name_id: String,
@@ -40,4 +43,19 @@ pub enum InsertSupplierInvoiceError {
     OtherPartyIsNotASupplier(NameQuery),
     InvoiceExists,
     DBError(RepositoryError),
+}
+
+pub enum UpdateSupplierInvoiceError {
+    OtherPartyNotFound(String),
+    OtherPartyIsNotASupplier(NameQuery),
+    CannotEditFinalisedInvoice,         // ok
+    InvoiceDoesNotExist,                // ok
+    NotASupplierInvoice,                // ok
+    InvoiceDoesNotBelongToCurrentStore, // ok
+    CannoChangeInvoiceBackToDraft,      // ok
+    DBError(RepositoryError),
+}
+
+pub fn current_date_time() -> NaiveDateTime {
+    Utc::now().naive_utc()
 }

--- a/src/business/supplier_invoice/update.rs
+++ b/src/business/supplier_invoice/update.rs
@@ -1,0 +1,101 @@
+use async_graphql::Context;
+
+use crate::{
+    business::check_other_party_update,
+    database::{
+        repository::{
+            FullInvoiceRepository, InvoiceRepository, NameQueryRepository, RepositoryError,
+            StoreRepository,
+        },
+        schema::{InvoiceRowStatus, InvoiceRowType},
+    },
+    server::service::graphql::{
+        schema::mutations::supplier_invoice::UpdateSupplierInvoiceInput, ContextExt,
+    },
+};
+
+use super::{
+    check_invoice_update, current_date_time, current_store_id, invoice_row, FullInvoice,
+    UpdateSupplierInvoiceError,
+};
+
+impl From<RepositoryError> for UpdateSupplierInvoiceError {
+    fn from(error: RepositoryError) -> Self {
+        UpdateSupplierInvoiceError::DBError(error)
+    }
+}
+
+pub async fn update_supplier_invoice(
+    ctx: &Context<'_>,
+    UpdateSupplierInvoiceInput {
+        id,
+        other_party_id,
+        status,
+        comment,
+        their_reference,
+    }: UpdateSupplierInvoiceInput,
+) -> Result<(), UpdateSupplierInvoiceError> {
+    let name_query_respository = ctx.get_repository::<NameQueryRepository>();
+    let full_invoice_repository = ctx.get_repository::<FullInvoiceRepository>();
+    let invoice_repository = ctx.get_repository::<InvoiceRepository>();
+    let store_repository = ctx.get_repository::<StoreRepository>();
+
+    let invoice_row = invoice_row(invoice_repository, &id).await?;
+    check_invoice_update(&invoice_row, &status)?;
+    check_other_party_update(name_query_respository, &other_party_id).await?;
+    current_store_id(store_repository).await?;
+
+    let status: Option<InvoiceRowStatus> = status.map(|status| status.into());
+    let previous_status = invoice_row.status;
+
+    let mut invoice = FullInvoice {
+        id: invoice_row.id,
+        r#type: InvoiceRowType::SupplierInvoice,
+        store_id: invoice_row.store_id,
+        invoice_number: invoice_row.invoice_number,
+        confirm_datetime: invoice_row.confirm_datetime,
+        finalised_datetime: invoice_row.finalised_datetime,
+        entry_datetime: invoice_row.entry_datetime,
+        status: previous_status.clone(),
+        name_id: other_party_id.unwrap_or(invoice_row.name_id),
+        comment: comment.or(invoice_row.comment),
+        their_reference: their_reference.or(invoice_row.their_reference),
+        // lines
+    };
+
+    set_new_status_datetime(&status, &previous_status, &mut invoice);
+
+    if let Some(status) = status {
+        invoice.status = status;
+    }
+
+    full_invoice_repository.update(invoice).await?;
+
+    Ok(())
+}
+
+fn set_new_status_datetime(
+    new_status: &Option<InvoiceRowStatus>,
+    previous_status: &InvoiceRowStatus,
+    invoice: &mut FullInvoice,
+) {
+    let current_datetime = current_date_time();
+
+    use InvoiceRowStatus::*;
+
+    if let Some(Finalised) = new_status {
+        if *previous_status == Draft {
+            invoice.confirm_datetime = Some(current_datetime.clone());
+        }
+
+        if *previous_status != Finalised {
+            invoice.finalised_datetime = Some(current_datetime.clone());
+        }
+    }
+
+    if let Some(Confirmed) = new_status {
+        if *previous_status == Draft {
+            invoice.confirm_datetime = Some(current_datetime.clone());
+        }
+    }
+}

--- a/src/database/repository/diesel/invoice.rs
+++ b/src/database/repository/diesel/invoice.rs
@@ -110,4 +110,18 @@ impl FullInvoiceRepository {
 
         Ok(())
     }
+
+    pub async fn update(&self, invoice: FullInvoice) -> Result<(), RepositoryError> {
+        use crate::database::schema::diesel_schema::invoice::dsl as invoice_dsl;
+        let connection = get_connection(&self.pool)?;
+
+        // Also insert the following in one transaction
+        // stock lines
+        // lines
+        diesel::update(invoice_dsl::invoice)
+            .set(InvoiceRow::from(invoice))
+            .execute(&connection)?;
+
+        Ok(())
+    }
 }

--- a/src/database/repository/diesel/mod.rs
+++ b/src/database/repository/diesel/mod.rs
@@ -58,6 +58,7 @@ pub type DBConnection = PooledConnection<ConnectionManager<DBBackendConnection>>
 
 impl From<DieselError> for RepositoryError {
     fn from(err: DieselError) -> Self {
+        println!("{:#?}", err);
         let msg = match err {
             DieselError::InvalidCString(_) => "DIESEL_INVALID_C_STRING".to_string(),
             DieselError::DatabaseError(err, _) => {

--- a/src/database/schema/invoice.rs
+++ b/src/database/schema/invoice.rs
@@ -17,7 +17,7 @@ pub enum InvoiceRowStatus {
     Finalised,
 }
 
-#[derive(Clone, Queryable, Insertable, Debug, PartialEq, Eq)]
+#[derive(Clone, Queryable, AsChangeset, Insertable, Debug, PartialEq, Eq)]
 #[table_name = "invoice"]
 pub struct InvoiceRow {
     pub id: String,

--- a/src/server/service/graphql/schema/mutations/mod.rs
+++ b/src/server/service/graphql/schema/mutations/mod.rs
@@ -1,4 +1,4 @@
-use crate::business::insert_supplier_invoice;
+use crate::business::{insert_supplier_invoice, update_supplier_invoice};
 use crate::database::repository::{
     InvoiceRepository, RepositoryError, RequisitionLineRepository, RequisitionRepository,
 };
@@ -10,7 +10,10 @@ use crate::server::service::graphql::ContextExt;
 
 use async_graphql::*;
 
-use self::supplier_invoice::{InsertSupplierInvoiceInput, InvoiceOrInsertSupplierInvoiceError};
+use self::supplier_invoice::{
+    InsertSupplierInvoiceInput, InvoiceOrInsertSupplierInvoiceError,
+    InvoiceOrUpdateSupplierInvoiceError, UpdateSupplierInvoiceInput,
+};
 
 pub mod supplier_invoice;
 
@@ -28,6 +31,18 @@ impl Mutations {
         let insert_result = insert_supplier_invoice(ctx, input).await;
 
         InvoiceOrInsertSupplierInvoiceError::new(new_id, insert_result, invoice_repository).await
+    }
+
+    async fn update_supplier_invoice(
+        &self,
+        ctx: &Context<'_>,
+        input: UpdateSupplierInvoiceInput,
+    ) -> InvoiceOrUpdateSupplierInvoiceError {
+        let invoice_repository = ctx.get_repository::<InvoiceRepository>();
+        let new_id = input.id.clone();
+        let update_result = update_supplier_invoice(ctx, input).await;
+
+        InvoiceOrUpdateSupplierInvoiceError::new(new_id, update_result, invoice_repository).await
     }
 
     async fn insert_requisition(
@@ -93,7 +108,12 @@ pub struct ForeignKeyError {
 }
 
 #[derive(SimpleObject)]
-pub struct RecordExists {
+pub struct GenericError {
+    pub description: String,
+}
+
+#[derive(SimpleObject)]
+pub struct RecordDoesNotExist {
     pub description: String,
 }
 

--- a/src/server/service/graphql/schema/mutations/supplier_invoice/insert.rs
+++ b/src/server/service/graphql/schema/mutations/supplier_invoice/insert.rs
@@ -1,0 +1,71 @@
+use super::{
+    InsertSupplierInvoiceError as ApiError, InsertSupplierInvoiceErrors as ApiErrors,
+    OtherPartyNotASuppier,
+};
+use crate::{
+    business::supplier_invoice::InsertSupplierInvoiceError as BusinessError,
+    database::repository::InvoiceRepository,
+    server::service::graphql::schema::{
+        mutations::{DBError, ForeignKeyError, ForeignKeys, GenericError},
+        types::Invoice,
+    },
+};
+
+use async_graphql::*;
+
+#[derive(Union)]
+pub enum InvoiceOrInsertSupplierInvoiceError {
+    Invoice(Invoice),
+    Errors(ApiErrors),
+}
+use self::InvoiceOrInsertSupplierInvoiceError as InvoiceWithError;
+
+impl InvoiceOrInsertSupplierInvoiceError {
+    pub async fn new(
+        id: String,
+        insert_result: Result<(), BusinessError>,
+        invoice_repository: &InvoiceRepository,
+    ) -> InvoiceWithError {
+        match insert_result {
+            Ok(_) => invoice_result(id, invoice_repository).await,
+            Err(error) => error_result(id, error),
+        }
+    }
+}
+
+async fn invoice_result(id: String, invoice_repository: &InvoiceRepository) -> InvoiceWithError {
+    match invoice_repository.find_one_by_id(&id).await {
+        Ok(invoice_row) => InvoiceWithError::Invoice(Invoice { invoice_row }),
+        Err(error) => {
+            InvoiceWithError::Errors(ApiErrors::new(id, ApiError::DBError(DBError(error))))
+        }
+    }
+}
+
+fn error_result(id: String, error: BusinessError) -> InvoiceWithError {
+    InvoiceWithError::Errors(ApiErrors::new(id, error.into()))
+}
+
+impl From<BusinessError> for ApiError {
+    fn from(business_error: BusinessError) -> Self {
+        match business_error {
+            BusinessError::OtherPartyNotFound(other_party_id) => {
+                ApiError::ForeignKeyError(ForeignKeyError {
+                    description: "Name with other party id does not exist".to_string(),
+                    key: ForeignKeys::OtherPartyId,
+                    key_id: other_party_id,
+                })
+            }
+            BusinessError::OtherPartyIsNotASupplier(name_query) => {
+                ApiError::OtherPartyNotASuppier(OtherPartyNotASuppier {
+                    description: "Other party name is not a supplier".to_string(),
+                    other_party: name_query,
+                })
+            }
+            BusinessError::InvoiceExists => ApiError::GenericError(GenericError {
+                description: "Invoice with this id already exists".to_string(),
+            }),
+            BusinessError::DBError(error) => ApiError::DBError(DBError(error)),
+        }
+    }
+}

--- a/src/server/service/graphql/schema/mutations/supplier_invoice/mod.rs
+++ b/src/server/service/graphql/schema/mutations/supplier_invoice/mod.rs
@@ -21,6 +21,16 @@ pub struct InsertSupplierInvoiceInput {
     // lines
 }
 
+#[derive(InputObject)]
+pub struct UpdateSupplierInvoiceInput {
+    pub id: String,
+    pub other_party_id: Option<String>,
+    pub status: Option<InvoiceStatus>,
+    pub comment: Option<String>,
+    pub their_reference: Option<String>,
+    // lines
+}
+
 #[derive(Union)]
 pub enum InvoiceOrInsertSupplierInvoiceError {
     Invoice(Invoice),

--- a/src/server/service/graphql/schema/mutations/supplier_invoice/update.rs
+++ b/src/server/service/graphql/schema/mutations/supplier_invoice/update.rs
@@ -1,0 +1,86 @@
+use super::{
+    OtherPartyNotASuppier, UpdateSupplierInvoiceError as ApiError,
+    UpdateSupplierInvoiceErrors as ApiErrors,
+};
+use crate::{
+    business::supplier_invoice::UpdateSupplierInvoiceError as BusinessError,
+    database::repository::InvoiceRepository,
+    server::service::graphql::schema::{
+        mutations::{DBError, ForeignKeyError, ForeignKeys, GenericError},
+        types::Invoice,
+    },
+};
+
+use async_graphql::*;
+
+#[derive(Union)]
+pub enum InvoiceOrUpdateSupplierInvoiceError {
+    Invoice(Invoice),
+    Errors(ApiErrors),
+}
+use self::InvoiceOrUpdateSupplierInvoiceError as InvoiceWithError;
+
+impl InvoiceOrUpdateSupplierInvoiceError {
+    pub async fn new(
+        id: String,
+        insert_result: Result<(), BusinessError>,
+        invoice_repository: &InvoiceRepository,
+    ) -> InvoiceWithError {
+        match insert_result {
+            Ok(_) => invoice_result(id, invoice_repository).await,
+            Err(error) => error_result(id, error),
+        }
+    }
+}
+
+async fn invoice_result(id: String, invoice_repository: &InvoiceRepository) -> InvoiceWithError {
+    match invoice_repository.find_one_by_id(&id).await {
+        Ok(invoice_row) => InvoiceWithError::Invoice(Invoice { invoice_row }),
+        Err(error) => {
+            InvoiceWithError::Errors(ApiErrors::new(id, ApiError::DBError(DBError(error))))
+        }
+    }
+}
+
+fn error_result(id: String, error: BusinessError) -> InvoiceWithError {
+    InvoiceWithError::Errors(ApiErrors::new(id, error.into()))
+}
+
+impl From<BusinessError> for ApiError {
+    fn from(business_error: BusinessError) -> Self {
+        match business_error {
+            BusinessError::OtherPartyNotFound(other_party_id) => {
+                ApiError::ForeignKeyError(ForeignKeyError {
+                    description: "Name with other party id does not exist".to_string(),
+                    key: ForeignKeys::OtherPartyId,
+                    key_id: other_party_id,
+                })
+            }
+            BusinessError::OtherPartyIsNotASupplier(name_query) => {
+                ApiError::OtherPartyNotASuppier(OtherPartyNotASuppier {
+                    description: "Other party name is not a supplier".to_string(),
+                    other_party: name_query,
+                })
+            }
+            BusinessError::InvoiceDoesNotExist => ApiError::GenericError(GenericError {
+                description: "Invoice with this id does not exist".to_string(),
+            }),
+
+            BusinessError::CannotEditFinalisedInvoice => ApiError::GenericError(GenericError {
+                description: "Cannot edit finalised invoice".to_string(),
+            }),
+            BusinessError::NotASupplierInvoice => ApiError::GenericError(GenericError {
+                description: "Not a supplier invoice".to_string(),
+            }),
+            BusinessError::InvoiceDoesNotBelongToCurrentStore => {
+                ApiError::GenericError(GenericError {
+                    description: "Invoice does not belong to current store".to_string(),
+                })
+            }
+            BusinessError::CannoChangeInvoiceBackToDraft => ApiError::GenericError(GenericError {
+                description: "Canno change invoice back to draft".to_string(),
+            }),
+            BusinessError::DBError(error) => ApiError::DBError(DBError(error)),
+        }
+    }
+}


### PR DESCRIPTION
Fixes: #364

Extending on insert supplier invoice mutation, basically copy paste GraphQL bits, and added new method in business. Not happy with generic error, i think they should be recognisable by __typename.

Also not so happy about the amount of duplication (in mutation errors), but I think it's best to find common patterns first by duplicating, rather then jumping straight into generic pattern.

### Changes
* Added business for update supplier invoice and re-arrange some shared business
* Added new input type and mutation

### Testing
* As per downstream PR but with this mutation

```graphql
mutation mutUpdate {
  updateSupplierInvoice(
    input: { id: "supplier_invoice_a", status: "CONFIRMED" }
  ) {
    ... on Invoice {
      id
    }

    ... on UpdateSupplierInvoiceErrors {
      id
      errors {
        ... on UpdateSupplierInvoiceError {
          __typename
          description
        }
        ... on ForeignKeyError {
          __typename
          key
          keyId
        }
        ... on OtherPartyNotASuppier {
          __typename
          otherParty {
            id
            name
            isSupplier
            isCustomer
          }
        }
        ... on Dberror {
          fullError
        }
      }
    }
  }
}
```

you can query results with

```graphql
query invoices {
  invoices {
    nodes {
      id
      status
      invoiceType
      confirmDatetime
      entryDatetime
      finalisedDatetime
    }  
  }
}
```