### PR TITLE
422 add supplier invoice line delete mutation

### DIFF
--- a/src/database/repository/diesel/invoice_line.rs
+++ b/src/database/repository/diesel/invoice_line.rs
@@ -34,6 +34,14 @@ impl<'a> InvoiceLineRepository<'a> {
             .execute(&self.connection.connection)?;
         Ok(())
     }
+
+    pub fn delete(&self, invoice_line_id: &str) -> Result<(), RepositoryError> {
+        use crate::database::schema::diesel_schema::invoice_line::dsl::*;
+        diesel::delete(invoice_line.filter(id.eq(invoice_line_id)))
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+
     pub fn find_one_by_id(&self, row_id: &str) -> Result<InvoiceLineRow, RepositoryError> {
         use crate::database::schema::diesel_schema::invoice_line::dsl::*;
         let result = invoice_line

--- a/src/domain/supplier_invoice.rs
+++ b/src/domain/supplier_invoice.rs
@@ -17,6 +17,9 @@ pub struct UpdateSupplierInvoice {
     pub comment: Option<String>,
     pub their_reference: Option<String>,
 }
+pub struct DeleteSupplierInvoice {
+    pub id: String,
+}
 
 pub struct InsertSupplierInvoiceLine {
     pub id: String,
@@ -40,4 +43,9 @@ pub struct UpdateSupplierInvoiceLine {
     pub sell_price_per_pack: Option<f64>,
     pub expiry_date: Option<NaiveDate>,
     pub number_of_packs: Option<u32>,
+}
+
+pub struct DeleteSupplierInvoiceLine {
+    pub id: String,
+    pub invoice_id: String,
 }

--- a/src/server/service/graphql/schema/mutations/mod.rs
+++ b/src/server/service/graphql/schema/mutations/mod.rs
@@ -15,7 +15,8 @@ use crate::{
             delete_supplier_invoice, get_invoice, insert_supplier_invoice, update_supplier_invoice,
         },
         invoice_line::{
-            get_invoice_line, insert_supplier_invoice_line, update_supplier_invoice_line,
+            delete_supplier_invoice_line, get_invoice_line, insert_supplier_invoice_line,
+            update_supplier_invoice_line,
         },
     },
 };
@@ -31,6 +32,8 @@ use supplier_invoice::{
     },
     update::{UpdateSupplierInvoiceInput, UpdateSupplierInvoiceResponse},
 };
+
+use self::supplier_invoice::DeleteSupplierInvoiceInput;
 
 pub struct Mutations;
 
@@ -89,11 +92,11 @@ impl Mutations {
     async fn delete_supplier_invoice(
         &self,
         ctx: &Context<'_>,
-        id: String,
+        input: DeleteSupplierInvoiceInput,
     ) -> DeleteSupplierInvoiceResponse {
         let connection_manager = ctx.get_repository::<StorageConnectionManager>();
 
-        delete_supplier_invoice(connection_manager, id).into()
+        delete_supplier_invoice(connection_manager, input.into()).into()
     }
 
     async fn insert_supplier_invoice_line(
@@ -127,7 +130,9 @@ impl Mutations {
         ctx: &Context<'_>,
         input: DeleteSupplierInvoiceLineInput,
     ) -> DeleteSupplierInvoiceLineResponse {
-        todo!();
+        let connection_manager = ctx.get_repository::<StorageConnectionManager>();
+
+        delete_supplier_invoice_line(connection_manager, input.into()).into()
     }
 }
 

--- a/src/server/service/graphql/schema/mutations/supplier_invoice/delete.rs
+++ b/src/server/service/graphql/schema/mutations/supplier_invoice/delete.rs
@@ -1,6 +1,7 @@
 use async_graphql::*;
 
 use crate::{
+    domain::supplier_invoice::DeleteSupplierInvoice,
     server::service::graphql::schema::{
         mutations::{
             CannotEditFinalisedInvoice, DeleteResponse, InvoiceDoesNotBelongToCurrentStore,
@@ -12,6 +13,11 @@ use crate::{
 };
 
 use super::CannotDeleteInvoiceWithLines;
+
+#[derive(InputObject)]
+pub struct DeleteSupplierInvoiceInput {
+    id: String,
+}
 
 #[derive(Union)]
 pub enum DeleteSupplierInvoiceResponse {
@@ -28,6 +34,12 @@ pub enum DeleteSupplierInvoiceErrorInterface {
     NotASupplierInvoice(NotASupplierInvoice),
     InvoiceDoesNotBelongToCurrentStore(InvoiceDoesNotBelongToCurrentStore),
     CannotDeleteInvoiceWithLines(CannotDeleteInvoiceWithLines),
+}
+
+impl From<DeleteSupplierInvoiceInput> for DeleteSupplierInvoice {
+    fn from(input: DeleteSupplierInvoiceInput) -> Self {
+        DeleteSupplierInvoice { id: input.id }
+    }
 }
 
 impl From<Result<String, DeleteSupplierInvoiceError>> for DeleteSupplierInvoiceResponse {

--- a/src/service/invoice/supplier_invoice/delete/mod.rs
+++ b/src/service/invoice/supplier_invoice/delete/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     database::repository::{InvoiceRepository, RepositoryError, StorageConnectionManager},
-    domain::invoice_line::InvoiceLine,
+    domain::{invoice_line::InvoiceLine, supplier_invoice::DeleteSupplierInvoice},
 };
 
 mod validate;
@@ -9,15 +9,15 @@ use validate::validate;
 
 pub fn delete_supplier_invoice(
     connection_manager: &StorageConnectionManager,
-    id: String,
+    input: DeleteSupplierInvoice,
 ) -> Result<String, DeleteSupplierInvoiceError> {
     let connection = connection_manager.connection()?;
     // TODO do inside transaction
-    validate(&id, &connection)?;
+    validate(&input, &connection)?;
 
-    InvoiceRepository::new(&connection).delete(&id)?;
+    InvoiceRepository::new(&connection).delete(&input.id)?;
 
-    Ok(id)
+    Ok(input.id)
 }
 
 pub enum DeleteSupplierInvoiceError {

--- a/src/service/invoice/supplier_invoice/delete/validate.rs
+++ b/src/service/invoice/supplier_invoice/delete/validate.rs
@@ -3,6 +3,7 @@ use crate::{
         repository::{InvoiceLineQueryRepository, StorageConnection},
         schema::InvoiceRow,
     },
+    domain::supplier_invoice::DeleteSupplierInvoice,
     service::invoice::{
         check_invoice_exists, check_invoice_finalised, check_invoice_type, CommonError,
     },
@@ -11,15 +12,15 @@ use crate::{
 use super::DeleteSupplierInvoiceError;
 
 pub fn validate(
-    id: &str,
+    input: &DeleteSupplierInvoice,
     connection: &StorageConnection,
 ) -> Result<InvoiceRow, DeleteSupplierInvoiceError> {
-    let invoice = check_invoice_exists(&id, connection)?;
+    let invoice = check_invoice_exists(&input.id, connection)?;
 
     // check_store(invoice, connection)?; InvoiceDoesNotBelongToCurrentStore
     check_invoice_type(&invoice)?;
     check_invoice_finalised(&invoice)?;
-    check_lines_exist(id, connection)?;
+    check_lines_exist(&input.id, connection)?;
 
     Ok(invoice)
 }

--- a/src/service/invoice_line/supplier_invoice_line/delete/mod.rs
+++ b/src/service/invoice_line/supplier_invoice_line/delete/mod.rs
@@ -1,0 +1,45 @@
+use crate::{
+    database::repository::{
+        InvoiceLineRepository, RepositoryError, StockLineRepository, StorageConnectionManager,
+    },
+    domain::supplier_invoice::DeleteSupplierInvoiceLine,
+};
+
+mod validate;
+
+use validate::validate;
+
+pub fn delete_supplier_invoice_line(
+    connection_manager: &StorageConnectionManager,
+    input: DeleteSupplierInvoiceLine,
+) -> Result<String, DeleteSupplierInvoiceLineError> {
+    let connection = connection_manager.connection()?;
+    // TODO do inside transaction
+    let line = validate(&input, &connection)?;
+
+    let delete_batch_id_option = line.stock_line_id.clone();
+
+    InvoiceLineRepository::new(&connection).delete(&line.id)?;
+
+    if let Some(id) = delete_batch_id_option {
+        StockLineRepository::new(&connection).delete(&id)?;
+    }
+
+    Ok(line.id)
+}
+pub enum DeleteSupplierInvoiceLineError {
+    LineDoesNotExist,
+    DatabaseError(RepositoryError),
+    InvoiceDoesNotExist,
+    NotASupplierInvoice,
+    NotThisStoreInvoice,
+    CannotEditFinalised,
+    BatchIsReserved,
+    NotThisInvoiceLine(String),
+}
+
+impl From<RepositoryError> for DeleteSupplierInvoiceLineError {
+    fn from(error: RepositoryError) -> Self {
+        DeleteSupplierInvoiceLineError::DatabaseError(error)
+    }
+}

--- a/src/service/invoice_line/supplier_invoice_line/delete/validate.rs
+++ b/src/service/invoice_line/supplier_invoice_line/delete/validate.rs
@@ -1,0 +1,58 @@
+use crate::{
+    database::{repository::StorageConnection, schema::InvoiceLineRow},
+    domain::supplier_invoice::DeleteSupplierInvoiceLine,
+    service::{
+        invoice::{
+            check_invoice_exists, check_invoice_finalised, check_invoice_type,
+            CommonError as CommonInvoiceError,
+        },
+        invoice_line::{
+            supplier_invoice_line::{
+                check_batch, check_line_belongs_to_invoice, check_line_exists,
+            },
+            InsertAndDeleteError,
+        },
+    },
+};
+
+use super::DeleteSupplierInvoiceLineError;
+
+pub fn validate(
+    input: &DeleteSupplierInvoiceLine,
+    connection: &StorageConnection,
+) -> Result<InvoiceLineRow, DeleteSupplierInvoiceLineError> {
+    let line = check_line_exists(&input.id, connection)?;
+
+    let invoice = check_invoice_exists(&input.invoice_id, connection)?;
+    // check_store(invoice, connection)?; InvoiceDoesNotBelongToCurrentStore
+    check_line_belongs_to_invoice(&line, &invoice)?;
+    check_invoice_type(&invoice)?;
+    check_invoice_finalised(&invoice)?;
+    check_batch(&line, connection)?;
+
+    Ok(line)
+}
+
+impl From<CommonInvoiceError> for DeleteSupplierInvoiceLineError {
+    fn from(error: CommonInvoiceError) -> Self {
+        use DeleteSupplierInvoiceLineError::*;
+        match error {
+            CommonInvoiceError::InvoiceDoesNotExists => InvoiceDoesNotExist,
+            CommonInvoiceError::DatabaseError(error) => DatabaseError(error),
+            CommonInvoiceError::InvoiceIsFinalised => CannotEditFinalised,
+            CommonInvoiceError::NotASupplierInvoice => NotASupplierInvoice,
+        }
+    }
+}
+
+impl From<InsertAndDeleteError> for DeleteSupplierInvoiceLineError {
+    fn from(error: InsertAndDeleteError) -> Self {
+        use DeleteSupplierInvoiceLineError::*;
+        match error {
+            InsertAndDeleteError::LineDoesNotExist => LineDoesNotExist,
+            InsertAndDeleteError::NotInvoiceLine(invoice_id) => NotThisInvoiceLine(invoice_id),
+            InsertAndDeleteError::DatabaseError(error) => DatabaseError(error),
+            InsertAndDeleteError::BatchIsReserved => BatchIsReserved,
+        }
+    }
+}

--- a/src/service/invoice_line/supplier_invoice_line/mod.rs
+++ b/src/service/invoice_line/supplier_invoice_line/mod.rs
@@ -1,3 +1,4 @@
+pub mod delete;
 pub mod insert;
 pub mod update;
 use uuid::Uuid;
@@ -13,6 +14,7 @@ use crate::{
     service::invoice::current_store_id,
 };
 
+pub use self::delete::*;
 pub use self::insert::*;
 pub use self::update::*;
 


### PR DESCRIPTION
Closes: #422 

Pretty much just the delete, but i saw shape of supplier invoice line delete needing invoice id (why ? i thought it would be good for safety and to reuse methods from update), and that lead me to also make a shape for supplier invoice delete (small change) 