### PR TITLE
307 invoices filter sort

### DIFF
--- a/src/database/repository/diesel/invoice_query.rs
+++ b/src/database/repository/diesel/invoice_query.rs
@@ -1,3 +1,7 @@
+use super::{
+    get_connection, DBBackendConnection, DatetimeFilter, EqualFilter, SimpleStringFilter, Sort,
+};
+
 use crate::{
     database::{
         repository::RepositoryError,
@@ -5,18 +9,38 @@ use crate::{
             diesel_schema::{
                 invoice::dsl as invoice_dsl, name_table::dsl as name_dsl, store::dsl as store_dsl,
             },
-            InvoiceRow, NameRow, StoreRow,
+            InvoiceRow, InvoiceRowStatus, InvoiceRowType, NameRow, StoreRow,
         },
     },
     server::service::graphql::schema::queries::pagination::{Pagination, PaginationOption},
 };
 
-use super::{get_connection, DBBackendConnection};
-
 use diesel::{
     prelude::*,
     r2d2::{ConnectionManager, Pool},
 };
+
+pub struct InvoiceFilter {
+    pub name_id: Option<EqualFilter<String>>,
+    pub store_id: Option<EqualFilter<String>>,
+    pub r#type: Option<EqualFilter<InvoiceRowType>>,
+    pub status: Option<EqualFilter<InvoiceRowStatus>>,
+    pub comment: Option<SimpleStringFilter>,
+    pub their_reference: Option<EqualFilter<String>>,
+    pub entry_datetime: Option<DatetimeFilter>,
+    pub confirm_datetime: Option<DatetimeFilter>,
+    pub finalised_datetime: Option<DatetimeFilter>,
+}
+
+pub enum InvoiceSortField {
+    Type,
+    Status,
+    EntryDatetime,
+    ConfirmDatetime,
+    FinalisedDateTime,
+}
+
+pub type InvoiceSort = Sort<InvoiceSortField>;
 
 pub struct InvoiceQueryRepository {
     pool: Pool<ConnectionManager<DBBackendConnection>>,
@@ -38,16 +62,123 @@ impl InvoiceQueryRepository {
     pub fn all(
         &self,
         pagination: &Option<Pagination>,
+        filter: &Option<InvoiceFilter>,
+        sort: &Option<InvoiceSort>,
     ) -> Result<Vec<InvoiceQueryJoin>, RepositoryError> {
         let connection = get_connection(&self.pool)?;
 
-        Ok(invoice_dsl::invoice
+        let mut query = invoice_dsl::invoice
             .inner_join(name_dsl::name_table)
             .inner_join(store_dsl::store)
-            .order(invoice_dsl::id.asc())
             .offset(pagination.offset())
             .limit(pagination.first())
-            .load::<InvoiceQueryJoin>(&*connection)?)
+            .into_boxed();
+
+        if let Some(f) = filter {
+            if let Some(value) = &f.name_id {
+                if let Some(eq) = &value.equal_to {
+                    query = query.filter(invoice_dsl::name_id.eq(eq));
+                }
+            }
+            if let Some(value) = &f.store_id {
+                if let Some(eq) = &value.equal_to {
+                    query = query.filter(invoice_dsl::store_id.eq(eq));
+                }
+            }
+            if let Some(value) = &f.r#type {
+                if let Some(eq) = &value.equal_to {
+                    query = query.filter(invoice_dsl::type_.eq(eq));
+                }
+            }
+            if let Some(value) = &f.status {
+                if let Some(eq) = &value.equal_to {
+                    query = query.filter(invoice_dsl::status.eq(eq));
+                }
+            }
+            if let Some(value) = &f.comment {
+                if let Some(eq) = &value.equal_to {
+                    query = query.filter(invoice_dsl::comment.eq(eq));
+                } else if let Some(like) = &value.like {
+                    query = query.filter(invoice_dsl::comment.like(like));
+                }
+            }
+            if let Some(value) = &f.their_reference {
+                if let Some(eq) = &value.equal_to {
+                    query = query.filter(invoice_dsl::their_reference.eq(eq));
+                }
+            }
+            if let Some(value) = &f.entry_datetime {
+                if let Some(eq) = &value.equal_to {
+                    query = query.filter(invoice_dsl::entry_datetime.eq(eq));
+                } else if let Some(before_or_equal) = &value.before_or_equal_to {
+                    query = query.filter(invoice_dsl::entry_datetime.le(before_or_equal));
+                } else if let Some(after_or_equal) = &value.after_or_equal_to {
+                    query = query.filter(invoice_dsl::entry_datetime.ge(after_or_equal));
+                }
+            }
+            if let Some(value) = &f.confirm_datetime {
+                if let Some(eq) = &value.equal_to {
+                    query = query.filter(invoice_dsl::confirm_datetime.eq(eq));
+                } else if let Some(before_or_equal) = &value.before_or_equal_to {
+                    query = query.filter(invoice_dsl::confirm_datetime.le(before_or_equal));
+                } else if let Some(after_or_equal) = &value.after_or_equal_to {
+                    query = query.filter(invoice_dsl::confirm_datetime.ge(after_or_equal));
+                }
+            }
+            if let Some(value) = &f.finalised_datetime {
+                if let Some(eq) = &value.equal_to {
+                    query = query.filter(invoice_dsl::finalised_datetime.eq(eq));
+                } else if let Some(before_or_equal) = &value.before_or_equal_to {
+                    query = query.filter(invoice_dsl::finalised_datetime.le(before_or_equal));
+                } else if let Some(after_or_equal) = &value.after_or_equal_to {
+                    query = query.filter(invoice_dsl::finalised_datetime.ge(after_or_equal));
+                }
+            }
+        }
+
+        if let Some(sort) = sort {
+            match sort.key {
+                InvoiceSortField::Type => {
+                    if sort.desc.unwrap_or(false) {
+                        query = query.order(invoice_dsl::type_.desc());
+                    } else {
+                        query = query.order(invoice_dsl::type_.asc());
+                    }
+                }
+                InvoiceSortField::Status => {
+                    if sort.desc.unwrap_or(false) {
+                        query = query.order(invoice_dsl::status.desc());
+                    } else {
+                        query = query.order(invoice_dsl::status.asc());
+                    }
+                }
+                InvoiceSortField::EntryDatetime => {
+                    if sort.desc.unwrap_or(false) {
+                        query = query.order(invoice_dsl::entry_datetime.desc());
+                    } else {
+                        query = query.order(invoice_dsl::entry_datetime.asc());
+                    }
+                }
+                InvoiceSortField::ConfirmDatetime => {
+                    if sort.desc.unwrap_or(false) {
+                        query = query.order(invoice_dsl::confirm_datetime.desc());
+                    } else {
+                        query = query.order(invoice_dsl::confirm_datetime.asc());
+                    }
+                }
+                InvoiceSortField::FinalisedDateTime => {
+                    if sort.desc.unwrap_or(false) {
+                        query = query.order(invoice_dsl::finalised_datetime.desc());
+                    } else {
+                        query = query.order(invoice_dsl::finalised_datetime.asc());
+                    }
+                }
+            }
+        } else {
+            query = query.order(invoice_dsl::id.asc())
+        }
+
+        Ok(query.load::<InvoiceQueryJoin>(&*connection)?)
     }
 
     pub async fn find_one_by_id(&self, row_id: &str) -> Result<InvoiceQueryJoin, RepositoryError> {

--- a/src/database/repository/diesel/invoice_query.rs
+++ b/src/database/repository/diesel/invoice_query.rs
@@ -110,27 +110,33 @@ impl InvoiceQueryRepository {
             if let Some(value) = &f.entry_datetime {
                 if let Some(eq) = &value.equal_to {
                     query = query.filter(invoice_dsl::entry_datetime.eq(eq));
-                } else if let Some(before_or_equal) = &value.before_or_equal_to {
+                }
+                if let Some(before_or_equal) = &value.before_or_equal_to {
                     query = query.filter(invoice_dsl::entry_datetime.le(before_or_equal));
-                } else if let Some(after_or_equal) = &value.after_or_equal_to {
+                }
+                if let Some(after_or_equal) = &value.after_or_equal_to {
                     query = query.filter(invoice_dsl::entry_datetime.ge(after_or_equal));
                 }
             }
             if let Some(value) = &f.confirm_datetime {
                 if let Some(eq) = &value.equal_to {
                     query = query.filter(invoice_dsl::confirm_datetime.eq(eq));
-                } else if let Some(before_or_equal) = &value.before_or_equal_to {
+                }
+                if let Some(before_or_equal) = &value.before_or_equal_to {
                     query = query.filter(invoice_dsl::confirm_datetime.le(before_or_equal));
-                } else if let Some(after_or_equal) = &value.after_or_equal_to {
+                }
+                if let Some(after_or_equal) = &value.after_or_equal_to {
                     query = query.filter(invoice_dsl::confirm_datetime.ge(after_or_equal));
                 }
             }
             if let Some(value) = &f.finalised_datetime {
                 if let Some(eq) = &value.equal_to {
                     query = query.filter(invoice_dsl::finalised_datetime.eq(eq));
-                } else if let Some(before_or_equal) = &value.before_or_equal_to {
+                }
+                if let Some(before_or_equal) = &value.before_or_equal_to {
                     query = query.filter(invoice_dsl::finalised_datetime.le(before_or_equal));
-                } else if let Some(after_or_equal) = &value.after_or_equal_to {
+                }
+                if let Some(after_or_equal) = &value.after_or_equal_to {
                     query = query.filter(invoice_dsl::finalised_datetime.ge(after_or_equal));
                 }
             }

--- a/src/database/repository/diesel/mod.rs
+++ b/src/database/repository/diesel/mod.rs
@@ -30,7 +30,9 @@ pub use central_sync_cursor::CentralSyncCursorRepository;
 pub use invoice::{CustomerInvoiceRepository, InvoiceRepository};
 pub use invoice_line::InvoiceLineRepository;
 pub use invoice_line_query::{InvoiceLineQueryJoin, InvoiceLineQueryRepository, InvoiceLineStats};
-pub use invoice_query::{InvoiceQueryJoin, InvoiceQueryRepository};
+pub use invoice_query::{
+    InvoiceFilter, InvoiceQueryJoin, InvoiceQueryRepository, InvoiceSort, InvoiceSortField,
+};
 pub use item::ItemRepository;
 pub use item_query::ItemQueryRepository;
 pub use master_list::MasterListRepository;

--- a/src/database/repository/diesel/mod.rs
+++ b/src/database/repository/diesel/mod.rs
@@ -37,9 +37,7 @@ pub use master_list::MasterListRepository;
 pub use master_list_line::MasterListLineRepository;
 pub use master_list_name_join::MasterListNameJoinRepository;
 pub use name::NameRepository;
-pub use name_query::{
-    NameQueryFilter, NameQueryRepository, NameQuerySort, NameQuerySortField, NameQueryStringFilter,
-};
+pub use name_query::{NameQueryFilter, NameQueryRepository, NameQuerySort, NameQuerySortField};
 pub use requisition::RequisitionRepository;
 pub use requisition_line::RequisitionLineRepository;
 pub use sort_filter_types::*;

--- a/src/database/repository/diesel/mod.rs
+++ b/src/database/repository/diesel/mod.rs
@@ -17,6 +17,7 @@ mod name;
 mod name_query;
 mod requisition;
 mod requisition_line;
+mod sort_filter_types;
 mod stock_line;
 mod store;
 mod sync;
@@ -41,6 +42,7 @@ pub use name_query::{
 };
 pub use requisition::RequisitionRepository;
 pub use requisition_line::RequisitionLineRepository;
+pub use sort_filter_types::*;
 pub use stock_line::StockLineRepository;
 pub use store::StoreRepository;
 pub use sync::{IntegrationRecord, IntegrationUpsertRecord, SyncRepository};

--- a/src/database/repository/diesel/name_query.rs
+++ b/src/database/repository/diesel/name_query.rs
@@ -1,4 +1,5 @@
-use super::{get_connection, DBBackendConnection};
+use super::{get_connection, DBBackendConnection, SimpleStringFilter, Sort};
+
 use crate::{
     database::{
         repository::RepositoryError,
@@ -42,22 +43,14 @@ impl From<NameAndNameStoreJoin> for NameQuery {
     }
 }
 
-pub struct NameQueryStringFilter {
-    pub equal_to: Option<String>,
-    pub like: Option<String>,
-}
-
 pub struct NameQueryFilter {
-    pub name: Option<NameQueryStringFilter>,
-    pub code: Option<NameQueryStringFilter>,
+    pub name: Option<SimpleStringFilter>,
+    pub code: Option<SimpleStringFilter>,
     pub is_customer: Option<bool>,
     pub is_supplier: Option<bool>,
 }
 
-pub struct NameQuerySort {
-    pub key: NameQuerySortField,
-    pub desc: Option<bool>,
-}
+pub type NameQuerySort = Sort<NameQuerySortField>;
 
 pub enum NameQuerySortField {
     Name,

--- a/src/database/repository/diesel/sort_filter_types.rs
+++ b/src/database/repository/diesel/sort_filter_types.rs
@@ -1,0 +1,25 @@
+use chrono::NaiveDateTime;
+
+/// Simple string filter for list queries
+pub struct SimpleStringFilter {
+    pub equal_to: Option<String>,
+    pub like: Option<String>,
+}
+
+/// Filter for list queries
+pub struct EqualFilter<T> {
+    pub equal_to: Option<T>,
+}
+
+/// Datetime filter for list queries
+pub struct DatetimeFilter {
+    pub equal_to: Option<NaiveDateTime>,
+    pub before_or_equal_to: Option<NaiveDateTime>,
+    pub after_or_equal_to: Option<NaiveDateTime>,
+}
+
+/// Generic sort option for list queries
+pub struct Sort<T> {
+    pub key: T,
+    pub desc: Option<bool>,
+}

--- a/src/database/repository/tests.rs
+++ b/src/database/repository/tests.rs
@@ -296,8 +296,8 @@ mod repository_test {
                 InvoiceLineQueryRepository, InvoiceLineRepository, InvoiceRepository,
                 ItemRepository, MasterListLineRepository, MasterListNameJoinRepository,
                 NameQueryFilter, NameQueryRepository, NameQuerySort, NameQuerySortField,
-                NameQueryStringFilter, NameRepository, RequisitionLineRepository,
-                RequisitionRepository, StockLineRepository, StoreRepository, UserAccountRepository,
+                NameRepository, RequisitionLineRepository, RequisitionRepository,
+                SimpleStringFilter, StockLineRepository, StoreRepository, UserAccountRepository,
             },
             schema::{
                 CentralSyncBufferRow, InvoiceLineRow, InvoiceRow, InvoiceRowType, ItemRow,
@@ -340,7 +340,7 @@ mod repository_test {
             .all(
                 &None,
                 &Some(NameQueryFilter {
-                    name: Some(NameQueryStringFilter {
+                    name: Some(SimpleStringFilter {
                         equal_to: Some("name_1".to_string()),
                         like: None,
                     }),
@@ -358,7 +358,7 @@ mod repository_test {
             .all(
                 &None,
                 &Some(NameQueryFilter {
-                    name: Some(NameQueryStringFilter {
+                    name: Some(SimpleStringFilter {
                         equal_to: None,
                         like: Some("me_".to_string()),
                     }),
@@ -376,7 +376,7 @@ mod repository_test {
                 &None,
                 &Some(NameQueryFilter {
                     name: None,
-                    code: Some(NameQueryStringFilter {
+                    code: Some(SimpleStringFilter {
                         equal_to: Some("code1".to_string()),
                         like: None,
                     }),

--- a/src/server/service/graphql/schema/queries/mod.rs
+++ b/src/server/service/graphql/schema/queries/mod.rs
@@ -8,7 +8,10 @@ use crate::database::schema::{InvoiceLineRow, RequisitionRow, StoreRow};
 use crate::server::service::graphql::schema::types::{InvoiceLine, Requisition, Store};
 use crate::server::service::graphql::ContextExt;
 
-use super::types::{InvoiceList, InvoiceNode, ItemList, NameFilterInput, NameList, NameSortInput};
+use super::types::{
+    InvoiceFilterInput, InvoiceList, InvoiceNode, InvoiceSortInput, ItemList, NameFilterInput,
+    NameList, NameSortInput,
+};
 use async_graphql::{Context, Object};
 use pagination::Pagination;
 pub struct Queries;
@@ -25,7 +28,8 @@ impl Queries {
         _ctx: &Context<'_>,
         #[graphql(desc = "pagination (first and offset)")] page: Option<Pagination>,
         #[graphql(desc = "filters option")] filter: Option<NameFilterInput>,
-        #[graphql(desc = "sort options")] sort: Option<Vec<NameSortInput>>,
+        #[graphql(desc = "sort options (only first sort input is evaluated for this endpoint)")]
+        sort: Option<Vec<NameSortInput>>,
     ) -> NameList {
         NameList {
             pagination: page,
@@ -57,8 +61,15 @@ impl Queries {
         &self,
         _ctx: &Context<'_>,
         #[graphql(desc = "pagination (first and offset)")] page: Option<Pagination>,
+        #[graphql(desc = "filters option")] filter: Option<InvoiceFilterInput>,
+        #[graphql(desc = "sort options (only first sort input is evaluated for this endpoint)")]
+        sort: Option<Vec<InvoiceSortInput>>,
     ) -> InvoiceList {
-        InvoiceList { pagination: page }
+        InvoiceList {
+            pagination: page,
+            filter,
+            sort,
+        }
     }
 
     pub async fn store(

--- a/src/server/service/graphql/schema/queries/mod.rs
+++ b/src/server/service/graphql/schema/queries/mod.rs
@@ -8,7 +8,7 @@ use crate::database::schema::{InvoiceLineRow, RequisitionRow, StoreRow};
 use crate::server::service::graphql::schema::types::{InvoiceLine, Requisition, Store};
 use crate::server::service::graphql::ContextExt;
 
-use super::types::{InvoiceList, InvoiceNode, ItemList, NameFilter, NameList, NameSortInput};
+use super::types::{InvoiceList, InvoiceNode, ItemList, NameFilterInput, NameList, NameSortInput};
 use async_graphql::{Context, Object};
 use pagination::Pagination;
 pub struct Queries;
@@ -24,7 +24,7 @@ impl Queries {
         &self,
         _ctx: &Context<'_>,
         #[graphql(desc = "pagination (first and offset)")] page: Option<Pagination>,
-        #[graphql(desc = "filters option")] filter: Option<NameFilter>,
+        #[graphql(desc = "filters option")] filter: Option<NameFilterInput>,
         #[graphql(desc = "sort options")] sort: Option<Vec<NameSortInput>>,
     ) -> NameList {
         NameList {

--- a/src/server/service/graphql/schema/types/invoice_query.rs
+++ b/src/server/service/graphql/schema/types/invoice_query.rs
@@ -2,7 +2,6 @@ use crate::{
     database::{
         loader::{InvoiceLineQueryLoader, InvoiceLineStatsLoader},
         repository::{InvoiceLineQueryJoin, InvoiceLineStats, InvoiceQueryJoin},
-        schema::{InvoiceRowStatus, InvoiceRowType},
     },
     server::service::graphql::ContextExt,
 };
@@ -11,35 +10,18 @@ use async_graphql::{dataloader::DataLoader, ComplexObject, Context, Enum, Object
 use chrono::{DateTime, NaiveDate, Utc};
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq, Debug)]
-pub enum InvoiceType {
+#[graphql(remote = "crate::database::schema::InvoiceRowType")]
+pub enum InvoiceTypeInput {
     CustomerInvoice,
     SupplierInvoice,
 }
 
-impl From<InvoiceRowType> for InvoiceType {
-    fn from(row: InvoiceRowType) -> InvoiceType {
-        match row {
-            InvoiceRowType::CustomerInvoice => InvoiceType::CustomerInvoice,
-            InvoiceRowType::SupplierInvoice => InvoiceType::SupplierInvoice,
-        }
-    }
-}
-
 #[derive(Enum, Copy, Clone, PartialEq, Eq, Debug)]
-pub enum InvoiceStatus {
+#[graphql(remote = "crate::database::schema::InvoiceRowStatus")]
+pub enum InvoiceStatusInput {
     Draft,
     Confirmed,
     Finalised,
-}
-
-impl From<InvoiceRowStatus> for InvoiceStatus {
-    fn from(row: InvoiceRowStatus) -> InvoiceStatus {
-        match row {
-            InvoiceRowStatus::Draft => InvoiceStatus::Draft,
-            InvoiceRowStatus::Confirmed => InvoiceStatus::Confirmed,
-            InvoiceRowStatus::Finalised => InvoiceStatus::Finalised,
-        }
-    }
 }
 
 #[derive(SimpleObject, PartialEq, Debug)]
@@ -54,8 +36,8 @@ pub struct InvoiceNode {
     id: String,
     other_party_name: String,
     other_party_id: String,
-    status: InvoiceStatus,
-    invoice_type: InvoiceType,
+    status: InvoiceStatusInput,
+    invoice_type: InvoiceTypeInput,
     invoice_number: i32,
     their_reference: Option<String>,
     comment: Option<String>,
@@ -95,8 +77,8 @@ impl From<InvoiceQueryJoin> for InvoiceNode {
             id: invoice_row.id.to_owned(),
             other_party_name: name_row.name,
             other_party_id: name_row.id,
-            status: InvoiceStatus::from(invoice_row.status),
-            invoice_type: InvoiceType::from(invoice_row.r#type),
+            status: InvoiceStatusInput::from(invoice_row.status),
+            invoice_type: InvoiceTypeInput::from(invoice_row.r#type),
             invoice_number: invoice_row.invoice_number,
             their_reference: invoice_row.their_reference,
             comment: invoice_row.comment,

--- a/src/server/service/graphql/schema/types/invoices_query.rs
+++ b/src/server/service/graphql/schema/types/invoices_query.rs
@@ -22,7 +22,7 @@ impl InvoiceList {
         let repository = ctx.get_repository::<InvoiceQueryRepository>();
 
         repository
-            .all(&self.pagination)
+            .all(&self.pagination, &None, &None)
             .map_or(Vec::<InvoiceNode>::new(), |list| {
                 list.into_iter().map(InvoiceNode::from).collect()
             })

--- a/src/server/service/graphql/schema/types/invoices_query.rs
+++ b/src/server/service/graphql/schema/types/invoices_query.rs
@@ -75,7 +75,7 @@ impl InvoiceList {
         let first_sort = self
             .sort
             .as_ref()
-            .map(|sort_list| sort_list.get(0))
+            .map(|sort_list| sort_list.first())
             .flatten()
             .map(|opt| InvoiceSort {
                 key: InvoiceSortField::from(opt.key),

--- a/src/server/service/graphql/schema/types/invoices_query.rs
+++ b/src/server/service/graphql/schema/types/invoices_query.rs
@@ -1,14 +1,62 @@
-use super::InvoiceNode;
+use super::{
+    DatetimeFilterInput, EqualFilterInput, EqualFilterStringInput, InvoiceNode, InvoiceStatusInput,
+    InvoiceTypeInput, SimpleStringFilterInput, SortInput,
+};
 
 use crate::{
-    database::repository::InvoiceQueryRepository,
+    database::repository::{
+        DatetimeFilter, EqualFilter, InvoiceFilter, InvoiceQueryRepository, InvoiceSort,
+        InvoiceSortField, SimpleStringFilter,
+    },
     server::service::graphql::{schema::queries::pagination::Pagination, ContextExt},
 };
 
-use async_graphql::{Context, Object};
+use async_graphql::{Context, Enum, InputObject, Object};
+
+#[derive(Enum, Copy, Clone, PartialEq, Eq)]
+#[graphql(remote = "crate::database::repository::repository::InvoiceSortField")]
+pub enum InvoiceSortFieldInput {
+    Type,
+    Status,
+    EntryDatetime,
+    ConfirmDatetime,
+    FinalisedDateTime,
+}
+pub type InvoiceSortInput = SortInput<InvoiceSortFieldInput>;
+#[derive(InputObject, Clone)]
+
+pub struct InvoiceFilterInput {
+    pub name_id: Option<EqualFilterStringInput>,
+    pub store_id: Option<EqualFilterStringInput>,
+    pub r#type: Option<EqualFilterInput<InvoiceTypeInput>>,
+    pub status: Option<EqualFilterInput<InvoiceStatusInput>>,
+    pub comment: Option<SimpleStringFilterInput>,
+    pub their_reference: Option<EqualFilterStringInput>,
+    pub entry_datetime: Option<DatetimeFilterInput>,
+    pub confirm_datetime: Option<DatetimeFilterInput>,
+    pub finalised_datetime: Option<DatetimeFilterInput>,
+}
+
+impl From<InvoiceFilterInput> for InvoiceFilter {
+    fn from(f: InvoiceFilterInput) -> Self {
+        InvoiceFilter {
+            name_id: f.name_id.map(EqualFilter::from),
+            store_id: f.store_id.map(EqualFilter::from),
+            r#type: f.r#type.map(EqualFilter::from),
+            status: f.status.map(EqualFilter::from),
+            comment: f.comment.map(SimpleStringFilter::from),
+            their_reference: f.their_reference.map(EqualFilter::from),
+            entry_datetime: f.entry_datetime.map(DatetimeFilter::from),
+            confirm_datetime: f.confirm_datetime.map(DatetimeFilter::from),
+            finalised_datetime: f.finalised_datetime.map(DatetimeFilter::from),
+        }
+    }
+}
 
 pub struct InvoiceList {
     pub pagination: Option<Pagination>,
+    pub filter: Option<InvoiceFilterInput>,
+    pub sort: Option<Vec<InvoiceSortInput>>,
 }
 
 #[Object]
@@ -21,8 +69,21 @@ impl InvoiceList {
     async fn nodes(&self, ctx: &Context<'_>) -> Vec<InvoiceNode> {
         let repository = ctx.get_repository::<InvoiceQueryRepository>();
 
+        let filter = self.filter.clone().map(InvoiceFilter::from);
+
+        // Currently only one sort option is supported, use the first from the list.
+        let first_sort = self
+            .sort
+            .as_ref()
+            .map(|sort_list| sort_list.get(0))
+            .flatten()
+            .map(|opt| InvoiceSort {
+                key: InvoiceSortField::from(opt.key),
+                desc: opt.desc,
+            });
+
         repository
-            .all(&self.pagination, &None, &None)
+            .all(&self.pagination, &filter, &first_sort)
             .map_or(Vec::<InvoiceNode>::new(), |list| {
                 list.into_iter().map(InvoiceNode::from).collect()
             })

--- a/src/server/service/graphql/schema/types/mod.rs
+++ b/src/server/service/graphql/schema/types/mod.rs
@@ -3,8 +3,8 @@ use crate::{
         loader::{InvoiceLoader, StoreLoader},
         repository::{CustomerInvoiceRepository, InvoiceLineRepository, RequisitionLineRepository},
         schema::{
-            InvoiceLineRow, InvoiceRow, InvoiceRowType, RequisitionLineRow, RequisitionRow,
-            RequisitionRowType, StoreRow,
+            InvoiceLineRow, InvoiceRow, RequisitionLineRow, RequisitionRow, RequisitionRowType,
+            StoreRow,
         },
     },
     server::service::graphql::ContextExt,
@@ -188,30 +188,6 @@ impl RequisitionLine {
     }
 }
 
-#[derive(Enum, Copy, Clone, PartialEq, Eq)]
-pub enum InvoiceType {
-    CustomerInvoice,
-    SupplierInvoice,
-}
-
-impl From<InvoiceRowType> for InvoiceType {
-    fn from(invoice_row_type: InvoiceRowType) -> InvoiceType {
-        match invoice_row_type {
-            InvoiceRowType::CustomerInvoice => InvoiceType::CustomerInvoice,
-            InvoiceRowType::SupplierInvoice => InvoiceType::SupplierInvoice,
-        }
-    }
-}
-
-impl From<InvoiceType> for InvoiceRowType {
-    fn from(invoice_type: InvoiceType) -> InvoiceRowType {
-        match invoice_type {
-            InvoiceType::CustomerInvoice => InvoiceRowType::CustomerInvoice,
-            InvoiceType::SupplierInvoice => InvoiceRowType::SupplierInvoice,
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct Invoice {
     pub invoice_row: InvoiceRow,
@@ -227,7 +203,7 @@ impl Invoice {
         self.invoice_row.invoice_number
     }
 
-    pub async fn r#type(&self) -> InvoiceType {
+    pub async fn r#type(&self) -> InvoiceTypeInput {
         self.invoice_row.r#type.clone().into()
     }
 

--- a/src/server/service/graphql/schema/types/mod.rs
+++ b/src/server/service/graphql/schema/types/mod.rs
@@ -29,6 +29,9 @@ pub use self::invoice_query::*;
 pub mod invoices_query;
 pub use self::invoices_query::*;
 
+pub mod sort_filter_types;
+pub use self::sort_filter_types::*;
+
 #[derive(Clone)]
 pub struct Store {
     pub store_row: StoreRow,

--- a/src/server/service/graphql/schema/types/name.rs
+++ b/src/server/service/graphql/schema/types/name.rs
@@ -67,7 +67,7 @@ impl NameList {
         let first_sort = self
             .sort
             .as_ref()
-            .map(|sort_list| sort_list.get(0))
+            .map(|sort_list| sort_list.first())
             .flatten()
             .map(|opt| NameQuerySort {
                 key: NameQuerySortField::from(opt.key),

--- a/src/server/service/graphql/schema/types/name.rs
+++ b/src/server/service/graphql/schema/types/name.rs
@@ -1,20 +1,37 @@
 use crate::database::repository::{
-    NameQueryFilter, NameQueryRepository, NameQuerySort, NameQuerySortField, NameQueryStringFilter,
+    NameQueryFilter, NameQueryRepository, NameQuerySort, NameQuerySortField, SimpleStringFilter,
 };
 use crate::server::service::graphql::{schema::queries::pagination::Pagination, ContextExt};
 use async_graphql::{Context, Enum, InputObject, Object, SimpleObject};
 
-#[derive(InputObject)]
-pub struct NameSortInput {
-    key: NameSortField,
-    desc: Option<bool>,
-}
+use super::{SimpleStringFilterInput, SortInput};
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
 #[graphql(remote = "crate::database::repository::repository::NameQuerySortField")]
-enum NameSortField {
+pub enum NameSortFieldInput {
     Name,
     Code,
+}
+pub type NameSortInput = SortInput<NameSortFieldInput>;
+
+#[derive(InputObject, Clone)]
+
+pub struct NameFilterInput {
+    pub name: Option<SimpleStringFilterInput>,
+    pub code: Option<SimpleStringFilterInput>,
+    pub is_customer: Option<bool>,
+    pub is_supplier: Option<bool>,
+}
+
+impl From<NameFilterInput> for NameQueryFilter {
+    fn from(f: NameFilterInput) -> Self {
+        NameQueryFilter {
+            name: f.name.map(SimpleStringFilter::from),
+            code: f.code.map(SimpleStringFilter::from),
+            is_customer: f.is_customer,
+            is_supplier: f.is_supplier,
+        }
+    }
 }
 
 #[derive(SimpleObject, PartialEq, Debug)]
@@ -30,43 +47,8 @@ pub struct NameQuery {
 
 pub struct NameList {
     pub pagination: Option<Pagination>,
-    pub filter: Option<NameFilter>,
+    pub filter: Option<NameFilterInput>,
     pub sort: Option<Vec<NameSortInput>>,
-}
-
-#[derive(InputObject, Clone)]
-pub struct NameStringFilter {
-    equal_to: Option<String>,
-    like: Option<String>,
-}
-
-impl From<NameStringFilter> for NameQueryStringFilter {
-    fn from(f: NameStringFilter) -> Self {
-        NameQueryStringFilter {
-            equal_to: f.equal_to,
-            like: f.like,
-        }
-    }
-}
-
-#[derive(InputObject, Clone)]
-
-pub struct NameFilter {
-    pub name: Option<NameStringFilter>,
-    pub code: Option<NameStringFilter>,
-    pub is_customer: Option<bool>,
-    pub is_supplier: Option<bool>,
-}
-
-impl From<NameFilter> for NameQueryFilter {
-    fn from(f: NameFilter) -> Self {
-        NameQueryFilter {
-            name: f.name.map(NameQueryStringFilter::from),
-            code: f.code.map(NameQueryStringFilter::from),
-            is_customer: f.is_customer,
-            is_supplier: f.is_supplier,
-        }
-    }
 }
 
 #[Object]

--- a/src/server/service/graphql/schema/types/sort_filter_types.rs
+++ b/src/server/service/graphql/schema/types/sort_filter_types.rs
@@ -1,0 +1,27 @@
+use super::NameSortFieldInput;
+
+use crate::database::repository::SimpleStringFilter;
+
+use async_graphql::{InputObject, InputType};
+
+#[derive(InputObject)]
+#[graphql(concrete(name = "NameSortInput", params(NameSortFieldInput)))]
+pub struct SortInput<T: InputType> {
+    pub key: T,
+    pub desc: Option<bool>,
+}
+
+#[derive(InputObject, Clone)]
+pub struct SimpleStringFilterInput {
+    equal_to: Option<String>,
+    like: Option<String>,
+}
+
+impl From<SimpleStringFilterInput> for SimpleStringFilter {
+    fn from(f: SimpleStringFilterInput) -> Self {
+        SimpleStringFilter {
+            equal_to: f.equal_to,
+            like: f.like,
+        }
+    }
+}

--- a/src/server/service/graphql/schema/types/sort_filter_types.rs
+++ b/src/server/service/graphql/schema/types/sort_filter_types.rs
@@ -1,15 +1,22 @@
-use super::NameSortFieldInput;
+use super::{InvoiceSortFieldInput, InvoiceStatusInput, InvoiceTypeInput, NameSortFieldInput};
 
-use crate::database::repository::SimpleStringFilter;
+use crate::database::{
+    repository::{DatetimeFilter, EqualFilter, SimpleStringFilter},
+    schema::{InvoiceRowStatus, InvoiceRowType},
+};
 
 use async_graphql::{InputObject, InputType};
+use chrono::NaiveDateTime;
 
 #[derive(InputObject)]
 #[graphql(concrete(name = "NameSortInput", params(NameSortFieldInput)))]
+#[graphql(concrete(name = "InvoiceSortInput", params(InvoiceSortFieldInput)))]
 pub struct SortInput<T: InputType> {
     pub key: T,
     pub desc: Option<bool>,
 }
+
+// simple string filter
 
 #[derive(InputObject, Clone)]
 pub struct SimpleStringFilterInput {
@@ -22,6 +29,65 @@ impl From<SimpleStringFilterInput> for SimpleStringFilter {
         SimpleStringFilter {
             equal_to: f.equal_to,
             like: f.like,
+        }
+    }
+}
+
+// string equal filter
+
+#[derive(InputObject, Clone)]
+pub struct EqualFilterStringInput {
+    equal_to: Option<String>,
+}
+
+impl From<EqualFilterStringInput> for EqualFilter<String> {
+    fn from(f: EqualFilterStringInput) -> Self {
+        EqualFilter {
+            equal_to: f.equal_to,
+        }
+    }
+}
+
+// generic equal filters
+
+#[derive(InputObject, Clone)]
+#[graphql(concrete(name = "EqualFilterInvoiceTypeInput", params(InvoiceTypeInput)))]
+#[graphql(concrete(name = "EqualFilterInvoiceStatusInput", params(InvoiceStatusInput)))]
+pub struct EqualFilterInput<T: InputType> {
+    equal_to: Option<T>,
+}
+
+impl From<EqualFilterInput<InvoiceTypeInput>> for EqualFilter<InvoiceRowType> {
+    fn from(f: EqualFilterInput<InvoiceTypeInput>) -> Self {
+        EqualFilter {
+            equal_to: f.equal_to.map(InvoiceRowType::from),
+        }
+    }
+}
+
+impl From<EqualFilterInput<InvoiceStatusInput>> for EqualFilter<InvoiceRowStatus> {
+    fn from(f: EqualFilterInput<InvoiceStatusInput>) -> Self {
+        EqualFilter {
+            equal_to: f.equal_to.map(InvoiceRowStatus::from),
+        }
+    }
+}
+
+// Datetime filter
+
+#[derive(InputObject, Clone)]
+pub struct DatetimeFilterInput {
+    pub equal_to: Option<NaiveDateTime>,
+    pub before_or_equal_to: Option<NaiveDateTime>,
+    pub after_or_equal_to: Option<NaiveDateTime>,
+}
+
+impl From<DatetimeFilterInput> for DatetimeFilter {
+    fn from(f: DatetimeFilterInput) -> Self {
+        DatetimeFilter {
+            equal_to: f.equal_to,
+            before_or_equal_to: f.before_or_equal_to,
+            after_or_equal_to: f.after_or_equal_to,
         }
     }
 }


### PR DESCRIPTION
Add filter and sort options for the invoices endpoint.

- Define common filter and sort types/struct that can be reused between endpoints (both on repository layer and graphql layer)
- Use common structs for the name endpoint
- Refactor repo to graph gql enum mapping for the invoices endpoint