### PR TITLE
348 ci insert delete

### DIFF
--- a/src/database/repository/diesel/mod.rs
+++ b/src/database/repository/diesel/mod.rs
@@ -41,7 +41,7 @@ pub use name_store_join::NameStoreJoinRepository;
 pub use requisition::RequisitionRepository;
 pub use requisition_line::RequisitionLineRepository;
 pub use stock_line::StockLineRepository;
-pub use storage_connection::{StorageConnection, StorageConnectionManager};
+pub use storage_connection::{StorageConnection, StorageConnectionManager, TransactionError};
 pub use store::StoreRepository;
 pub use user_account::UserAccountRepository;
 

--- a/src/domain/customer_invoice.rs
+++ b/src/domain/customer_invoice.rs
@@ -1,0 +1,17 @@
+use super::invoice::InvoiceStatus;
+
+pub struct InsertCustomerInvoice {
+    pub id: String,
+    pub other_party_id: String,
+    pub status: InvoiceStatus,
+    pub comment: Option<String>,
+    pub their_reference: Option<String>,
+}
+
+pub struct UpdateCustomerInvoice {
+    pub id: String,
+    pub other_party_id: Option<String>,
+    pub status: Option<InvoiceStatus>,
+    pub comment: Option<String>,
+    pub their_reference: Option<String>,
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,3 +1,4 @@
+pub mod customer_invoice;
 pub mod invoice;
 pub mod invoice_line;
 pub mod item;

--- a/src/server/service/graphql/schema/mutations/customer_invoice/delete.rs
+++ b/src/server/service/graphql/schema/mutations/customer_invoice/delete.rs
@@ -2,7 +2,7 @@ use crate::{
     server::service::graphql::schema::{
         mutations::{
             CannotDeleteInvoiceWithLines, CannotEditFinalisedInvoice, DeleteResponse,
-            InvoiceDoesNotBelongToCurrentStore, RecordDoesNotExist,
+            InvoiceDoesNotBelongToCurrentStore, NotACustomerInvoice, RecordDoesNotExist,
         },
         types::{DatabaseError, ErrorWrapper},
     },
@@ -22,6 +22,7 @@ pub enum DeleteCustomerInvoiceResponse {
 pub enum DeleteCustomerInvoiceErrorInterface {
     RecordDoesNotExist(RecordDoesNotExist),
     CannotEditFinalisedInvoice(CannotEditFinalisedInvoice),
+    NotACustomerInvoice(NotACustomerInvoice),
     InvoiceDoesNotBelongToCurrentStore(InvoiceDoesNotBelongToCurrentStore),
     CannotDeleteInvoiceWithLines(CannotDeleteInvoiceWithLines),
     DatabaseError(DatabaseError),
@@ -54,6 +55,9 @@ impl From<DeleteCustomerInvoiceError> for DeleteCustomerInvoiceResponse {
             }
             DeleteCustomerInvoiceError::DatabaseError(error) => {
                 OutError::DatabaseError(DatabaseError(error))
+            }
+            DeleteCustomerInvoiceError::NotACustomerInvoice => {
+                OutError::NotACustomerInvoice(NotACustomerInvoice {})
             }
         };
 

--- a/src/server/service/graphql/schema/mutations/customer_invoice/delete.rs
+++ b/src/server/service/graphql/schema/mutations/customer_invoice/delete.rs
@@ -1,38 +1,62 @@
-use crate::server::service::graphql::schema::mutations::error::DatabaseError;
-
-use super::{
-    CanOnlyEditInvoicesInLoggedInStoreError, FinalisedInvoiceIsNotEditableError,
-    InvoiceNotFoundError,
+use crate::{
+    server::service::graphql::schema::{
+        mutations::{
+            CannotDeleteInvoiceWithLines, CannotEditFinalisedInvoice, DeleteResponse,
+            InvoiceDoesNotBelongToCurrentStore, RecordDoesNotExist,
+        },
+        types::{DatabaseError, ErrorWrapper},
+    },
+    service::invoice::DeleteCustomerInvoiceError,
 };
 
-use async_graphql::{InputObject, Interface, SimpleObject, Union};
-
-#[derive(InputObject)]
-pub struct DeleteCustomerInvoiceInput {
-    id: String,
-}
+use async_graphql::{Interface, Union};
 
 #[derive(Union)]
-pub enum DeleteCustomerInvoiceResultUnion {
-    Ok(DeleteCustomerInvoiceOk),
-    Error(DeleteCustomerInvoiceError),
-}
-
-#[derive(SimpleObject)]
-pub struct DeleteCustomerInvoiceOk {
-    invoice_id: String,
-}
-
-#[derive(SimpleObject)]
-pub struct DeleteCustomerInvoiceError {
-    error: DeleteCustomerInvoiceErrorInterface,
+pub enum DeleteCustomerInvoiceResponse {
+    Error(ErrorWrapper<DeleteCustomerInvoiceErrorInterface>),
+    Response(DeleteResponse),
 }
 
 #[derive(Interface)]
-#[graphql(field(name = "description", type = "String"))]
+#[graphql(field(name = "description", type = "&str"))]
 pub enum DeleteCustomerInvoiceErrorInterface {
-    CanOnlyEditInvoicesInLoggedInStore(CanOnlyEditInvoicesInLoggedInStoreError),
-    FinalisedInvoiceIsNotEditable(FinalisedInvoiceIsNotEditableError),
-    InvoiceNotFound(InvoiceNotFoundError),
+    RecordDoesNotExist(RecordDoesNotExist),
+    CannotEditFinalisedInvoice(CannotEditFinalisedInvoice),
+    InvoiceDoesNotBelongToCurrentStore(InvoiceDoesNotBelongToCurrentStore),
+    CannotDeleteInvoiceWithLines(CannotDeleteInvoiceWithLines),
     DatabaseError(DatabaseError),
+}
+
+impl From<Result<String, DeleteCustomerInvoiceError>> for DeleteCustomerInvoiceResponse {
+    fn from(result: Result<String, DeleteCustomerInvoiceError>) -> Self {
+        match result {
+            Ok(id) => DeleteCustomerInvoiceResponse::Response(DeleteResponse(id)),
+            Err(error) => error.into(),
+        }
+    }
+}
+
+impl From<DeleteCustomerInvoiceError> for DeleteCustomerInvoiceResponse {
+    fn from(error: DeleteCustomerInvoiceError) -> Self {
+        use DeleteCustomerInvoiceErrorInterface as OutError;
+        let error = match error {
+            DeleteCustomerInvoiceError::InvoiceDoesNotExists => {
+                OutError::RecordDoesNotExist(RecordDoesNotExist {})
+            }
+            DeleteCustomerInvoiceError::CannotEditFinalised => {
+                OutError::CannotEditFinalisedInvoice(CannotEditFinalisedInvoice {})
+            }
+            DeleteCustomerInvoiceError::NotThisStoreInvoice => {
+                OutError::InvoiceDoesNotBelongToCurrentStore(InvoiceDoesNotBelongToCurrentStore {})
+            }
+            DeleteCustomerInvoiceError::InvoiceLinesExists(lines) => {
+                OutError::CannotDeleteInvoiceWithLines(CannotDeleteInvoiceWithLines(lines.into()))
+            }
+            DeleteCustomerInvoiceError::DatabaseError(error) => {
+                OutError::DatabaseError(DatabaseError(error))
+            }
+        };
+
+        DeleteCustomerInvoiceResponse::Error(ErrorWrapper { error })
+    }
 }

--- a/src/server/service/graphql/schema/mutations/customer_invoice/error.rs
+++ b/src/server/service/graphql/schema/mutations/customer_invoice/error.rs
@@ -1,5 +1,7 @@
 use async_graphql::Object;
 
+use crate::server::service::graphql::schema::types::NameNode;
+
 pub struct CannotChangeStatusBackToDraftError;
 
 #[Object]
@@ -75,14 +77,15 @@ impl OtherPartyIdNotFoundError {
     }
 }
 
-pub struct OtherPartyNotACustomerOfThisStoreError(pub String);
+pub struct OtherPartyNotACustomerError(pub NameNode);
 
 #[Object]
-impl OtherPartyNotACustomerOfThisStoreError {
-    pub async fn description(&self) -> String {
-        format!(
-            "Other party with id '{}' is not a valid customer of this store.",
-            self.0
-        )
+impl OtherPartyNotACustomerError {
+    pub async fn description(&self) -> &'static str {
+        "Other party name is not a customer"
+    }
+
+    pub async fn other_party(&self) -> &NameNode {
+        &self.0
     }
 }

--- a/src/server/service/graphql/schema/mutations/customer_invoice/error.rs
+++ b/src/server/service/graphql/schema/mutations/customer_invoice/error.rs
@@ -81,7 +81,7 @@ pub struct OtherPartyNotACustomerOfThisStoreError(pub String);
 impl OtherPartyNotACustomerOfThisStoreError {
     pub async fn description(&self) -> String {
         format!(
-            "Other party with id '{}' is not a valid supplier of this store.",
+            "Other party with id '{}' is not a valid customer of this store.",
             self.0
         )
     }

--- a/src/server/service/graphql/schema/mutations/customer_invoice/insert.rs
+++ b/src/server/service/graphql/schema/mutations/customer_invoice/insert.rs
@@ -1,45 +1,94 @@
-use crate::server::service::graphql::schema::{
-    mutations::error::DatabaseError,
-    types::{InvoiceNode, InvoiceNodeStatus},
+use crate::{
+    domain::{
+        customer_invoice::InsertCustomerInvoice,
+        invoice::{Invoice, InvoiceStatus},
+    },
+    server::service::graphql::schema::{
+        mutations::{ForeignKey, ForeignKeyError, RecordAlreadyExist},
+        types::{DatabaseError, ErrorWrapper, InvoiceNodeStatus, InvoiceResponse},
+    },
+    service::{invoice::InsertCustomerInvoiceError, SingleRecordError},
 };
 
-use super::{
-    OtherPartyCannotBeThisStoreError, OtherPartyIdMissingError, OtherPartyIdNotFoundError,
-    OtherPartyNotACustomerOfThisStoreError,
-};
+use super::{OtherPartyCannotBeThisStoreError, OtherPartyNotACustomerOfThisStoreError};
 
-use async_graphql::{InputObject, Interface, SimpleObject, Union};
+use async_graphql::{InputObject, Interface, Union};
+
+use async_graphql::*;
 
 #[derive(InputObject)]
 pub struct InsertCustomerInvoiceInput {
+    /// The new invoice id provided by the client
+    id: String,
+    /// The other party must be an customer of the current store
     other_party_id: String,
     status: Option<InvoiceNodeStatus>,
     comment: Option<String>,
     their_reference: Option<String>,
 }
 
+impl From<InsertCustomerInvoiceInput> for InsertCustomerInvoice {
+    fn from(input: InsertCustomerInvoiceInput) -> Self {
+        InsertCustomerInvoice {
+            other_party_id: input.other_party_id,
+            status: input
+                .status
+                .map(|s| s.into())
+                .unwrap_or(InvoiceStatus::Draft),
+            comment: input.comment,
+            their_reference: input.their_reference,
+        }
+    }
+}
+
 #[derive(Union)]
-pub enum InsertCustomerInvoiceResultUnion {
-    Ok(InsertCustomerInvoiceOk),
-    Error(InsertCustomerInvoiceError),
-}
-
-#[derive(SimpleObject)]
-pub struct InsertCustomerInvoiceOk {
-    invoice: InvoiceNode,
-}
-
-#[derive(SimpleObject)]
-pub struct InsertCustomerInvoiceError {
-    error: InsertCustomerInvoiceErrorInterface,
+pub enum InsertCustomerInvoiceResponse {
+    Error(ErrorWrapper<InsertCustomerInvoiceErrorInterface>),
+    #[graphql(flatten)]
+    Response(InvoiceResponse),
 }
 
 #[derive(Interface)]
 #[graphql(field(name = "description", type = "String"))]
 pub enum InsertCustomerInvoiceErrorInterface {
+    InvoiceAlreadyExists(RecordAlreadyExist),
+    ForeignKeyError(ForeignKeyError),
     OtherPartyCannotBeThisStore(OtherPartyCannotBeThisStoreError),
-    OtherPartyIdMissing(OtherPartyIdMissingError),
-    OtherPartyIdNotFound(OtherPartyIdNotFoundError),
     OtherPartyNotACustomerOfThisStore(OtherPartyNotACustomerOfThisStoreError),
     DatabaseError(DatabaseError),
+}
+
+impl From<Result<Invoice, SingleRecordError>> for InsertCustomerInvoiceResponse {
+    fn from(result: Result<Invoice, SingleRecordError>) -> Self {
+        let invoice_response: InvoiceResponse = result.into();
+        // Implemented by flatten union
+        invoice_response.into()
+    }
+}
+
+impl From<InsertCustomerInvoiceError> for InsertCustomerInvoiceResponse {
+    fn from(error: InsertCustomerInvoiceError) -> Self {
+        use InsertCustomerInvoiceErrorInterface as OutError;
+        let error = match error {
+            InsertCustomerInvoiceError::OtherPartyCannotBeThisStore => {
+                OutError::OtherPartyCannotBeThisStore(OtherPartyCannotBeThisStoreError {})
+            }
+            InsertCustomerInvoiceError::OtherPartyIdNotFound(_) => {
+                OutError::ForeignKeyError(ForeignKeyError(ForeignKey::OtherPartyId))
+            }
+            InsertCustomerInvoiceError::OtherPartyNotACustomerOfThisStore(id) => {
+                OutError::OtherPartyNotACustomerOfThisStore(OtherPartyNotACustomerOfThisStoreError(
+                    id,
+                ))
+            }
+            InsertCustomerInvoiceError::DatabaseError(error) => {
+                OutError::DatabaseError(DatabaseError(error))
+            }
+            InsertCustomerInvoiceError::InvoiceAlreadyExists => {
+                OutError::InvoiceAlreadyExists(RecordAlreadyExist {})
+            }
+        };
+
+        InsertCustomerInvoiceResponse::Error(ErrorWrapper { error })
+    }
 }

--- a/src/server/service/graphql/schema/mutations/customer_invoice/insert.rs
+++ b/src/server/service/graphql/schema/mutations/customer_invoice/insert.rs
@@ -30,6 +30,7 @@ pub struct InsertCustomerInvoiceInput {
 impl From<InsertCustomerInvoiceInput> for InsertCustomerInvoice {
     fn from(input: InsertCustomerInvoiceInput) -> Self {
         InsertCustomerInvoice {
+            id: input.id,
             other_party_id: input.other_party_id,
             status: input
                 .status

--- a/src/server/service/graphql/schema/mutations/customer_invoice/insert.rs
+++ b/src/server/service/graphql/schema/mutations/customer_invoice/insert.rs
@@ -5,12 +5,12 @@ use crate::{
     },
     server::service::graphql::schema::{
         mutations::{ForeignKey, ForeignKeyError, RecordAlreadyExist},
-        types::{DatabaseError, ErrorWrapper, InvoiceNodeStatus, InvoiceResponse},
+        types::{DatabaseError, ErrorWrapper, InvoiceNodeStatus, InvoiceResponse, NameNode},
     },
     service::{invoice::InsertCustomerInvoiceError, SingleRecordError},
 };
 
-use super::{OtherPartyCannotBeThisStoreError, OtherPartyNotACustomerOfThisStoreError};
+use super::{OtherPartyCannotBeThisStoreError, OtherPartyNotACustomerError};
 
 use async_graphql::{InputObject, Interface, Union};
 
@@ -55,7 +55,7 @@ pub enum InsertCustomerInvoiceErrorInterface {
     InvoiceAlreadyExists(RecordAlreadyExist),
     ForeignKeyError(ForeignKeyError),
     OtherPartyCannotBeThisStore(OtherPartyCannotBeThisStoreError),
-    OtherPartyNotACustomerOfThisStore(OtherPartyNotACustomerOfThisStoreError),
+    OtherPartyNotACustomer(OtherPartyNotACustomerError),
     DatabaseError(DatabaseError),
 }
 
@@ -77,10 +77,8 @@ impl From<InsertCustomerInvoiceError> for InsertCustomerInvoiceResponse {
             InsertCustomerInvoiceError::OtherPartyIdNotFound(_) => {
                 OutError::ForeignKeyError(ForeignKeyError(ForeignKey::OtherPartyId))
             }
-            InsertCustomerInvoiceError::OtherPartyNotACustomerOfThisStore(id) => {
-                OutError::OtherPartyNotACustomerOfThisStore(OtherPartyNotACustomerOfThisStoreError(
-                    id,
-                ))
+            InsertCustomerInvoiceError::OtherPartyNotACustomer(name) => {
+                OutError::OtherPartyNotACustomer(OtherPartyNotACustomerError(NameNode { name }))
             }
             InsertCustomerInvoiceError::DatabaseError(error) => {
                 OutError::DatabaseError(DatabaseError(error))

--- a/src/server/service/graphql/schema/mutations/customer_invoice/update.rs
+++ b/src/server/service/graphql/schema/mutations/customer_invoice/update.rs
@@ -6,7 +6,7 @@ use crate::server::service::graphql::schema::{
 use super::{
     CanOnlyEditInvoicesInLoggedInStoreError, CannotChangeStatusBackToDraftError,
     FinalisedInvoiceIsNotEditableError, InvoiceNotFoundError, OtherPartyCannotBeThisStoreError,
-    OtherPartyIdMissingError, OtherPartyIdNotFoundError, OtherPartyNotACustomerOfThisStoreError,
+    OtherPartyIdMissingError, OtherPartyIdNotFoundError, OtherPartyNotACustomerError,
 };
 
 use async_graphql::{InputObject, Interface, SimpleObject, Union};
@@ -46,6 +46,6 @@ pub enum UpdateCustomerInvoiceErrorInterface {
     OtherPartyCannotBeThisStore(OtherPartyCannotBeThisStoreError),
     OtherPartyIdMissing(OtherPartyIdMissingError),
     OtherPartyIdNotFound(OtherPartyIdNotFoundError),
-    OtherPartyNotACustomerOfThisStore(OtherPartyNotACustomerOfThisStoreError),
+    OtherPartyNotACustomer(OtherPartyNotACustomerError),
     DatabaseError(DatabaseError),
 }

--- a/src/server/service/graphql/schema/mutations/mod.rs
+++ b/src/server/service/graphql/schema/mutations/mod.rs
@@ -27,6 +27,8 @@ use supplier_invoice::{
     update::{UpdateSupplierInvoiceInput, UpdateSupplierInvoiceResponse},
 };
 
+use self::customer_invoice::InsertCustomerInvoiceResponse;
+
 pub struct Mutations;
 
 #[Object]
@@ -35,8 +37,13 @@ impl Mutations {
         &self,
         ctx: &Context<'_>,
         input: InsertCustomerInvoiceInput,
-    ) -> InsertCustomerInvoiceResultUnion {
-        todo!()
+    ) -> InsertCustomerInvoiceResponse {
+        let connection_manager = ctx.get_repository::<StorageConnectionManager>();
+
+        match insert_customer_invoice(connection_manager, input.into()) {
+            Ok(id) => get_invoice(connection_manager, id).into(),
+            Err(error) => error.into(),
+        }
     }
 
     async fn update_customer_invoice(

--- a/src/server/service/graphql/schema/mutations/mod.rs
+++ b/src/server/service/graphql/schema/mutations/mod.rs
@@ -170,6 +170,14 @@ impl CannotEditFinalisedInvoice {
     }
 }
 
+pub struct NotACustomerInvoice;
+#[Object]
+impl NotACustomerInvoice {
+    pub async fn description(&self) -> &'static str {
+        "Invoice is not Customer Invoice"
+    }
+}
+
 pub struct NotASupplierInvoice;
 #[Object]
 impl NotASupplierInvoice {

--- a/src/server/service/graphql/schema/mutations/supplier_invoice/delete.rs
+++ b/src/server/service/graphql/schema/mutations/supplier_invoice/delete.rs
@@ -3,15 +3,13 @@ use async_graphql::*;
 use crate::{
     server::service::graphql::schema::{
         mutations::{
-            CannotEditFinalisedInvoice, DeleteResponse, InvoiceDoesNotBelongToCurrentStore,
-            NotASupplierInvoice, RecordDoesNotExist,
+            CannotDeleteInvoiceWithLines, CannotEditFinalisedInvoice, DeleteResponse,
+            InvoiceDoesNotBelongToCurrentStore, NotASupplierInvoice, RecordDoesNotExist,
         },
         types::{DatabaseError, ErrorWrapper},
     },
     service::invoice::DeleteSupplierInvoiceError,
 };
-
-use super::CannotDeleteInvoiceWithLines;
 
 #[derive(Union)]
 pub enum DeleteSupplierInvoiceResponse {

--- a/src/server/service/graphql/schema/mutations/supplier_invoice/mod.rs
+++ b/src/server/service/graphql/schema/mutations/supplier_invoice/mod.rs
@@ -1,5 +1,3 @@
-use crate::server::service::graphql::schema::types::Connector;
-use crate::server::service::graphql::schema::types::InvoiceLineNode;
 use crate::server::service::graphql::schema::types::NameNode;
 use async_graphql::*;
 
@@ -23,18 +21,6 @@ impl OtherPartyNotASupplier {
     }
 
     pub async fn other_party(&self) -> &NameNode {
-        &self.0
-    }
-}
-
-pub struct CannotDeleteInvoiceWithLines(Connector<InvoiceLineNode>);
-#[Object]
-impl CannotDeleteInvoiceWithLines {
-    pub async fn description(&self) -> &'static str {
-        "Cannot delete invoice with existing lines"
-    }
-
-    pub async fn lines(&self) -> &Connector<InvoiceLineNode> {
         &self.0
     }
 }

--- a/src/server/service/graphql/schema/types/mod.rs
+++ b/src/server/service/graphql/schema/types/mod.rs
@@ -25,6 +25,7 @@ pub use self::invoice_line::*;
 pub mod sort_filter_types;
 pub use self::sort_filter_types::*;
 
+use super::mutations::customer_invoice::*;
 use super::mutations::supplier_invoice::*;
 
 /// Generic Connector
@@ -85,6 +86,14 @@ impl From<PaginationInput> for PaginationOption {
 #[derive(SimpleObject)]
 #[graphql(concrete(name = "ConnectorError", params(ConnectorErrorInterface)))]
 #[graphql(concrete(name = "NodeError", params(NodeErrorInterface)))]
+#[graphql(concrete(
+    name = "InsertCustomerInvoiceError",
+    params(InsertCustomerInvoiceErrorInterface)
+))]
+#[graphql(concrete(
+    name = "DeleteCustomerInvoiceError",
+    params(DeleteCustomerInvoiceErrorInterface)
+))]
 #[graphql(concrete(
     name = "InsertSupplierInvoiceError",
     params(InsertSupplierInvoiceErrorInterface)
@@ -197,7 +206,7 @@ pub struct DatabaseError(pub RepositoryError);
 #[Object]
 impl DatabaseError {
     pub async fn description(&self) -> &'static str {
-        "Dabase Error"
+        "Database Error"
     }
 
     pub async fn full_error(&self) -> String {

--- a/src/service/invoice/customer_invoice/delete/mod.rs
+++ b/src/service/invoice/customer_invoice/delete/mod.rs
@@ -1,0 +1,48 @@
+use crate::{
+    database::repository::{
+        InvoiceRepository, RepositoryError, StorageConnectionManager, TransactionError,
+    },
+    domain::invoice_line::InvoiceLine,
+};
+
+pub mod validate;
+
+use validate::validate;
+
+pub fn delete_customer_invoice(
+    connection_manager: &StorageConnectionManager,
+    id: String,
+) -> Result<String, DeleteCustomerInvoiceError> {
+    let connection = connection_manager.connection()?;
+    connection.transaction_sync(|connection| {
+        validate(&id, &connection)?;
+        InvoiceRepository::new(&connection).delete(&id)?;
+        Ok(())
+    })?;
+    Ok(id)
+}
+
+pub enum DeleteCustomerInvoiceError {
+    InvoiceDoesNotExists,
+    DatabaseError(RepositoryError),
+    NotThisStoreInvoice,
+    CannotEditFinalised,
+    InvoiceLinesExists(Vec<InvoiceLine>),
+}
+
+impl From<RepositoryError> for DeleteCustomerInvoiceError {
+    fn from(error: RepositoryError) -> Self {
+        DeleteCustomerInvoiceError::DatabaseError(error)
+    }
+}
+
+impl From<TransactionError<DeleteCustomerInvoiceError>> for DeleteCustomerInvoiceError {
+    fn from(error: TransactionError<DeleteCustomerInvoiceError>) -> Self {
+        match error {
+            TransactionError::Transaction { msg } => {
+                DeleteCustomerInvoiceError::DatabaseError(RepositoryError::DBError { msg })
+            }
+            TransactionError::Inner(e) => e,
+        }
+    }
+}

--- a/src/service/invoice/customer_invoice/delete/mod.rs
+++ b/src/service/invoice/customer_invoice/delete/mod.rs
@@ -28,6 +28,7 @@ pub enum DeleteCustomerInvoiceError {
     NotThisStoreInvoice,
     CannotEditFinalised,
     InvoiceLinesExists(Vec<InvoiceLine>),
+    NotACustomerInvoice,
 }
 
 impl From<RepositoryError> for DeleteCustomerInvoiceError {

--- a/src/service/invoice/customer_invoice/delete/validate.rs
+++ b/src/service/invoice/customer_invoice/delete/validate.rs
@@ -2,7 +2,7 @@ use crate::database::{
     repository::{
         InvoiceLineQueryRepository, InvoiceRepository, RepositoryError, StorageConnection,
     },
-    schema::{InvoiceRow, InvoiceRowStatus},
+    schema::{InvoiceRow, InvoiceRowStatus, InvoiceRowType},
 };
 
 use super::DeleteCustomerInvoiceError;
@@ -28,6 +28,11 @@ pub fn validate(
         InvoiceLineQueryRepository::new(connection).find_many_by_invoice_ids(&[id.to_string()])?;
     if lines.len() > 0 {
         return Err(DeleteCustomerInvoiceError::InvoiceLinesExists(lines));
+    }
+
+    // check its a customer invoice
+    if invoice.r#type != InvoiceRowType::CustomerInvoice {
+        return Err(DeleteCustomerInvoiceError::NotACustomerInvoice);
     }
 
     Ok(invoice)

--- a/src/service/invoice/customer_invoice/delete/validate.rs
+++ b/src/service/invoice/customer_invoice/delete/validate.rs
@@ -11,8 +11,8 @@ pub fn validate(
     id: &str,
     connection: &StorageConnection,
 ) -> Result<InvoiceRow, DeleteCustomerInvoiceError> {
-    let result = InvoiceRepository::new(connection).find_one_by_id(id);
     //  check invoice exists
+    let result = InvoiceRepository::new(connection).find_one_by_id(id);
     if let Err(RepositoryError::NotFound) = &result {
         return Err(DeleteCustomerInvoiceError::InvoiceDoesNotExists);
     }

--- a/src/service/invoice/customer_invoice/delete/validate.rs
+++ b/src/service/invoice/customer_invoice/delete/validate.rs
@@ -1,0 +1,34 @@
+use crate::database::{
+    repository::{
+        InvoiceLineQueryRepository, InvoiceRepository, RepositoryError, StorageConnection,
+    },
+    schema::{InvoiceRow, InvoiceRowStatus},
+};
+
+use super::DeleteCustomerInvoiceError;
+
+pub fn validate(
+    id: &str,
+    connection: &StorageConnection,
+) -> Result<InvoiceRow, DeleteCustomerInvoiceError> {
+    let result = InvoiceRepository::new(connection).find_one_by_id(id);
+    //  check invoice exists
+    if let Err(RepositoryError::NotFound) = &result {
+        return Err(DeleteCustomerInvoiceError::InvoiceDoesNotExists);
+    }
+    let invoice = result?;
+
+    // check invoice is not finalised
+    if invoice.status == InvoiceRowStatus::Finalised {
+        return Err(DeleteCustomerInvoiceError::CannotEditFinalised);
+    }
+
+    // check no lines exist for the invoice;
+    let lines =
+        InvoiceLineQueryRepository::new(connection).find_many_by_invoice_ids(&[id.to_string()])?;
+    if lines.len() > 0 {
+        return Err(DeleteCustomerInvoiceError::InvoiceLinesExists(lines));
+    }
+
+    Ok(invoice)
+}

--- a/src/service/invoice/customer_invoice/insert/generate.rs
+++ b/src/service/invoice/customer_invoice/insert/generate.rs
@@ -1,0 +1,65 @@
+use chrono::{NaiveDateTime, Utc};
+
+use crate::{
+    database::{
+        repository::{RepositoryError, StorageConnection, StoreRepository},
+        schema::InvoiceRow,
+    },
+    domain::{
+        customer_invoice::InsertCustomerInvoice,
+        invoice::{InvoiceStatus, InvoiceType},
+    },
+};
+
+use super::InsertCustomerInvoiceError;
+
+pub fn generate(
+    id: String,
+    input: InsertCustomerInvoice,
+    connection: &StorageConnection,
+) -> Result<InvoiceRow, InsertCustomerInvoiceError> {
+    let current_datetime = Utc::now().naive_utc();
+
+    let result = InvoiceRow {
+        id,
+        name_id: input.other_party_id,
+        r#type: InvoiceType::SupplierInvoice.into(),
+        comment: input.comment,
+        their_reference: input.their_reference,
+        invoice_number: new_invoice_number(),
+        store_id: current_store_id(connection)?,
+        confirm_datetime: confirm_datetime(&input.status, &current_datetime),
+        finalised_datetime: finalised_datetime(&input.status, &current_datetime),
+        status: input.status.into(),
+        entry_datetime: current_datetime,
+    };
+
+    Ok(result)
+}
+
+fn new_invoice_number() -> i32 {
+    // TODO Existing mSupply Mechanism for this
+    1
+}
+
+fn confirm_datetime(status: &InvoiceStatus, current_time: &NaiveDateTime) -> Option<NaiveDateTime> {
+    match status {
+        InvoiceStatus::Draft => None,
+        _ => Some(current_time.clone()),
+    }
+}
+
+fn finalised_datetime(
+    status: &InvoiceStatus,
+    current_time: &NaiveDateTime,
+) -> Option<NaiveDateTime> {
+    match status {
+        InvoiceStatus::Finalised => None,
+        _ => Some(current_time.clone()),
+    }
+}
+
+pub fn current_store_id(connection: &StorageConnection) -> Result<String, RepositoryError> {
+    // Need to check session for store
+    Ok(StoreRepository::new(connection).all()?[0].id.clone())
+}

--- a/src/service/invoice/customer_invoice/insert/generate.rs
+++ b/src/service/invoice/customer_invoice/insert/generate.rs
@@ -14,14 +14,13 @@ use crate::{
 use super::InsertCustomerInvoiceError;
 
 pub fn generate(
-    id: String,
     input: InsertCustomerInvoice,
     connection: &StorageConnection,
 ) -> Result<InvoiceRow, InsertCustomerInvoiceError> {
     let current_datetime = Utc::now().naive_utc();
 
     let result = InvoiceRow {
-        id,
+        id: input.id,
         name_id: input.other_party_id,
         r#type: InvoiceType::SupplierInvoice.into(),
         comment: input.comment,

--- a/src/service/invoice/customer_invoice/insert/mod.rs
+++ b/src/service/invoice/customer_invoice/insert/mod.rs
@@ -1,0 +1,57 @@
+use crate::{
+    database::repository::{
+        InvoiceRepository, RepositoryError, StorageConnectionManager, TransactionError,
+    },
+    domain::customer_invoice::InsertCustomerInvoice,
+    util::uuid::uuid,
+};
+
+pub mod generate;
+pub mod validate;
+
+use generate::generate;
+use validate::validate;
+
+pub enum InsertCustomerInvoiceError {
+    OtherPartyCannotBeThisStore,
+    OtherPartyIdNotFound(String),
+    OtherPartyNotACustomerOfThisStore(String),
+    InvoiceAlreadyExists,
+    DatabaseError(RepositoryError),
+}
+
+impl From<RepositoryError> for InsertCustomerInvoiceError {
+    fn from(error: RepositoryError) -> Self {
+        InsertCustomerInvoiceError::DatabaseError(error)
+    }
+}
+
+impl From<TransactionError<InsertCustomerInvoiceError>> for InsertCustomerInvoiceError {
+    fn from(error: TransactionError<InsertCustomerInvoiceError>) -> Self {
+        match error {
+            TransactionError::Transaction { msg } => {
+                InsertCustomerInvoiceError::DatabaseError(RepositoryError::DBError { msg })
+            }
+            TransactionError::Inner(e) => e,
+        }
+    }
+}
+
+/// Insert a new customer invoice and returns the invoice id when successful.
+pub fn insert_customer_invoice(
+    connection_manager: &StorageConnectionManager,
+    input: InsertCustomerInvoice,
+) -> Result<String, InsertCustomerInvoiceError> {
+    let connection = connection_manager.connection()?;
+
+    let new_invoice_id = connection.transaction_sync(|connection| {
+        let id = uuid();
+        validate(&id, &input, &connection)?;
+        let new_invoice = generate(id, input, &connection)?;
+        InvoiceRepository::new(&connection).upsert_one(&new_invoice)?;
+
+        Ok(new_invoice.id)
+    })?;
+
+    Ok(new_invoice_id)
+}

--- a/src/service/invoice/customer_invoice/insert/mod.rs
+++ b/src/service/invoice/customer_invoice/insert/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     database::repository::{
         InvoiceRepository, RepositoryError, StorageConnectionManager, TransactionError,
     },
-    domain::customer_invoice::InsertCustomerInvoice,
+    domain::{customer_invoice::InsertCustomerInvoice, name::Name},
 };
 
 pub mod generate;
@@ -14,7 +14,7 @@ use validate::validate;
 pub enum InsertCustomerInvoiceError {
     OtherPartyCannotBeThisStore,
     OtherPartyIdNotFound(String),
-    OtherPartyNotACustomerOfThisStore(String),
+    OtherPartyNotACustomer(Name),
     InvoiceAlreadyExists,
     DatabaseError(RepositoryError),
 }

--- a/src/service/invoice/customer_invoice/insert/mod.rs
+++ b/src/service/invoice/customer_invoice/insert/mod.rs
@@ -3,7 +3,6 @@ use crate::{
         InvoiceRepository, RepositoryError, StorageConnectionManager, TransactionError,
     },
     domain::customer_invoice::InsertCustomerInvoice,
-    util::uuid::uuid,
 };
 
 pub mod generate;
@@ -45,9 +44,8 @@ pub fn insert_customer_invoice(
     let connection = connection_manager.connection()?;
 
     let new_invoice_id = connection.transaction_sync(|connection| {
-        let id = uuid();
-        validate(&id, &input, &connection)?;
-        let new_invoice = generate(id, input, &connection)?;
+        validate(&input, &connection)?;
+        let new_invoice = generate(input, &connection)?;
         InvoiceRepository::new(&connection).upsert_one(&new_invoice)?;
 
         Ok(new_invoice.id)

--- a/src/service/invoice/customer_invoice/insert/validate.rs
+++ b/src/service/invoice/customer_invoice/insert/validate.rs
@@ -51,8 +51,12 @@ pub fn check_other_party_id(
         None,
     )?;
 
-    if let Some(_) = result.pop() {
-        Ok(())
+    if let Some(name) = result.pop() {
+        if name.is_customer {
+            Ok(())
+        } else {
+            Err(OtherPartyNotACustomer(name))
+        }
     } else {
         Err(OtherPartyIdNotFound(other_party_id.to_string()))
     }

--- a/src/service/invoice/customer_invoice/insert/validate.rs
+++ b/src/service/invoice/customer_invoice/insert/validate.rs
@@ -8,11 +8,10 @@ use crate::{
 use super::InsertCustomerInvoiceError;
 
 pub fn validate(
-    invoice_id: &str,
     input: &InsertCustomerInvoice,
     connection: &StorageConnection,
 ) -> Result<(), InsertCustomerInvoiceError> {
-    check_invoice_does_not_exists(invoice_id, connection)?;
+    check_invoice_does_not_exists(&input.id, connection)?;
     check_other_party_id(input, connection)?;
 
     // TODO check OtherPartyCannotBeThisStore

--- a/src/service/invoice/customer_invoice/insert/validate.rs
+++ b/src/service/invoice/customer_invoice/insert/validate.rs
@@ -1,0 +1,60 @@
+use crate::{
+    database::repository::{
+        InvoiceRepository, NameQueryRepository, RepositoryError, StorageConnection,
+    },
+    domain::{customer_invoice::InsertCustomerInvoice, name::NameFilter, Pagination},
+};
+
+use super::InsertCustomerInvoiceError;
+
+pub fn validate(
+    invoice_id: &str,
+    input: &InsertCustomerInvoice,
+    connection: &StorageConnection,
+) -> Result<(), InsertCustomerInvoiceError> {
+    check_invoice_does_not_exists(invoice_id, connection)?;
+    check_other_party_id(input, connection)?;
+
+    // TODO check OtherPartyCannotBeThisStore
+
+    // TODO add check that customer belongs to "this" store (from name_store_join?)
+    // OtherPartyNotACustomerOfThisStore
+
+    Ok(())
+}
+
+pub fn check_invoice_does_not_exists(
+    id: &str,
+    connection: &StorageConnection,
+) -> Result<(), InsertCustomerInvoiceError> {
+    let result = InvoiceRepository::new(connection).find_one_by_id(id);
+
+    if let Err(RepositoryError::NotFound) = &result {
+        Ok(())
+    } else if let Err(error) = result {
+        Err(error.into())
+    } else {
+        Err(InsertCustomerInvoiceError::InvoiceAlreadyExists)
+    }
+}
+
+pub fn check_other_party_id(
+    input: &InsertCustomerInvoice,
+    connection: &StorageConnection,
+) -> Result<(), InsertCustomerInvoiceError> {
+    use InsertCustomerInvoiceError::*;
+    let repository = NameQueryRepository::new(&connection);
+
+    let other_party_id = &input.other_party_id;
+    let mut result = repository.query(
+        Pagination::one(),
+        Some(NameFilter::new().match_id(other_party_id)),
+        None,
+    )?;
+
+    if let Some(_) = result.pop() {
+        Ok(())
+    } else {
+        Err(OtherPartyIdNotFound(other_party_id.to_string()))
+    }
+}

--- a/src/service/invoice/customer_invoice/mod.rs
+++ b/src/service/invoice/customer_invoice/mod.rs
@@ -1,2 +1,5 @@
 pub mod insert;
 pub use self::insert::*;
+
+pub mod delete;
+pub use self::delete::*;

--- a/src/service/invoice/customer_invoice/mod.rs
+++ b/src/service/invoice/customer_invoice/mod.rs
@@ -1,0 +1,2 @@
+pub mod insert;
+pub use self::insert::*;

--- a/src/service/invoice/mod.rs
+++ b/src/service/invoice/mod.rs
@@ -1,5 +1,8 @@
 pub mod query;
 pub use self::query::*;
 
+pub mod customer_invoice;
+pub use self::customer_invoice::*;
+
 pub mod supplier_invoice;
 pub use self::supplier_invoice::*;

--- a/src/service/invoice/supplier_invoice/update/generate.rs
+++ b/src/service/invoice/supplier_invoice/update/generate.rs
@@ -1,5 +1,4 @@
 use chrono::Utc;
-use uuid::Uuid;
 
 use crate::{
     database::{
@@ -8,6 +7,7 @@ use crate::{
     },
     domain::{invoice::InvoiceStatus, supplier_invoice::UpdateSupplierInvoice},
     service::invoice::current_store_id,
+    util::uuid::uuid,
 };
 
 use super::UpdateSupplierInvoiceError;
@@ -87,7 +87,7 @@ pub fn generate_batches(
     } in invoice_lines.into_iter()
     {
         result.push(StockLineRow {
-            id: Uuid::new_v4().to_string(),
+            id: uuid(),
             item_id,
             store_id: current_store_id(connection)?,
             batch,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -5,3 +5,4 @@ pub mod environment;
 pub mod settings;
 pub mod sync;
 pub mod test_db;
+pub mod uuid;

--- a/src/util/uuid.rs
+++ b/src/util/uuid.rs
@@ -1,0 +1,6 @@
+use uuid::Uuid;
+
+/// Generates unique id
+pub fn uuid() -> String {
+    Uuid::new_v4().to_string()
+}


### PR DESCRIPTION
Here is already the insert and delete part of the ticket.

- I introduced an uuid utils method (which I then don't use but I kept in anyway)
- There is a new transaction_sync() method for the StorageConnection, I plan to refactor that later (think we going fully sync right?)
- There are some validation checks that can be shared with SI. I plan to refactor that as well as soon as SI is settled. To make the reuse easier the common validation methods should return a bool or Option instead of a CommonError. 
- Due to the point above I inlined all delete checks for now. At least for these simple checks its makes things much easier to read.