### PR TITLE
374 Granular mutations on for full invoice shape

### DIFF
--- a/src/business/supplier_invoice/mod.rs
+++ b/src/business/supplier_invoice/mod.rs
@@ -35,6 +35,70 @@ pub struct FullInvoiceLine {
     pub batch: Option<StockLineRow>,
 }
 
+pub struct Mutations<T> {
+    pub inserts: Option<Vec<T>>,
+    pub updates: Option<Vec<T>>,
+    pub deletes: Option<Vec<T>>,
+}
+
+impl<T> Mutations<T> {
+    fn new() -> Mutations<T> {
+        Mutations {
+            inserts: None,
+            updates: None,
+            deletes: None,
+        }
+    }
+    fn new_inserts(value: T) -> Mutations<T> {
+        Mutations {
+            inserts: Some(vec![value]),
+            updates: None,
+            deletes: None,
+        }
+    }
+    fn new_updates(value: T) -> Mutations<T> {
+        Mutations {
+            inserts: None,
+            updates: Some(vec![value]),
+            deletes: None,
+        }
+    }
+    fn new_deletes(value: T) -> Mutations<T> {
+        Mutations {
+            inserts: None,
+            updates: None,
+            deletes: Some(vec![value]),
+        }
+    }
+    fn add_insert(&mut self, value: T) -> &Self {
+        add_to_mutations(&mut self.inserts, value);
+        self
+    }
+
+    fn add_update(&mut self, value: T) -> &Self {
+        add_to_mutations(&mut self.updates, value);
+        self
+    }
+
+    fn add_delete(&mut self, value: T) -> &Self {
+        add_to_mutations(&mut self.deletes, value);
+        self
+    }
+}
+
+fn add_to_mutations<T>(mutations: &mut Option<Vec<T>>, value: T) {
+    match mutations {
+        Some(mutations) => mutations.push(value),
+        None => *mutations = Some(vec![value]),
+    };
+}
+
+pub struct FullInvoiceMutation {
+    pub invoice: Mutations<InvoiceRow>,
+    pub lines: Mutations<InvoiceLineRow>,
+    pub batches: Mutations<StockLineRow>,
+}
+
 pub enum InsertSupplierInvoiceError {
     OtherPartyNotFound(String),
     OtherPartyIsNotASupplier(NameQuery),

--- a/src/business/supplier_invoice/update.rs
+++ b/src/business/supplier_invoice/update.rs
@@ -14,8 +14,8 @@ use crate::{
 };
 
 use super::{
-    check_invoice_update, current_date_time, current_store_id, get_invoice, FullInvoice,
-    UpdateSupplierInvoiceError,
+    check_invoice_update, current_date_time, current_store_id, get_invoice, FullInvoiceMutation,
+    Mutations, UpdateSupplierInvoiceError,
 };
 
 impl From<RepositoryError> for UpdateSupplierInvoiceError {
@@ -65,12 +65,13 @@ pub async fn update_supplier_invoice(
         previous_invoice_row.status = status;
     }
 
-    let invoice = FullInvoice {
-        invoice: previous_invoice_row,
-        lines: Vec::new(),
+    let invoice = FullInvoiceMutation {
+        invoice: Mutations::new_updates(previous_invoice_row),
+        lines: Mutations::new(),
+        batches: Mutations::new(),
     };
 
-    full_invoice_repository.update(invoice).await?;
+    full_invoice_repository.mutate(invoice).await?;
 
     Ok(())
 }

--- a/src/database/schema/invoice_line.rs
+++ b/src/database/schema/invoice_line.rs
@@ -3,7 +3,7 @@ use chrono::NaiveDate;
 use super::diesel_schema::invoice_line;
 use super::diesel_schema::invoice_line_stats;
 
-#[derive(Clone, Queryable, Insertable, Debug, PartialEq)]
+#[derive(Clone, Queryable, AsChangeset, Identifiable, Insertable, Debug, PartialEq)]
 #[table_name = "invoice_line"]
 pub struct InvoiceLineRow {
     pub id: String,

--- a/src/database/schema/stock_line.rs
+++ b/src/database/schema/stock_line.rs
@@ -2,7 +2,7 @@ use chrono::NaiveDate;
 
 use super::diesel_schema::stock_line;
 
-#[derive(Clone, Queryable, Insertable, Debug, PartialEq)]
+#[derive(Clone, Queryable, AsChangeset, Identifiable, Insertable, Debug, PartialEq)]
 #[table_name = "stock_line"]
 pub struct StockLineRow {
     pub id: String,


### PR DESCRIPTION
Fixes: #374 

At first I thought we can use existing FullInvoiceShape, but then realised it would be to difficult and mess with 'read' part of invoice too much. So decided to go with different approach, which i kind of like, and i think we can make it a standard for mutations across all repos, i.e just one method 'mutate' in repo which accepts Mutations<Type>.

