### PR TITLE
#385 add sync feature

### DIFF
--- a/src/server/service/rest/mod.rs
+++ b/src/server/service/rest/mod.rs
@@ -1,7 +1,7 @@
 use crate::server::data::ActorRegistry;
 
 use actix_web::{
-    web::{get, scope, Data, ServiceConfig},
+    web::{get, post, scope, Data, ServiceConfig},
     HttpRequest, HttpResponse, Result,
 };
 
@@ -9,7 +9,7 @@ pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(
         scope("/")
             .route("/health_check", get().to(health_check))
-            .route("/schedule_sync", get().to(schedule_sync)),
+            .route("/sync", post().to(sync)),
     );
 }
 
@@ -17,9 +17,8 @@ async fn health_check(_req: HttpRequest) -> Result<HttpResponse> {
     Ok(HttpResponse::Ok().finish())
 }
 
-async fn schedule_sync(actor_registry: Data<ActorRegistry>) -> Result<HttpResponse> {
+async fn sync(actor_registry: Data<ActorRegistry>) -> Result<HttpResponse> {
     let sync_sender = &actor_registry.sync_sender;
     sync_sender.lock().unwrap().send();
-
     Ok(HttpResponse::Ok().body(""))
 }


### PR DESCRIPTION
Closes #385.

Initial idea was to put sync functionality behind a feature flag or add some sort of run-time logic to disable/enable sync. On reflection, the tidiest way to do this for now is to remove scheduling from `main.rs` and expose sync as a RESTful operation. 

Sync now will not be scheduled on start up, but can be triggered manually by POSTing to `/sync`. The scheduling logic is gone, but can always be retrieved from the git history (I think this is a nicer approach than leaving commented out code around the place).