### PR TITLE
371 add lines to insert supplier invoice mutation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bytes 1.1.0",
+ "chrono",
  "fnv",
  "futures-channel",
  "futures-timer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ actix-cors = "0.5.4"
 actix-rt = "1.1.0"
 actix-web = "3.3.2" # Versions >=v4 depend on Tokio v1.
 anymap = "0.12"
-async-graphql = { version = "2.9.8", features = ["dataloader"] }
+async-graphql = { version = "2.9.8", features = ["dataloader", "chrono"] }
 async-graphql-actix-web = "2.9.8"
 async-trait = "0.1.16"
 diesel = { version = "1.4.7", default-features = false, features = ["sqlite", "postgres", "r2d2", "numeric", "chrono"] }

--- a/migrations/postgres/00000106_create_stock_line_table/up.sql
+++ b/migrations/postgres/00000106_create_stock_line_table/up.sql
@@ -3,7 +3,7 @@ CREATE TABLE stock_line (
     item_id TEXT NOT NULL REFERENCES item(id),
     store_id TEXT NOT NULL REFERENCES store(id),
     batch TEXT,
-    expiry_date TEXT,
+    expiry_date DATE,
     cost_price_per_pack DECIMAL NOT NULL,
     sell_price_per_pack DECIMAL NOT NULL,
     available_number_of_packs INTEGER NOT NULL,

--- a/migrations/postgres/00000108_create_invoice_line_table/up.sql
+++ b/migrations/postgres/00000108_create_invoice_line_table/up.sql
@@ -4,12 +4,11 @@ CREATE TABLE invoice_line (
     item_id TEXT NOT NULL REFERENCES item(id),
     stock_line_id TEXT REFERENCES stock_line(id),
     batch TEXT,
-    expiry_date TEXT,
-    cost_price_per_pack DECIMAL NOT NULL,
-    sell_price_per_pack DECIMAL NOT NULL,
-    total_after_tax DECIMAL NOT NULL,
-    available_number_of_packs INTEGER NOT NULL,
-    total_number_of_packs INTEGER NOT NULL,
+    expiry_date DATE,
+    cost_price_per_pack DOUBLE PRECISION NOT NULL,
+    sell_price_per_pack DOUBLE PRECISION NOT NULL,
+    total_after_tax DOUBLE PRECISION NOT NULL,
+    number_of_packs INTEGER NOT NULL,
     pack_size INTEGER NOT NULL
 );
 

--- a/migrations/sqlite/00000107_create_invoice_line_table/up.sql
+++ b/migrations/sqlite/00000107_create_invoice_line_table/up.sql
@@ -8,8 +8,7 @@ CREATE TABLE invoice_line (
     cost_price_per_pack REAL NOT NULL,
     sell_price_per_pack REAL NOT NULL,
     total_after_tax REAL NOT NULL,
-    available_number_of_packs INTEGER NOT NULL,
-    total_number_of_packs INTEGER NOT NULL,
+    number_of_packs INTEGER NOT NULL,
     pack_size INTEGER NOT NULL
 );
 

--- a/src/business/supplier_invoice/check_invoice.rs
+++ b/src/business/supplier_invoice/check_invoice.rs
@@ -1,19 +1,19 @@
-use super::{InsertSupplierInvoiceError, UpdateSupplierInvoiceError};
+use super::{FullInvoice, InsertSupplierInvoiceError, UpdateSupplierInvoiceError};
 use crate::{
     database::{
-        repository::{InvoiceRepository, RepositoryError},
+        repository::{FullInvoiceRepository, RepositoryError},
         schema::{InvoiceRow, InvoiceRowStatus, InvoiceRowType},
     },
     server::service::graphql::schema::types::InvoiceStatus,
 };
 
 pub async fn check_invoice_insert(
-    invoice_respository: &InvoiceRepository,
+    repository: &FullInvoiceRepository,
     invoice_id: &str,
 ) -> Result<(), InsertSupplierInvoiceError> {
     use self::InsertSupplierInvoiceError::*;
 
-    match invoice_respository.find_one_by_id(invoice_id).await {
+    match repository.one(invoice_id).await {
         Ok(_) => Err(InvoiceExists),
         Err(error) => match &error {
             RepositoryError::NotFound => Ok(()),
@@ -47,14 +47,14 @@ pub fn check_invoice_update(
     Ok(())
 }
 
-pub async fn invoice_row(
-    invoice_respository: &InvoiceRepository,
+pub async fn get_invoice(
+    repository: &FullInvoiceRepository,
     invoice_id: &str,
-) -> Result<InvoiceRow, UpdateSupplierInvoiceError> {
+) -> Result<FullInvoice, UpdateSupplierInvoiceError> {
     use self::UpdateSupplierInvoiceError::*;
 
-    match invoice_respository.find_one_by_id(invoice_id).await {
-        Ok(invoice_row) => Ok(invoice_row),
+    match repository.one(invoice_id).await {
+        Ok(invoice) => Ok(invoice),
         Err(error) => match &error {
             RepositoryError::NotFound => Err(InvoiceDoesNotExist),
             _ => Err(DBError(error)),

--- a/src/business/supplier_invoice/lines/mod.rs
+++ b/src/business/supplier_invoice/lines/mod.rs
@@ -1,0 +1,201 @@
+use std::convert::TryInto;
+
+use uuid::Uuid;
+
+use crate::{
+    database::{
+        repository::{InvoiceLineRepository, ItemRepository},
+        schema::{InvoiceLineRow, InvoiceRow, InvoiceRowStatus, StockLineRow},
+    },
+    server::service::graphql::schema::mutations::supplier_invoice::InsertSupplierInvoiceLineInput,
+};
+
+use super::{
+    FullInvoiceLine, InsertSupplierInvoiceError, InsertSupplierInvoiceLineError as Error,
+    InsertSupplierInvoiceLineErrors as LineErrors,
+};
+
+type Errors = Vec<LineErrors>;
+type Input = InsertSupplierInvoiceLineInput;
+
+pub async fn get_new_insert_lines(
+    lines: Option<Vec<Input>>,
+    invoice_line_repository: &InvoiceLineRepository,
+    item_respository: &ItemRepository,
+    invoice: &InvoiceRow,
+) -> Result<Vec<FullInvoiceLine>, InsertSupplierInvoiceError> {
+    let mut result = Vec::new();
+
+    if let Some(lines) = lines {
+        let all_errors = merge_errors(vec![
+            check_exists(&lines, invoice_line_repository).await?,
+            check_syntax(&lines),
+            check_item_id(&lines, item_respository).await?,
+        ]);
+
+        if all_errors.len() > 0 {
+            return Err(all_errors.into());
+        }
+
+        for line in lines {
+            let mut invoice_line = FullInvoiceLine {
+                line: create_line(line, invoice),
+                batch: None,
+            };
+
+            if invoice.status != InvoiceRowStatus::Draft {
+                let batch = create_batch(&invoice_line.line, invoice);
+                invoice_line.line.stock_line_id = Some(batch.id.clone());
+                invoice_line.batch = Some(batch);
+            }
+
+            result.push(invoice_line);
+        }
+    }
+
+    Ok(result)
+}
+
+fn create_line(
+    Input {
+        id,
+        pack_size,
+        batch,
+        number_of_packs,
+        item_id,
+        cost_price_per_pack,
+        sell_price_per_pack,
+        expiry_date,
+    }: Input,
+    invoice: &InvoiceRow,
+) -> InvoiceLineRow {
+    let pack_size = pack_size.try_into().unwrap_or(1);
+    let number_of_packs = number_of_packs.try_into().unwrap_or(0);
+
+    let total_after_tax = cost_price_per_pack * pack_size as f64 * number_of_packs as f64;
+
+    InvoiceLineRow {
+        id,
+        invoice_id: invoice.id.clone(),
+        item_id,
+        stock_line_id: None,
+        batch,
+        expiry_date,
+        pack_size,
+        number_of_packs,
+        cost_price_per_pack,
+        sell_price_per_pack,
+        total_after_tax,
+    }
+}
+
+fn create_batch(line: &InvoiceLineRow, invoice: &InvoiceRow) -> StockLineRow {
+    StockLineRow {
+        id: Uuid::new_v4().to_string(),
+        item_id: line.item_id.clone(),
+        store_id: invoice.store_id.to_string(),
+        batch: line.batch.clone(),
+        pack_size: line.pack_size,
+        cost_price_per_pack: line.cost_price_per_pack,
+        sell_price_per_pack: line.sell_price_per_pack,
+        available_number_of_packs: line.number_of_packs,
+        total_number_of_packs: line.number_of_packs,
+        expiry_date: line.expiry_date.clone(),
+    }
+}
+
+impl From<Errors> for InsertSupplierInvoiceError {
+    fn from(errors: Errors) -> Self {
+        InsertSupplierInvoiceError::InvoiceLineErrors(errors)
+    }
+}
+
+fn merge_errors(errors: Vec<Errors>) -> Errors {
+    let mut result: Errors = Vec::new();
+    let errors_flattened: Errors = errors.into_iter().flatten().collect();
+
+    for mut error in errors_flattened.into_iter() {
+        let matched = result
+            .iter_mut()
+            .find(|error_to_match| error_to_match.id == error.id);
+
+        if let Some(matched) = matched {
+            matched.errors.append(&mut error.errors);
+        } else {
+            result.push(error);
+        }
+    }
+    result
+}
+
+pub async fn check_exists(
+    lines: &Vec<Input>,
+    repository: &InvoiceLineRepository,
+) -> Result<Errors, InsertSupplierInvoiceError> {
+    let ids: Vec<String> = lines.iter().map(|input| input.id.clone()).collect();
+    let invoice_lines = repository.find_many_by_id(&ids).await?;
+
+    let result = invoice_lines
+        .into_iter()
+        .map(|invoice_line| LineErrors {
+            id: invoice_line.id,
+            errors: vec![Error::InvoiceLineAlreadyExists],
+        })
+        .collect();
+    Ok(result)
+}
+
+fn check_syntax(lines: &Vec<Input>) -> Errors {
+    let mut result = Vec::new();
+
+    for line in lines {
+        let mut errors = Vec::new();
+
+        if line.pack_size < 1 {
+            errors.push(Error::PackSizeMustBeAboveOne(line.pack_size))
+        }
+
+        if line.sell_price_per_pack < 0.0 {
+            errors.push(Error::SellPricePerPackMustBePositive(
+                line.sell_price_per_pack,
+            ))
+        }
+
+        if line.cost_price_per_pack < 0.0 {
+            errors.push(Error::CostPricePerPackMustBePositive(
+                line.cost_price_per_pack,
+            ))
+        }
+
+        if errors.len() > 0 {
+            result.push(LineErrors {
+                id: line.id.clone(),
+                errors,
+            });
+        }
+    }
+
+    result
+}
+
+async fn check_item_id(
+    lines: &Vec<Input>,
+    repository: &ItemRepository,
+) -> Result<Errors, InsertSupplierInvoiceError> {
+    let item_ids: Vec<String> = lines.iter().map(|input| input.item_id.clone()).collect();
+    let items = repository.find_many_by_id(&item_ids).await?;
+
+    let item_does_not_exists =
+        |line: &&Input| -> bool { !items.iter().any(|item| item.id == line.item_id) };
+
+    let result = lines
+        .iter()
+        .filter(item_does_not_exists)
+        .map(|line| LineErrors {
+            id: line.id.clone(),
+            errors: vec![Error::ItemIdNotFound(line.item_id.clone())],
+        })
+        .collect();
+
+    Ok(result)
+}

--- a/src/business/supplier_invoice/update.rs
+++ b/src/business/supplier_invoice/update.rs
@@ -4,10 +4,9 @@ use crate::{
     business::check_other_party_update,
     database::{
         repository::{
-            FullInvoiceRepository, InvoiceRepository, NameQueryRepository, RepositoryError,
-            StoreRepository,
+            FullInvoiceRepository, NameQueryRepository, RepositoryError, StoreRepository,
         },
-        schema::{InvoiceRowStatus, InvoiceRowType},
+        schema::{InvoiceRow, InvoiceRowStatus},
     },
     server::service::graphql::{
         schema::mutations::supplier_invoice::UpdateSupplierInvoiceInput, ContextExt,
@@ -15,7 +14,7 @@ use crate::{
 };
 
 use super::{
-    check_invoice_update, current_date_time, current_store_id, invoice_row, FullInvoice,
+    check_invoice_update, current_date_time, current_store_id, get_invoice, FullInvoice,
     UpdateSupplierInvoiceError,
 };
 
@@ -37,37 +36,39 @@ pub async fn update_supplier_invoice(
 ) -> Result<(), UpdateSupplierInvoiceError> {
     let name_query_respository = ctx.get_repository::<NameQueryRepository>();
     let full_invoice_repository = ctx.get_repository::<FullInvoiceRepository>();
-    let invoice_repository = ctx.get_repository::<InvoiceRepository>();
     let store_repository = ctx.get_repository::<StoreRepository>();
 
-    let invoice_row = invoice_row(invoice_repository, &id).await?;
-    check_invoice_update(&invoice_row, &status)?;
+    let previous_invoice = get_invoice(full_invoice_repository, &id).await?;
+    let mut previous_invoice_row = previous_invoice.invoice;
+
+    check_invoice_update(&previous_invoice_row, &status)?;
     check_other_party_update(name_query_respository, &other_party_id).await?;
     current_store_id(store_repository).await?;
 
     let status: Option<InvoiceRowStatus> = status.map(|status| status.into());
-    let previous_status = invoice_row.status;
 
-    let mut invoice = FullInvoice {
-        id: invoice_row.id,
-        r#type: InvoiceRowType::SupplierInvoice,
-        store_id: invoice_row.store_id,
-        invoice_number: invoice_row.invoice_number,
-        confirm_datetime: invoice_row.confirm_datetime,
-        finalised_datetime: invoice_row.finalised_datetime,
-        entry_datetime: invoice_row.entry_datetime,
-        status: previous_status.clone(),
-        name_id: other_party_id.unwrap_or(invoice_row.name_id),
-        comment: comment.or(invoice_row.comment),
-        their_reference: their_reference.or(invoice_row.their_reference),
-        // lines
-    };
+    if let Some(other_party_id) = other_party_id {
+        previous_invoice_row.name_id = other_party_id;
+    }
 
-    set_new_status_datetime(&status, &previous_status, &mut invoice);
+    if let Some(comment) = comment {
+        previous_invoice_row.comment = Some(comment);
+    }
+
+    if let Some(their_reference) = their_reference {
+        previous_invoice_row.their_reference = Some(their_reference);
+    }
+
+    set_new_status_datetime(&status, &mut previous_invoice_row);
 
     if let Some(status) = status {
-        invoice.status = status;
+        previous_invoice_row.status = status;
     }
+
+    let invoice = FullInvoice {
+        invoice: previous_invoice_row,
+        lines: Vec::new(),
+    };
 
     full_invoice_repository.update(invoice).await?;
 
@@ -76,26 +77,25 @@ pub async fn update_supplier_invoice(
 
 fn set_new_status_datetime(
     new_status: &Option<InvoiceRowStatus>,
-    previous_status: &InvoiceRowStatus,
-    invoice: &mut FullInvoice,
+    previous_invoice: &mut InvoiceRow,
 ) {
     let current_datetime = current_date_time();
 
     use InvoiceRowStatus::*;
 
     if let Some(Finalised) = new_status {
-        if *previous_status == Draft {
-            invoice.confirm_datetime = Some(current_datetime.clone());
+        if previous_invoice.status == Draft {
+            previous_invoice.confirm_datetime = Some(current_datetime.clone());
         }
 
-        if *previous_status != Finalised {
-            invoice.finalised_datetime = Some(current_datetime.clone());
+        if previous_invoice.status != Finalised {
+            previous_invoice.finalised_datetime = Some(current_datetime.clone());
         }
     }
 
     if let Some(Confirmed) = new_status {
-        if *previous_status == Draft {
-            invoice.confirm_datetime = Some(current_datetime.clone());
+        if previous_invoice.status == Draft {
+            previous_invoice.confirm_datetime = Some(current_datetime.clone());
         }
     }
 }

--- a/src/database/mock/invoice_line.rs
+++ b/src/database/mock/invoice_line.rs
@@ -1,3 +1,5 @@
+use chrono::NaiveDate;
+
 use crate::database::schema::InvoiceLineRow;
 
 pub fn mock_customer_invoice_a_invoice_lines() -> Vec<InvoiceLineRow> {
@@ -7,13 +9,12 @@ pub fn mock_customer_invoice_a_invoice_lines() -> Vec<InvoiceLineRow> {
         item_id: String::from("item_a"),
         stock_line_id: Some(String::from("item_a_line_a")),
         batch: Some(String::from("item_a_line_a")),
-        expiry_date: Some(String::from("item_a_line_a")),
+        expiry_date: Some(NaiveDate::from_yo(2021, 9)),
         pack_size: 1,
         cost_price_per_pack: 0.0,
         sell_price_per_pack: 0.0,
         total_after_tax: 1.0,
-        available_number_of_packs: 1,
-        total_number_of_packs: 1,
+        number_of_packs: 1,
     };
 
     let mock_customer_invoice_a_invoice_line_b: InvoiceLineRow = InvoiceLineRow {
@@ -22,13 +23,12 @@ pub fn mock_customer_invoice_a_invoice_lines() -> Vec<InvoiceLineRow> {
         item_id: String::from("item_b"),
         stock_line_id: Some(String::from("item_b_line_a")),
         batch: Some(String::from("item_a_line_a")),
-        expiry_date: Some(String::from("item_a_line_a")),
+        expiry_date: Some(NaiveDate::from_yo(2021, 9)),
         pack_size: 1,
         cost_price_per_pack: 0.0,
         sell_price_per_pack: 0.0,
         total_after_tax: 2.0,
-        available_number_of_packs: 1,
-        total_number_of_packs: 1,
+        number_of_packs: 1,
     };
 
     vec![
@@ -44,13 +44,12 @@ pub fn mock_customer_invoice_b_invoice_lines() -> Vec<InvoiceLineRow> {
         item_id: String::from("item_a"),
         stock_line_id: Some(String::from("item_a_line_a")),
         batch: Some(String::from("item_a_line_a")),
-        expiry_date: Some(String::from("item_a_line_a")),
+        expiry_date: Some(NaiveDate::from_yo(2021, 9)),
         pack_size: 1,
         cost_price_per_pack: 0.0,
         sell_price_per_pack: 0.0,
         total_after_tax: 3.0,
-        available_number_of_packs: 1,
-        total_number_of_packs: 1,
+        number_of_packs: 1,
     };
 
     let mock_customer_invoice_b_invoice_line_b: InvoiceLineRow = InvoiceLineRow {
@@ -59,13 +58,12 @@ pub fn mock_customer_invoice_b_invoice_lines() -> Vec<InvoiceLineRow> {
         item_id: String::from("item_b"),
         stock_line_id: Some(String::from("item_b_line_a")),
         batch: Some(String::from("item_a_line_a")),
-        expiry_date: Some(String::from("item_a_line_a")),
+        expiry_date: Some(NaiveDate::from_yo(2021, 9)),
         pack_size: 1,
         cost_price_per_pack: 0.0,
         sell_price_per_pack: 0.0,
         total_after_tax: 4.0,
-        available_number_of_packs: 1,
-        total_number_of_packs: 1,
+        number_of_packs: 1,
     };
 
     vec![
@@ -81,13 +79,12 @@ pub fn mock_supplier_invoice_a_invoice_lines() -> Vec<InvoiceLineRow> {
         item_id: String::from("item_a"),
         stock_line_id: Some(String::from("item_a_line_a")),
         batch: Some(String::from("item_a_line_a")),
-        expiry_date: Some(String::from("item_a_line_a")),
+        expiry_date: Some(NaiveDate::from_yo(2021, 9)),
         pack_size: 1,
         cost_price_per_pack: 0.0,
         sell_price_per_pack: 0.0,
         total_after_tax: 5.0,
-        available_number_of_packs: 1,
-        total_number_of_packs: 1,
+        number_of_packs: 1,
     };
 
     let mock_supplier_invoice_a_invoice_line_b: InvoiceLineRow = InvoiceLineRow {
@@ -96,13 +93,12 @@ pub fn mock_supplier_invoice_a_invoice_lines() -> Vec<InvoiceLineRow> {
         item_id: String::from("item_b"),
         stock_line_id: Some(String::from("item_b_line_a")),
         batch: Some(String::from("item_a_line_a")),
-        expiry_date: Some(String::from("item_a_line_a")),
+        expiry_date: Some(NaiveDate::from_yo(2021, 9)),
         pack_size: 1,
         cost_price_per_pack: 0.0,
         sell_price_per_pack: 0.0,
         total_after_tax: 6.0,
-        available_number_of_packs: 1,
-        total_number_of_packs: 1,
+        number_of_packs: 1,
     };
 
     vec![
@@ -118,13 +114,12 @@ pub fn mock_supplier_invoice_b_invoice_lines() -> Vec<InvoiceLineRow> {
         item_id: String::from("item_a"),
         stock_line_id: Some(String::from("item_a_line_a")),
         batch: Some(String::from("item_a_line_a")),
-        expiry_date: Some(String::from("item_a_line_a")),
+        expiry_date: Some(NaiveDate::from_yo(2021, 9)),
         pack_size: 1,
         cost_price_per_pack: 0.0,
         sell_price_per_pack: 0.0,
         total_after_tax: 7.0,
-        available_number_of_packs: 1,
-        total_number_of_packs: 1,
+        number_of_packs: 1,
     };
 
     let mock_supplier_invoice_b_invoice_line_b: InvoiceLineRow = InvoiceLineRow {
@@ -133,13 +128,12 @@ pub fn mock_supplier_invoice_b_invoice_lines() -> Vec<InvoiceLineRow> {
         item_id: String::from("item_b"),
         stock_line_id: Some(String::from("item_b_line_a")),
         batch: Some(String::from("item_a_line_a")),
-        expiry_date: Some(String::from("item_a_line_a")),
+        expiry_date: Some(NaiveDate::from_yo(2021, 9)),
         pack_size: 1,
         cost_price_per_pack: 0.0,
         sell_price_per_pack: 0.0,
         total_after_tax: 8.0,
-        available_number_of_packs: 1,
-        total_number_of_packs: 1,
+        number_of_packs: 1,
     };
 
     vec![

--- a/src/database/repository/diesel/invoice.rs
+++ b/src/database/repository/diesel/invoice.rs
@@ -1,11 +1,16 @@
-use super::{DBBackendConnection, DBConnection};
+use super::DBBackendConnection;
 
 use crate::{
-    business::FullInvoice,
+    business::{FullInvoice, FullInvoiceLine},
     database::{
         repository::{repository::get_connection, RepositoryError},
-        schema::InvoiceRow,
+        schema::{InvoiceLineRow, InvoiceRow, StockLineRow},
     },
+};
+
+use crate::database::schema::diesel_schema::{
+    invoice::dsl as invoice_dsl, invoice_line::dsl as invoice_line_dsl,
+    stock_line::dsl as stock_line_dsl,
 };
 
 use diesel::{
@@ -23,7 +28,8 @@ impl InvoiceRepository {
     }
 
     pub async fn insert_one(&self, invoice_row: &InvoiceRow) -> Result<(), RepositoryError> {
-        use crate::database::schema::diesel_schema::invoice::dsl::*;
+        use self::invoice_dsl::*;
+
         let connection = get_connection(&self.pool)?;
         diesel::insert_into(invoice)
             .values(invoice_row)
@@ -31,25 +37,22 @@ impl InvoiceRepository {
         Ok(())
     }
 
-    pub fn one(connection: &DBConnection, invoice_id: &str) -> Result<InvoiceRow, RepositoryError> {
-        use crate::database::schema::diesel_schema::invoice::dsl::*;
+    pub async fn find_one_by_id(&self, invoice_id: &str) -> Result<InvoiceRow, RepositoryError> {
+        use self::invoice_dsl::*;
 
+        let connection = get_connection(&self.pool)?;
         invoice
             .filter(id.eq(invoice_id))
-            .first(connection)
+            .first(&connection)
             .map_err(RepositoryError::from)
-    }
-
-    pub async fn find_one_by_id(&self, invoice_id: &str) -> Result<InvoiceRow, RepositoryError> {
-        let connection = get_connection(&self.pool)?;
-        InvoiceRepository::one(&connection, invoice_id)
     }
 
     pub async fn find_many_by_id(
         &self,
         ids: &[String],
     ) -> Result<Vec<InvoiceRow>, RepositoryError> {
-        use crate::database::schema::diesel_schema::invoice::dsl::*;
+        use self::invoice_dsl::*;
+
         let connection = get_connection(&self.pool)?;
         let result = invoice.filter(id.eq_any(ids)).load(&connection)?;
         Ok(result)
@@ -60,34 +63,13 @@ pub struct FullInvoiceRepository {
     pool: Pool<ConnectionManager<DBBackendConnection>>,
 }
 
-impl From<FullInvoice> for InvoiceRow {
-    fn from(
-        FullInvoice {
-            id,
-            name_id,
-            store_id,
-            invoice_number,
-            r#type,
-            status,
-            comment,
-            their_reference,
-            entry_datetime,
-            confirm_datetime,
-            finalised_datetime,
-        }: FullInvoice,
-    ) -> Self {
-        InvoiceRow {
-            id,
-            name_id,
-            store_id,
-            invoice_number,
-            r#type,
-            status,
-            comment,
-            their_reference,
-            entry_datetime,
-            confirm_datetime,
-            finalised_datetime,
+type InvoiceLinesWithStockLine = (InvoiceLineRow, Option<StockLineRow>);
+
+impl From<InvoiceLinesWithStockLine> for FullInvoiceLine {
+    fn from((invoice_line_row, stock_line_row): InvoiceLinesWithStockLine) -> Self {
+        FullInvoiceLine {
+            line: invoice_line_row,
+            batch: stock_line_row,
         }
     }
 }
@@ -97,29 +79,65 @@ impl FullInvoiceRepository {
         FullInvoiceRepository { pool }
     }
 
+    pub async fn one(&self, invoice_id: &str) -> Result<FullInvoice, RepositoryError> {
+        let connection = get_connection(&self.pool)?;
+        let invoice: InvoiceRow = invoice_dsl::invoice
+            .filter(invoice_dsl::id.eq(invoice_id))
+            .first(&connection)?;
+
+        let invoice_lines_with_stock_line: Vec<InvoiceLinesWithStockLine> =
+            invoice_line_dsl::invoice_line
+                .left_join(stock_line_dsl::stock_line)
+                .filter(invoice_line_dsl::invoice_id.eq(invoice_id))
+                .load(&connection)?;
+
+        Ok(FullInvoice {
+            invoice,
+            lines: invoice_lines_with_stock_line
+                .into_iter()
+                .map(FullInvoiceLine::from)
+                .collect(),
+        })
+    }
+
     pub async fn insert(&self, invoice: FullInvoice) -> Result<(), RepositoryError> {
-        use crate::database::schema::diesel_schema::invoice::dsl as invoice_dsl;
         let connection = get_connection(&self.pool)?;
 
-        // Also insert the following in one transaction
-        // stock lines
-        // lines
-        diesel::insert_into(invoice_dsl::invoice)
-            .values(InvoiceRow::from(invoice))
-            .execute(&connection)?;
+        let mut stock_lines = Vec::new();
+        let mut invoice_lines = Vec::new();
 
-        Ok(())
+        let invoice_row = invoice.invoice;
+        for line in invoice.lines.into_iter() {
+            invoice_lines.push(line.line);
+            if let Some(stock_line) = line.batch {
+                stock_lines.push(stock_line)
+            }
+        }
+
+        connection.transaction::<(), RepositoryError, _>(|| {
+            diesel::insert_into(invoice_dsl::invoice)
+                .values(invoice_row)
+                .execute(&connection)?;
+
+            diesel::insert_into(stock_line_dsl::stock_line)
+                .values(stock_lines)
+                .execute(&*connection)?;
+
+            diesel::insert_into(invoice_line_dsl::invoice_line)
+                .values(invoice_lines)
+                .execute(&*connection)?;
+            Ok(())
+        })
     }
 
     pub async fn update(&self, invoice: FullInvoice) -> Result<(), RepositoryError> {
-        use crate::database::schema::diesel_schema::invoice::dsl as invoice_dsl;
         let connection = get_connection(&self.pool)?;
 
         // Also insert the following in one transaction
         // stock lines
         // lines
         diesel::update(invoice_dsl::invoice)
-            .set(InvoiceRow::from(invoice))
+            .set(invoice.invoice)
             .execute(&connection)?;
 
         Ok(())

--- a/src/database/repository/tests.rs
+++ b/src/database/repository/tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod repository_test {
     mod data {
-        use chrono::NaiveDateTime;
+        use chrono::{NaiveDate, NaiveDateTime};
 
         use crate::database::schema::{InvoiceRowStatus, MasterListNameJoinRow};
 
@@ -186,13 +186,12 @@ mod repository_test {
                 invoice_id: "invoice1".to_string(),
                 stock_line_id: None,
                 batch: Some("".to_string()),
-                expiry_date: Some("".to_string()),
+                expiry_date: Some(NaiveDate::from_yo(2021, 9)),
                 pack_size: 1,
                 cost_price_per_pack: 0.0,
                 sell_price_per_pack: 0.0,
                 total_after_tax: 0.0,
-                available_number_of_packs: 1,
-                total_number_of_packs: 1,
+                number_of_packs: 1,
             }
         }
         pub fn invoice_line_2() -> InvoiceLineRow {
@@ -202,13 +201,12 @@ mod repository_test {
                 invoice_id: "invoice1".to_string(),
                 stock_line_id: None,
                 batch: Some("".to_string()),
-                expiry_date: Some("".to_string()),
+                expiry_date: Some(NaiveDate::from_yo(2021, 9)),
                 pack_size: 1,
                 cost_price_per_pack: 0.0,
                 sell_price_per_pack: 0.0,
                 total_after_tax: 0.0,
-                available_number_of_packs: 1,
-                total_number_of_packs: 1,
+                number_of_packs: 1,
             }
         }
 
@@ -219,13 +217,12 @@ mod repository_test {
                 invoice_id: "invoice2".to_string(),
                 stock_line_id: None,
                 batch: Some("".to_string()),
-                expiry_date: Some("".to_string()),
+                expiry_date: Some(NaiveDate::from_yo(2021, 9)),
                 pack_size: 1,
                 cost_price_per_pack: 0.0,
                 sell_price_per_pack: 0.0,
                 total_after_tax: 0.0,
-                available_number_of_packs: 1,
-                total_number_of_packs: 1,
+                number_of_packs: 1,
             }
         }
 
@@ -272,10 +269,10 @@ mod repository_test {
         database::{
             repository::{
                 get_repositories, repository::MasterListRepository, CentralSyncBufferRepository,
-                CustomerInvoiceRepository, DBBackendConnection, DBConnection,
-                InvoiceLineRepository, InvoiceRepository, ItemRepository, MasterListLineRepository,
-                MasterListNameJoinRepository, NameRepository, RequisitionLineRepository,
-                RequisitionRepository, StockLineRepository, StoreRepository, UserAccountRepository,
+                DBBackendConnection, DBConnection, InvoiceLineRepository, InvoiceRepository,
+                ItemRepository, MasterListLineRepository, MasterListNameJoinRepository,
+                NameRepository, RequisitionLineRepository, RequisitionRepository,
+                StockLineRepository, StoreRepository, UserAccountRepository,
             },
             schema::{
                 CentralSyncBufferRow, InvoiceLineRow, InvoiceRow, InvoiceRowType, ItemRow,
@@ -504,27 +501,11 @@ mod repository_test {
         store_repo.insert_one(&data::store_1()).await.unwrap();
 
         let repo = registry.get::<InvoiceRepository>().unwrap();
-        let customer_invoice_repo = registry.get::<CustomerInvoiceRepository>().unwrap();
 
         let item1 = data::invoice_1();
         repo.insert_one(&item1).await.unwrap();
         let loaded_item = repo.find_one_by_id(item1.id.as_str()).await.unwrap();
         assert_eq!(item1, loaded_item);
-
-        // customer invoice
-        let item1 = data::invoice_2();
-        repo.insert_one(&item1).await.unwrap();
-        let loaded_item = customer_invoice_repo
-            .find_many_by_name_id(&item1.name_id)
-            .await
-            .unwrap();
-        assert_eq!(1, loaded_item.len());
-
-        let loaded_item = customer_invoice_repo
-            .find_many_by_store_id(&item1.store_id)
-            .await
-            .unwrap();
-        assert_eq!(1, loaded_item.len());
     }
 
     #[actix_rt::test]

--- a/src/database/schema/diesel_schema.rs
+++ b/src/database/schema/diesel_schema.rs
@@ -32,7 +32,7 @@ table! {
         sell_price_per_pack -> Double,
         available_number_of_packs -> Integer,
         total_number_of_packs -> Integer,
-        expiry_date -> Nullable<Text>,
+        expiry_date -> Nullable<Date>,
     }
 }
 
@@ -109,13 +109,12 @@ table! {
         item_id -> Text,
         stock_line_id -> Nullable<Text>,
         batch -> Nullable<Text>,
-        expiry_date -> Nullable<Text>,
+        expiry_date -> Nullable<Date>,
         pack_size -> Integer,
         cost_price_per_pack -> Double,
         sell_price_per_pack -> Double,
         total_after_tax -> Double,
-        available_number_of_packs -> Integer,
-        total_number_of_packs -> Integer,
+        number_of_packs -> Integer,
     }
 }
 

--- a/src/database/schema/invoice_line.rs
+++ b/src/database/schema/invoice_line.rs
@@ -1,3 +1,5 @@
+use chrono::NaiveDate;
+
 use super::diesel_schema::invoice_line;
 use super::diesel_schema::invoice_line_stats;
 
@@ -9,13 +11,12 @@ pub struct InvoiceLineRow {
     pub item_id: String,
     pub stock_line_id: Option<String>,
     pub batch: Option<String>,
-    pub expiry_date: Option<String>,
+    pub expiry_date: Option<NaiveDate>,
     pub pack_size: i32,
     pub cost_price_per_pack: f64,
     pub sell_price_per_pack: f64,
     pub total_after_tax: f64,
-    pub available_number_of_packs: i32,
-    pub total_number_of_packs: i32,
+    pub number_of_packs: i32,
 }
 
 /// Row for the invoice_line_stats VIEW table (needed because of a Diesel limitation to query

--- a/src/database/schema/stock_line.rs
+++ b/src/database/schema/stock_line.rs
@@ -1,3 +1,5 @@
+use chrono::NaiveDate;
+
 use super::diesel_schema::stock_line;
 
 #[derive(Clone, Queryable, Insertable, Debug, PartialEq)]
@@ -12,5 +14,5 @@ pub struct StockLineRow {
     pub sell_price_per_pack: f64,
     pub available_number_of_packs: i32,
     pub total_number_of_packs: i32,
-    pub expiry_date: Option<String>,
+    pub expiry_date: Option<NaiveDate>,
 }

--- a/src/server/service/graphql/schema/mutations/mod.rs
+++ b/src/server/service/graphql/schema/mutations/mod.rs
@@ -98,6 +98,7 @@ impl Mutations {
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
 pub enum ForeignKeys {
     OtherPartyId,
+    ItemId,
 }
 
 pub struct ForeignKeyError {
@@ -145,5 +146,28 @@ impl DBError {
 
     pub async fn full_error(&self) -> String {
         format!("{:#}", self.0)
+    }
+}
+
+#[derive(Enum, Copy, Clone, PartialEq, Eq)]
+pub enum RangeFields {
+    SellPricePerPack,
+    CostPricePerPack,
+    PackSize,
+}
+
+pub struct ValueOutOfRange {
+    pub field: RangeFields,
+    pub description: String,
+}
+
+#[Object]
+impl ValueOutOfRange {
+    pub async fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub async fn field(&self) -> &RangeFields {
+        &self.field
     }
 }

--- a/src/server/service/graphql/schema/mutations/supplier_invoice/lines/mod.rs
+++ b/src/server/service/graphql/schema/mutations/supplier_invoice/lines/mod.rs
@@ -1,0 +1,96 @@
+use crate::{
+    business::{
+        InsertSupplierInvoiceLineError as BusinessSingleError,
+        InsertSupplierInvoiceLineErrors as BusinessLineError,
+    },
+    server::service::graphql::schema::mutations::{
+        DBError, ForeignKeyError, ForeignKeys, RangeFields, RecordAlreadyExist, ValueOutOfRange,
+    },
+};
+use async_graphql::*;
+use chrono::NaiveDate;
+
+#[derive(InputObject)]
+pub struct InsertSupplierInvoiceLineInput {
+    pub id: String,
+    pub item_id: String,
+    pub pack_size: u32,
+    pub batch: Option<String>,
+    pub cost_price_per_pack: f64,
+    pub sell_price_per_pack: f64,
+    pub expiry_date: Option<NaiveDate>,
+    pub number_of_packs: u32,
+}
+
+#[derive(SimpleObject)]
+pub struct InsertSupplierInvoiceLineErrors {
+    pub id: String,
+    pub errors: Vec<InsertSupplierInvoiceLineError>,
+}
+
+#[derive(SimpleObject)]
+pub struct UpdateSupplierInvoiceLineErrors {
+    pub id: String,
+    pub errors: Vec<UpdateSupplierInvoiceLineError>,
+}
+
+#[derive(Interface)]
+#[graphql(field(name = "description", type = "&str"))]
+pub enum InsertSupplierInvoiceLineError {
+    RecordAlreadyExist(RecordAlreadyExist),
+    ValueOutOfRange(ValueOutOfRange),
+    ForeignKeyError(ForeignKeyError),
+    DBError(DBError),
+}
+
+#[derive(Interface)]
+#[graphql(field(name = "description", type = "&str"))]
+pub enum UpdateSupplierInvoiceLineError {
+    DBError(DBError),
+}
+
+type SingleApiError = InsertSupplierInvoiceLineError;
+type ApiLineError = InsertSupplierInvoiceLineErrors;
+
+impl From<BusinessLineError> for ApiLineError {
+    fn from(error: BusinessLineError) -> Self {
+        ApiLineError {
+            id: error.id,
+            errors: error.errors.into_iter().map(SingleApiError::from).collect(),
+        }
+    }
+}
+
+impl From<BusinessSingleError> for SingleApiError {
+    fn from(error: BusinessSingleError) -> Self {
+        match error {
+            BusinessSingleError::PackSizeMustBeAboveOne(pack_size) => {
+                SingleApiError::ValueOutOfRange(ValueOutOfRange {
+                    field: RangeFields::PackSize,
+                    description: format!("Pack size must be at least one, got {}", pack_size),
+                })
+            }
+            BusinessSingleError::SellPricePerPackMustBePositive(price) => {
+                SingleApiError::ValueOutOfRange(ValueOutOfRange {
+                    field: RangeFields::SellPricePerPack,
+                    description: format!("Sell price must be above zero, got {}", price),
+                })
+            }
+            BusinessSingleError::CostPricePerPackMustBePositive(price) => {
+                SingleApiError::ValueOutOfRange(ValueOutOfRange {
+                    field: RangeFields::CostPricePerPack,
+                    description: format!("Cost price must be above zero, got {}", price),
+                })
+            }
+            BusinessSingleError::InvoiceLineAlreadyExists => {
+                SingleApiError::RecordAlreadyExist(RecordAlreadyExist {})
+            }
+            BusinessSingleError::ItemIdNotFound(item_id) => {
+                SingleApiError::ForeignKeyError(ForeignKeyError {
+                    key: ForeignKeys::ItemId,
+                    id: item_id,
+                })
+            }
+        }
+    }
+}

--- a/src/server/service/graphql/schema/mutations/supplier_invoice/mod.rs
+++ b/src/server/service/graphql/schema/mutations/supplier_invoice/mod.rs
@@ -9,6 +9,11 @@ pub use self::insert::*;
 pub mod update;
 pub use self::update::*;
 
+pub mod lines;
+pub use self::lines::*;
+
+pub type OptVec<T> = Option<Vec<T>>;
+
 #[derive(InputObject)]
 pub struct InsertSupplierInvoiceInput {
     pub id: String,
@@ -16,7 +21,7 @@ pub struct InsertSupplierInvoiceInput {
     pub status: InvoiceStatus,
     pub comment: Option<String>,
     pub their_reference: Option<String>,
-    // lines
+    pub lines: OptVec<InsertSupplierInvoiceLineInput>,
 }
 
 #[derive(InputObject)]
@@ -30,36 +35,21 @@ pub struct UpdateSupplierInvoiceInput {
 }
 
 #[derive(SimpleObject)]
-#[graphql(concrete(
-    name = "InsertSupplierInvoiceErrors",
-    params(InsertSupplierInvoiceError)
-))]
-#[graphql(concrete(
-    name = "UpdateSupplierInvoiceErrors",
-    params(UpdateSupplierInvoiceError)
-))]
-pub struct MutationErrorsWrapper<ErrorType: OutputType> {
-    id: String,
-    errors: Vec<ErrorType>,
+pub struct InsertSupplierInvoiceErrors {
+    pub id: String,
+    pub errors: OptVec<InsertSupplierInvoiceError>,
+    pub lines: OptVec<InsertSupplierInvoiceLineErrors>,
 }
 
-pub trait MutationErrorsWrapperNew<MutationErrorsWrapperType, ErrorType: OutputType> {
-    fn new(id: String, error: ErrorType) -> MutationErrorsWrapperType;
-}
-
-impl<ErrorType: OutputType> MutationErrorsWrapperNew<MutationErrorsWrapper<ErrorType>, ErrorType>
-    for MutationErrorsWrapper<ErrorType>
-{
-    fn new(id: String, error: ErrorType) -> MutationErrorsWrapper<ErrorType> {
-        MutationErrorsWrapper {
-            id,
-            errors: vec![error],
-        }
-    }
+#[derive(SimpleObject)]
+pub struct UpdateSupplierInvoiceErrors {
+    pub id: String,
+    pub errors: OptVec<UpdateSupplierInvoiceError>,
+    pub lines: OptVec<UpdateSupplierInvoiceLineErrors>,
 }
 
 #[derive(Interface)]
-#[graphql(field(name = "description", type = "String"))]
+#[graphql(field(name = "description", type = "&str"))]
 pub enum InsertSupplierInvoiceError {
     ForeignKeyError(ForeignKeyError),
     RecordAlreadyExist(RecordAlreadyExist),
@@ -68,7 +58,7 @@ pub enum InsertSupplierInvoiceError {
 }
 
 #[derive(Interface)]
-#[graphql(field(name = "description", type = "String"))]
+#[graphql(field(name = "description", type = "&str"))]
 pub enum UpdateSupplierInvoiceError {
     ForeignKeyError(ForeignKeyError),
     RecordDoesNotExist(RecordDoesNotExist),
@@ -77,6 +67,21 @@ pub enum UpdateSupplierInvoiceError {
     CannotEditFinalisedInvoice(CannotEditFinalisedInvoice),
     InvoiceDoesNotBelongToCurrentStore(InvoiceDoesNotBelongToCurrentStore),
     CannotChangeInvoiceBackToDraft(CannotChangeInvoiceBackToDraft),
+    DBError(DBError),
+}
+
+#[derive(Interface)]
+#[graphql(field(name = "description", type = "&str"))]
+pub enum InsertSupplierInvoiceLineError {
+    ForeignKeyError(ForeignKeyError),
+    RecordAlreadyExist(RecordAlreadyExist),
+    OtherPartyNotASuppier(OtherPartyNotASuppier),
+    DBError(DBError),
+}
+
+#[derive(Interface)]
+#[graphql(field(name = "description", type = "&str"))]
+pub enum UpdateSupplierInvoiceLineError {
     DBError(DBError),
 }
 

--- a/src/server/service/graphql/schema/types/stock_line.rs
+++ b/src/server/service/graphql/schema/types/stock_line.rs
@@ -1,4 +1,5 @@
 use async_graphql::{Context, Object, SimpleObject};
+use chrono::NaiveDate;
 use std::convert::TryInto;
 
 use crate::database::schema::StockLineRow;
@@ -15,7 +16,7 @@ pub struct StockLineQuery {
     pub sell_price_per_pack: f64,
     pub available_number_of_packs: i32,
     pub total_number_of_packs: i32,
-    pub expiry_date: Option<String>,
+    pub expiry_date: Option<NaiveDate>,
 }
 
 impl From<StockLineRow> for StockLineQuery {


### PR DESCRIPTION
Fixes: #371 

Expands on downstream branches, main difference is errors in invoice lines are an array and are nested in 'lines' key of InsertSupplierInvoiceError. Also simplified full invoice shape (which will change again in next PR, as we would need to do delete and or insert and or update of invoice lines in one transaction). I tried to make errors a bit more generic in graphql, which ended up really hard to follow (it's already getting a bit complex), so ended up not committing those changes.

Also NaiveDate seems to work very good (i think we should use inbuilt async graphql functionality for this), had to enable chrono feature.

### Testing

* After full test with postgres, point base.yaml to `omsupply-database-gql-invoices-query`
* Run with postgres features (remove sync in main)
* Add at least on name_store_join with name_is_supplier `insert into name_store_join (id, name_is_supplier, name_is_customer, store_id, name_id) values('a', true, false, 'store_a', 'name_store_a')`

Use query below (try changing things for errors to show up, check `InsertSupplierInvoiceLineError` in graphql introspection or code)

```graphql
mutation mutInsert {
  insertSupplierInvoice(
    input: { id: "ABCD", otherPartyId: "name_store_a", status: "CONFIRMED", lines: [{
      id: "ABC2",
      itemId: "item_b",
      packSize: 1,
      costPricePerPack: 2,
      sellPricePerPack: 3,
      expiryDate: "2012-11-12",
      numberOfPacks: 10
      
    },{
      id: "B3",
      itemId: "item_a",
      packSize: 1,
      costPricePerPack: 2,
      sellPricePerPack: 3,
      expiryDate: "2012-11-12",
      numberOfPacks: 3
      
    }] }
  ) {
    ... on Invoice {
      id
    }

    ... on InsertSupplierInvoiceErrors {
      id
      errors {
        ... on InsertSupplierInvoiceError {
          __typename
          description
        }
        ... on ForeignKeyError {
          __typename
          key
          id
        }
        ... on OtherPartyNotASuppier {
          __typename
          otherParty {
            id
            name
            isSupplier
            isCustomer
          }
        }
        ... on Dberror {
          fullError
        }
      }
      lines {
        ... on InsertSupplierInvoiceLineErrors {
           __typename
          id
          errors {
            ... on InsertSupplierInvoiceError {
              __typename
              description
            }
            ... on ValueOutOfRange {
              field
            }
            ... on ForeignKeyError {
              key
              id
            }
            ... on RecordAlreadyExist  {
              description
            }
          }
        }
      }
    }
  }
}
```
 
