### PR TITLE
404 align name query with design decisions

### DIFF
--- a/src/database/repository/diesel/mod.rs
+++ b/src/database/repository/diesel/mod.rs
@@ -38,7 +38,7 @@ pub use master_list::MasterListRepository;
 pub use master_list_line::MasterListLineRepository;
 pub use master_list_name_join::MasterListNameJoinRepository;
 pub use name::NameRepository;
-pub use name_query::{NameQueryFilter, NameQueryRepository, NameQuerySort, NameQuerySortField};
+pub use name_query::NameQueryRepository;
 pub use requisition::RequisitionRepository;
 pub use requisition_line::RequisitionLineRepository;
 pub use sort_filter_types::*;
@@ -58,6 +58,12 @@ pub type DBBackendConnection = SqliteConnection;
 
 #[cfg(not(feature = "sqlite"))]
 pub type DBBackendConnection = PgConnection;
+
+#[cfg(feature = "sqlite")]
+pub type DBType = diesel::sqlite::Sqlite;
+
+#[cfg(not(feature = "sqlite"))]
+pub type DBType = diesel::sqlite::Pg;
 
 pub type DBConnection = PooledConnection<ConnectionManager<DBBackendConnection>>;
 

--- a/src/database/repository/diesel/name_query.rs
+++ b/src/database/repository/diesel/name_query.rs
@@ -1,26 +1,29 @@
-use super::{SimpleStringFilter, Sort, StorageConnection};
-
+use super::{DBType, StorageConnection};
 use crate::{
     database::{
         repository::RepositoryError,
         schema::{
             diesel_schema::{
-                name_store_join::dsl as name_store_join_dsl, name_table::dsl as name_table_dsl,
+                name_store_join, name_store_join::dsl as name_store_join_dsl, name_table,
+                name_table::dsl as name_table_dsl,
             },
             NameRow, NameStoreJoinRow,
         },
     },
-    server::service::graphql::schema::{
-        queries::pagination::{Pagination, PaginationOption},
-        types::NameQuery,
+    domain::{
+        name::{Name, NameFilter, NameSort, NameSortField},
+        Pagination,
     },
 };
 
-use diesel::prelude::*;
+use diesel::{
+    dsl::{IntoBoxed, LeftJoin},
+    prelude::*,
+};
 
 type NameAndNameStoreJoin = (NameRow, Option<NameStoreJoinRow>);
 
-impl From<NameAndNameStoreJoin> for NameQuery {
+impl From<NameAndNameStoreJoin> for Name {
     fn from((name_row, name_store_join_row_option): NameAndNameStoreJoin) -> Self {
         let (is_customer, is_supplier) = match name_store_join_row_option {
             Some(name_store_join_row) => (
@@ -30,7 +33,7 @@ impl From<NameAndNameStoreJoin> for NameQuery {
             None => (false, false),
         };
 
-        NameQuery {
+        Name {
             id: name_row.id,
             name: name_row.name,
             code: name_row.code,
@@ -38,20 +41,6 @@ impl From<NameAndNameStoreJoin> for NameQuery {
             is_supplier,
         }
     }
-}
-
-pub struct NameQueryFilter {
-    pub name: Option<SimpleStringFilter>,
-    pub code: Option<SimpleStringFilter>,
-    pub is_customer: Option<bool>,
-    pub is_supplier: Option<bool>,
-}
-
-pub type NameQuerySort = Sort<NameQuerySortField>;
-
-pub enum NameQuerySortField {
-    Name,
-    Code,
 }
 
 pub struct NameQueryRepository<'a> {
@@ -63,59 +52,32 @@ impl<'a> NameQueryRepository<'a> {
         NameQueryRepository { connection }
     }
 
-    pub fn count(&self) -> Result<i64, RepositoryError> {
-        Ok(name_table_dsl::name_table
-            .count()
-            .get_result(&self.connection.connection)?)
+    pub fn count(&self, filter: Option<NameFilter>) -> Result<i64, RepositoryError> {
+        // TODO (beyond M1), check that store_id matches current store
+        let query = create_filtered_query(filter);
+
+        Ok(query.count().get_result(&self.connection.connection)?)
     }
 
-    pub fn all(
+    pub fn query(
         &self,
-        pagination: &Option<Pagination>,
-        filter: &Option<NameQueryFilter>,
-        sort: &Option<NameQuerySort>,
-    ) -> Result<Vec<NameQuery>, RepositoryError> {
+        pagination: Pagination,
+        filter: Option<NameFilter>,
+        sort: Option<NameSort>,
+    ) -> Result<Vec<Name>, RepositoryError> {
         // TODO (beyond M1), check that store_id matches current store
-
-        let mut query = name_table_dsl::name_table
-            .left_join(name_store_join_dsl::name_store_join)
-            .offset(pagination.offset())
-            .limit(pagination.first())
-            .into_boxed();
-
-        if let Some(f) = filter {
-            if let Some(code) = &f.code {
-                if let Some(eq) = &code.equal_to {
-                    query = query.filter(name_table_dsl::code.eq(eq));
-                } else if let Some(like) = &code.like {
-                    query = query.filter(name_table_dsl::code.like(format!("%{}%", like)));
-                }
-            }
-            if let Some(name) = &f.name {
-                if let Some(eq) = &name.equal_to {
-                    query = query.filter(name_table_dsl::name.eq(eq));
-                } else if let Some(like) = &name.like {
-                    query = query.filter(name_table_dsl::name.like(format!("%{}%", like)));
-                }
-            }
-            if let Some(is_customer) = f.is_customer {
-                query = query.filter(name_store_join_dsl::name_is_customer.eq(is_customer));
-            }
-            if let Some(is_supplier) = f.is_supplier {
-                query = query.filter(name_store_join_dsl::name_is_supplier.eq(is_supplier));
-            }
-        }
+        let mut query = create_filtered_query(filter);
 
         if let Some(sort) = sort {
             match sort.key {
-                NameQuerySortField::Name => {
+                NameSortField::Name => {
                     if sort.desc.unwrap_or(false) {
                         query = query.order(name_table_dsl::name.desc());
                     } else {
                         query = query.order(name_table_dsl::name.asc());
                     }
                 }
-                NameQuerySortField::Code => {
+                NameSortField::Code => {
                     if sort.desc.unwrap_or(false) {
                         query = query.order(name_table_dsl::code.desc());
                     } else {
@@ -127,27 +89,55 @@ impl<'a> NameQueryRepository<'a> {
             query = query.order(name_table_dsl::id.asc())
         }
 
-        let result = query.load::<NameAndNameStoreJoin>(&self.connection.connection)?;
-        Ok(result.into_iter().map(NameQuery::from).collect())
+        let result = query
+            .offset(pagination.offset as i64)
+            .limit(pagination.limit as i64)
+            .load::<NameAndNameStoreJoin>(&self.connection.connection)?;
+
+        Ok(result.into_iter().map(Name::from).collect())
     }
+}
+
+type BoxedNameQuery =
+    IntoBoxed<'static, LeftJoin<name_table::table, name_store_join::table>, DBType>;
+
+pub fn create_filtered_query(filter: Option<NameFilter>) -> BoxedNameQuery {
+    let mut query = name_table_dsl::name_table
+        .left_join(name_store_join_dsl::name_store_join)
+        .into_boxed();
+
+    if let Some(f) = filter {
+        if let Some(code) = f.code {
+            if let Some(eq) = code.equal_to {
+                query = query.filter(name_table_dsl::code.eq(eq));
+            } else if let Some(like) = code.like {
+                query = query.filter(name_table_dsl::code.like(format!("%{}%", like)));
+            }
+        }
+        if let Some(name) = f.name {
+            if let Some(eq) = name.equal_to {
+                query = query.filter(name_table_dsl::name.eq(eq));
+            } else if let Some(like) = &name.like {
+                query = query.filter(name_table_dsl::name.like(format!("%{}%", like)));
+            }
+        }
+        if let Some(is_customer) = f.is_customer {
+            query = query.filter(name_store_join_dsl::name_is_customer.eq(is_customer));
+        }
+        if let Some(is_supplier) = f.is_supplier {
+            query = query.filter(name_store_join_dsl::name_is_supplier.eq(is_supplier));
+        }
+    }
+
+    query
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        database::{
-            repository::{NameQueryRepository, NameRepository, StorageConnectionManager},
-            schema::NameRow,
-        },
-        server::service::graphql::schema::{
-            queries::pagination::{Pagination, DEFAULT_PAGE_SIZE},
-            types::NameQuery,
-        },
-        util::test_db,
-    };
+    use crate::{database::{repository::{NameQueryRepository, NameRepository, StorageConnectionManager}, schema::NameRow}, domain::{name::Name, Pagination, DEFAULT_LIMIT}, util::test_db};
     use std::convert::TryFrom;
 
-    fn data() -> (Vec<NameRow>, Vec<NameQuery>) {
+    fn data() -> (Vec<NameRow>, Vec<Name>) {
         let mut rows = Vec::new();
         let mut queries = Vec::new();
         for index in 0..200 {
@@ -159,7 +149,7 @@ mod tests {
                 is_supplier: true,
             });
 
-            queries.push(NameQuery {
+            queries.push(Name {
                 id: format!("id{:05}", index),
                 name: format!("name{}", index),
                 code: format!("code{}", index),
@@ -186,31 +176,34 @@ mod tests {
                 .unwrap();
         }
 
-        let default_page_size = usize::try_from(DEFAULT_PAGE_SIZE).unwrap();
+        let default_page_size = usize::try_from(DEFAULT_LIMIT).unwrap();
 
         // Test
 
         // .count()
         assert_eq!(
-            usize::try_from(repository.count().unwrap()).unwrap(),
+            usize::try_from(repository.count(None).unwrap()).unwrap(),
             queries.len()
         );
 
-        // .all, no pagenation (default)
+        // .query, no pagenation (default)
         assert_eq!(
-            repository.all(&None, &None, &None).unwrap().len(),
+            repository
+                .query(Pagination::new(), None, None)
+                .unwrap()
+                .len(),
             default_page_size
         );
 
-        // .all, pagenation (offset 10)
+        // .query, pagenation (offset 10)
         let result = repository
-            .all(
-                &Some(Pagination {
-                    offset: Some(10),
-                    first: None,
-                }),
-                &None,
-                &None,
+            .query(
+                Pagination {
+                    offset: 10,
+                    limit: DEFAULT_LIMIT,
+                },
+                None,
+                None,
             )
             .unwrap();
         assert_eq!(result.len(), default_page_size);
@@ -220,29 +213,29 @@ mod tests {
             queries[10 + default_page_size - 1]
         );
 
-        // .all, pagenation (first 10)
+        // .query, pagenation (first 10)
         let result = repository
-            .all(
-                &Some(Pagination {
-                    offset: None,
-                    first: Some(10),
-                }),
-                &None,
-                &None,
+            .query(
+                Pagination {
+                    offset: 0,
+                    limit: 10,
+                },
+                None,
+                None,
             )
             .unwrap();
         assert_eq!(result.len(), 10);
         assert_eq!(*result.last().unwrap(), queries[9]);
 
-        // .all, pagenation (offset 150, first 90) <- more then records in table
+        // .query, pagenation (offset 150, first 90) <- more then records in table
         let result = repository
-            .all(
-                &Some(Pagination {
-                    offset: Some(150),
-                    first: Some(90),
-                }),
-                &None,
-                &None,
+            .query(
+                Pagination {
+                    offset: 150,
+                    limit: 90,
+                },
+                None,
+                None,
             )
             .unwrap();
         assert_eq!(result.len(), queries.len() - 150);

--- a/src/database/repository/tests.rs
+++ b/src/database/repository/tests.rs
@@ -292,9 +292,8 @@ mod repository_test {
                 get_repositories, repository::MasterListRepository, CentralSyncBufferRepository,
                 CustomerInvoiceRepository, InvoiceLineQueryRepository, InvoiceLineRepository,
                 InvoiceRepository, ItemRepository, MasterListLineRepository,
-                MasterListNameJoinRepository, NameQueryFilter, NameQueryRepository, NameQuerySort,
-                NameQuerySortField, NameRepository, RequisitionLineRepository,
-                RequisitionRepository, SimpleStringFilter, StockLineRepository,
+                MasterListNameJoinRepository, NameQueryRepository, NameRepository,
+                RequisitionLineRepository, RequisitionRepository, StockLineRepository,
                 StorageConnectionManager, StoreRepository, UserAccountRepository,
             },
             schema::{
@@ -302,6 +301,10 @@ mod repository_test {
                 MasterListLineRow, MasterListRow, NameRow, RequisitionLineRow, RequisitionRow,
                 RequisitionRowType, StockLineRow, StoreRow, UserAccountRow,
             },
+        },
+        domain::{
+            name::{NameFilter, NameSort, NameSortField},
+            Pagination, SimpleStringFilter,
         },
         util::test_db,
     };
@@ -339,9 +342,9 @@ mod repository_test {
         let repo = NameQueryRepository::new(&connection);
         // test filter:
         let result = repo
-            .all(
-                &None,
-                &Some(NameQueryFilter {
+            .query(
+                Pagination::new(),
+                Some(NameFilter {
                     name: Some(SimpleStringFilter {
                         equal_to: Some("name_1".to_string()),
                         like: None,
@@ -350,16 +353,16 @@ mod repository_test {
                     is_customer: None,
                     is_supplier: None,
                 }),
-                &None,
+                None,
             )
             .unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result.get(0).unwrap().name, "name_1");
 
         let result = repo
-            .all(
-                &None,
-                &Some(NameQueryFilter {
+            .query(
+                Pagination::new(),
+                Some(NameFilter {
                     name: Some(SimpleStringFilter {
                         equal_to: None,
                         like: Some("me_".to_string()),
@@ -368,15 +371,15 @@ mod repository_test {
                     is_customer: None,
                     is_supplier: None,
                 }),
-                &None,
+                None,
             )
             .unwrap();
         assert_eq!(result.len(), 3);
 
         let result = repo
-            .all(
-                &None,
-                &Some(NameQueryFilter {
+            .query(
+                Pagination::new(),
+                Some(NameFilter {
                     name: None,
                     code: Some(SimpleStringFilter {
                         equal_to: Some("code1".to_string()),
@@ -385,16 +388,16 @@ mod repository_test {
                     is_customer: None,
                     is_supplier: None,
                 }),
-                &None,
+                None,
             )
             .unwrap();
         assert_eq!(result.len(), 2);
 
         /* TODO currently no way to add name_store_join rows for the following tests:
         let result = repo
-            .all(
-                &None,
-                &Some(NameQueryFilter {
+            .query(
+                Pagination::new(),
+                Some(NameQueryFilter {
                     name: None,
                     code: None,
                     is_customer: Some(true),
@@ -406,9 +409,9 @@ mod repository_test {
         assert_eq!(result.get(0).unwrap().name, "name_3");
 
         let result = repo
-            .all(
-                &None,
-                &Some(NameQueryFilter {
+            .query(
+                Pagination::new(),
+                Some(NameQueryFilter {
                     name: None,
                     code: None,
                     is_customer: None,
@@ -422,11 +425,11 @@ mod repository_test {
         */
 
         let result = repo
-            .all(
-                &None,
-                &None,
-                &Some(NameQuerySort {
-                    key: NameQuerySortField::Code,
+            .query(
+                Pagination::new(),
+                None,
+                Some(NameSort {
+                    key: NameSortField::Code,
                     desc: Some(true),
                 }),
             )

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,0 +1,50 @@
+pub mod name;
+use chrono::NaiveDateTime;
+
+#[derive(Clone)]
+pub struct SimpleStringFilter {
+    pub equal_to: Option<String>,
+    pub like: Option<String>,
+}
+#[derive(Clone)]
+pub struct EqualFilter<T> {
+    pub equal_to: Option<T>,
+}
+#[derive(Clone)]
+pub struct DatetimeFilter {
+    pub equal_to: Option<NaiveDateTime>,
+    pub before_or_equal_to: Option<NaiveDateTime>,
+    pub after_or_equal_to: Option<NaiveDateTime>,
+}
+pub struct Sort<T> {
+    pub key: T,
+    pub desc: Option<bool>,
+}
+
+pub const DEFAULT_LIMIT: u32 = 100;
+
+pub struct PaginationOption {
+    pub limit: Option<u32>,
+    pub offset: Option<u32>,
+}
+
+pub struct Pagination {
+    pub limit: u32,
+    pub offset: u32,
+}
+
+impl Pagination {
+    pub fn new() -> Pagination {
+        Pagination {
+            offset: 0,
+            limit: DEFAULT_LIMIT,
+        }
+    }
+
+    pub fn one() -> Pagination {
+        Pagination {
+            offset: 0,
+            limit: 1,
+        }
+    }
+}

--- a/src/domain/name.rs
+++ b/src/domain/name.rs
@@ -1,0 +1,24 @@
+use super::{SimpleStringFilter, Sort};
+
+#[derive(PartialEq, Debug)]
+pub struct Name {
+    pub id: String,
+    pub name: String,
+    pub code: String,
+    pub is_customer: bool,
+    pub is_supplier: bool,
+}
+#[derive(Clone)]
+pub struct NameFilter {
+    pub name: Option<SimpleStringFilter>,
+    pub code: Option<SimpleStringFilter>,
+    pub is_customer: Option<bool>,
+    pub is_supplier: Option<bool>,
+}
+
+pub enum NameSortField {
+    Name,
+    Code,
+}
+
+pub type NameSort = Sort<NameSortField>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,7 @@
 extern crate diesel;
 
 pub mod database;
+pub mod domain;
 pub mod server;
+pub mod service;
 pub mod util;

--- a/src/server/service/graphql/schema/types/mod.rs
+++ b/src/server/service/graphql/schema/types/mod.rs
@@ -2,18 +2,21 @@ use crate::{
     database::{
         loader::{InvoiceLoader, StoreLoader},
         repository::{
-            CustomerInvoiceRepository, InvoiceLineRepository, RequisitionLineRepository,
-            StorageConnectionManager,
+            CustomerInvoiceRepository, InvoiceLineRepository, RepositoryError,
+            RequisitionLineRepository, StorageConnectionManager,
         },
         schema::{
             InvoiceLineRow, InvoiceRow, RequisitionLineRow, RequisitionRow, RequisitionRowType,
             StoreRow,
         },
     },
+    domain::PaginationOption,
     server::service::graphql::ContextExt,
+    service::{ListError, ListResult},
 };
 
-use async_graphql::{dataloader::DataLoader, Context, Enum, InputObject, Object};
+use async_graphql::*;
+use dataloader::DataLoader;
 
 // M1 speced API is moved to their own files
 // Types defined here are prototype types and should be removed before M1 release to avoid confusion (for consumers and devs)
@@ -34,6 +37,131 @@ pub use self::invoices_query::*;
 
 pub mod sort_filter_types;
 pub use self::sort_filter_types::*;
+
+/// Generic Connector
+#[derive(SimpleObject)]
+#[graphql(concrete(name = "NameConnector", params(NameNode)))]
+pub struct Connector<T: OutputType> {
+    total_count: u32,
+    nodes: Vec<T>,
+}
+
+/// Convert from ListResult to Generic Connector
+impl<DomainType, GQLType> From<ListResult<DomainType>> for Connector<GQLType>
+where
+    GQLType: From<DomainType> + OutputType,
+{
+    fn from(ListResult { count, rows }: ListResult<DomainType>) -> Self {
+        Connector {
+            total_count: count,
+            nodes: rows.into_iter().map(GQLType::from).collect(),
+        }
+    }
+}
+
+/// Generic Pagination Input
+#[derive(InputObject)]
+pub struct PaginationInput {
+    pub first: Option<u32>,
+    pub offset: Option<u32>,
+}
+
+impl From<PaginationInput> for PaginationOption {
+    fn from(PaginationInput { first, offset }: PaginationInput) -> Self {
+        PaginationOption {
+            limit: first,
+            offset,
+        }
+    }
+}
+
+/// Generic Error Wrapper
+#[derive(SimpleObject)]
+#[graphql(concrete(name = "ConnectorError", params(ConnectorErrorInterface)))]
+pub struct ErrorWrapper<T: OutputType> {
+    error: T,
+}
+
+// Generic Error Interface
+#[derive(Interface)]
+#[graphql(field(name = "description", type = "&str"))]
+pub enum ConnectorErrorInterface {
+    DBError(DBError),
+    PaginationError(PaginationError),
+}
+
+impl From<ListError> for ErrorWrapper<ConnectorErrorInterface> {
+    fn from(error: ListError) -> Self {
+        let error = match error {
+            ListError::DBError(error) => ConnectorErrorInterface::DBError(DBError(error)),
+            ListError::LimitBelowMin { limit, min } => {
+                ConnectorErrorInterface::PaginationError(PaginationError {
+                    out_of_range: FirstOutOfRange::Min(min),
+                    first: limit,
+                })
+            }
+            ListError::LimitAboveMax { limit, max } => {
+                ConnectorErrorInterface::PaginationError(PaginationError {
+                    out_of_range: FirstOutOfRange::Max(max),
+                    first: limit,
+                })
+            }
+        };
+
+        ErrorWrapper { error }
+    }
+}
+
+// Generic Errors
+pub struct DBError(pub RepositoryError);
+
+#[Object]
+impl DBError {
+    pub async fn description(&self) -> &'static str {
+        "Dabase Error"
+    }
+
+    pub async fn full_error(&self) -> String {
+        format!("{:#}", self.0)
+    }
+}
+
+pub enum FirstOutOfRange {
+    Max(u32),
+    Min(u32),
+}
+pub struct PaginationError {
+    out_of_range: FirstOutOfRange,
+    first: u32,
+}
+
+#[Object]
+impl PaginationError {
+    pub async fn description(&self) -> &'static str {
+        match &self.out_of_range {
+            FirstOutOfRange::Max(_) => "First is too big",
+            FirstOutOfRange::Min(_) => "First is too low",
+        }
+    }
+
+    pub async fn max(&self) -> Option<u32> {
+        match &self.out_of_range {
+            FirstOutOfRange::Max(max) => Some(max.clone()),
+            _ => None,
+        }
+    }
+
+    pub async fn min(&self) -> Option<u32> {
+        match &self.out_of_range {
+            FirstOutOfRange::Min(min) => Some(min.clone()),
+            _ => None,
+        }
+    }
+
+    pub async fn first(&self) -> u32 {
+        self.first
+    }
+}
 
 #[derive(Clone)]
 pub struct Store {

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,0 +1,80 @@
+use crate::{
+    database::repository::RepositoryError,
+    domain::{Pagination, PaginationOption, DEFAULT_LIMIT},
+};
+use std::convert::TryInto;
+
+pub mod name;
+
+pub struct ListResult<T> {
+    pub rows: Vec<T>,
+    pub count: u32,
+}
+
+pub enum ListError {
+    DBError(RepositoryError),
+    LimitBelowMin { limit: u32, min: u32 },
+    LimitAboveMax { limit: u32, max: u32 },
+}
+
+pub enum SingleRecordError {
+    DBError(RepositoryError),
+    NotFound(String),
+}
+
+impl From<RepositoryError> for ListError {
+    fn from(error: RepositoryError) -> Self {
+        ListError::DBError(error)
+    }
+}
+
+impl From<RepositoryError> for SingleRecordError {
+    fn from(error: RepositoryError) -> Self {
+        SingleRecordError::DBError(error)
+    }
+}
+
+pub fn get_default_pagination(
+    pagination_option: Option<PaginationOption>,
+    max_limit: u32,
+    min_limit: u32,
+) -> Result<Pagination, ListError> {
+    let check_limit = |limit: u32| -> Result<u32, ListError> {
+        if limit < min_limit {
+            return Err(ListError::LimitBelowMin {
+                limit,
+                min: min_limit,
+            });
+        }
+
+        if limit > max_limit {
+            return Err(ListError::LimitAboveMax {
+                limit,
+                max: max_limit,
+            });
+        }
+
+        Ok(limit)
+    };
+
+    let result = if let Some(pagination) = pagination_option {
+        Pagination {
+            offset: pagination.offset.unwrap_or(0),
+            limit: match pagination.limit {
+                Some(limit) => check_limit(limit)?,
+                None => DEFAULT_LIMIT,
+            },
+        }
+    } else {
+        Pagination {
+            offset: 0,
+            limit: DEFAULT_LIMIT,
+        }
+    };
+
+    Ok(result)
+}
+
+pub fn i64_to_u32(num: i64) -> u32 {
+    num.try_into().unwrap_or(0)
+}

--- a/src/service/name.rs
+++ b/src/service/name.rs
@@ -1,0 +1,28 @@
+use crate::{
+    database::repository::{NameQueryRepository, StorageConnectionManager},
+    domain::{
+        name::{Name, NameFilter, NameSort},
+        PaginationOption,
+    },
+};
+
+use super::{get_default_pagination, i64_to_u32, ListError, ListResult};
+
+pub const MAX_LIMIT: u32 = 1000;
+pub const MIN_LIMIT: u32 = 1;
+
+pub fn get_names(
+    connection_manager: &StorageConnectionManager,
+    pagination: Option<PaginationOption>,
+    filter: Option<NameFilter>,
+    sort: Option<NameSort>,
+) -> Result<ListResult<Name>, ListError> {
+    let pagination = get_default_pagination(pagination, MAX_LIMIT, MIN_LIMIT)?;
+    let connection = connection_manager.connection()?;
+    let repository = NameQueryRepository::new(&connection);
+
+    Ok(ListResult {
+        rows: repository.query(pagination, filter.clone(), sort)?,
+        count: i64_to_u32(repository.count(filter)?),
+    })
+}


### PR DESCRIPTION
Fixed: #404 

Add domain object, service and query with composition (of domain object). Also added generic types for error handling in queries and generic connector result

### Changes

* Move filters and sorts to domain area 
* Created service for name
* Changed repository to use domain object 
* Changed repository to allow for count to be filtered

Not that happy about both total count and nodes being queried (even if just one of them is requested in gql query, can work around it with look ahead, maybe in future PR)
