### PR TITLE
#455 add customer invoice line delete mutation

### DIFF
--- a/src/domain/customer_invoice.rs
+++ b/src/domain/customer_invoice.rs
@@ -31,3 +31,8 @@ pub struct UpdateCustomerInvoiceLine {
     pub stock_line_id: Option<String>,
     pub number_of_packs: Option<u32>,
 }
+
+pub struct DeleteCustomerInvoiceLine {
+    pub id: String,
+    pub invoice_id: String,
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -5,6 +5,7 @@ pub mod item;
 pub mod name;
 pub mod stock_line;
 pub mod supplier_invoice;
+
 use chrono::NaiveDateTime;
 
 #[derive(Clone)]

--- a/src/server/service/graphql/schema/mutations/mod.rs
+++ b/src/server/service/graphql/schema/mutations/mod.rs
@@ -12,9 +12,9 @@ use crate::{
             insert_supplier_invoice, update_supplier_invoice,
         },
         invoice_line::{
-            delete_supplier_invoice_line, get_invoice_line, insert_customer_invoice_line,
-            insert_supplier_invoice_line, update_customer_invoice_line,
-            update_supplier_invoice_line,
+            delete_customer_invoice_line, delete_supplier_invoice_line, get_invoice_line,
+            insert_customer_invoice_line, insert_supplier_invoice_line,
+            update_customer_invoice_line, update_supplier_invoice_line,
         },
     },
 };
@@ -87,7 +87,9 @@ impl Mutations {
         ctx: &Context<'_>,
         input: DeleteCustomerInvoiceLineInput,
     ) -> DeleteCustomerInvoiceLineResponse {
-        todo!()
+        let connection_manager = ctx.get_repository::<StorageConnectionManager>();
+
+        delete_customer_invoice_line(connection_manager, input.into()).into()
     }
 
     async fn insert_supplier_invoice(

--- a/src/service/invoice_line/customer_invoice_line/delete/mod.rs
+++ b/src/service/invoice_line/customer_invoice_line/delete/mod.rs
@@ -1,0 +1,58 @@
+use crate::{
+    database::repository::{
+        InvoiceLineRepository, RepositoryError, StockLineRepository, StorageConnectionManager,
+    },
+    domain::customer_invoice::DeleteCustomerInvoiceLine,
+    service::WithDBError,
+};
+
+mod validate;
+
+use validate::validate;
+
+pub fn delete_customer_invoice_line(
+    connection_manager: &StorageConnectionManager,
+    input: DeleteCustomerInvoiceLine,
+) -> Result<String, DeleteCustomerInvoiceLineError> {
+    let connection = connection_manager.connection()?;
+    // TODO: do inside transaction
+    let line = validate(&input, &connection)?;
+
+    let delete_batch_id_option = line.stock_line_id.clone();
+
+    InvoiceLineRepository::new(&connection).delete(&line.id)?;
+
+    if let Some(id) = delete_batch_id_option {
+        StockLineRepository::new(&connection).delete(&id)?;
+    }
+
+    Ok(line.id)
+}
+
+pub enum DeleteCustomerInvoiceLineError {
+    LineDoesNotExist,
+    DatabaseError(RepositoryError),
+    InvoiceDoesNotExist,
+    NotACustomerInvoice,
+    NotThisStoreInvoice,
+    CannotEditFinalised,
+    NotThisInvoiceLine(String),
+}
+
+impl From<RepositoryError> for DeleteCustomerInvoiceLineError {
+    fn from(error: RepositoryError) -> Self {
+        DeleteCustomerInvoiceLineError::DatabaseError(error)
+    }
+}
+
+impl<ERR> From<WithDBError<ERR>> for DeleteCustomerInvoiceLineError
+where
+    ERR: Into<DeleteCustomerInvoiceLineError>,
+{
+    fn from(result: WithDBError<ERR>) -> Self {
+        match result {
+            WithDBError::DatabaseError(error) => error.into(),
+            WithDBError::Error(error) => error.into(),
+        }
+    }
+}

--- a/src/service/invoice_line/customer_invoice_line/delete/validate.rs
+++ b/src/service/invoice_line/customer_invoice_line/delete/validate.rs
@@ -1,0 +1,59 @@
+use crate::{
+    database::{repository::StorageConnection, schema::InvoiceLineRow},
+    domain::{customer_invoice::DeleteCustomerInvoiceLine, invoice::InvoiceType},
+    service::{
+        invoice::{
+            check_invoice_exists, check_invoice_finalised, check_invoice_type,
+            validate::InvoiceIsFinalised, InvoiceDoesNotExist, WrongInvoiceType,
+        },
+        invoice_line::validate::{
+            check_line_belongs_to_invoice, check_line_exists, LineDoesNotExist, NotInvoiceLine,
+        },
+    },
+};
+
+use super::DeleteCustomerInvoiceLineError;
+
+pub fn validate(
+    input: &DeleteCustomerInvoiceLine,
+    connection: &StorageConnection,
+) -> Result<InvoiceLineRow, DeleteCustomerInvoiceLineError> {
+    let line = check_line_exists(&input.id, connection)?;
+    let invoice = check_invoice_exists(&input.invoice_id, connection)?;
+
+    check_line_belongs_to_invoice(&line, &invoice)?;
+    check_invoice_type(&invoice, InvoiceType::CustomerInvoice)?;
+    check_invoice_finalised(&invoice)?;
+
+    Ok(line)
+}
+
+impl From<LineDoesNotExist> for DeleteCustomerInvoiceLineError {
+    fn from(_: LineDoesNotExist) -> Self {
+        DeleteCustomerInvoiceLineError::LineDoesNotExist
+    }
+}
+
+impl From<WrongInvoiceType> for DeleteCustomerInvoiceLineError {
+    fn from(_: WrongInvoiceType) -> Self {
+        DeleteCustomerInvoiceLineError::NotACustomerInvoice
+    }
+}
+
+impl From<InvoiceIsFinalised> for DeleteCustomerInvoiceLineError {
+    fn from(_: InvoiceIsFinalised) -> Self {
+        DeleteCustomerInvoiceLineError::CannotEditFinalised
+    }
+}
+
+impl From<NotInvoiceLine> for DeleteCustomerInvoiceLineError {
+    fn from(error: NotInvoiceLine) -> Self {
+        DeleteCustomerInvoiceLineError::NotThisInvoiceLine(error.0)
+    }
+}
+
+impl From<InvoiceDoesNotExist> for DeleteCustomerInvoiceLineError {
+    fn from(_: InvoiceDoesNotExist) -> Self {
+        DeleteCustomerInvoiceLineError::InvoiceDoesNotExist
+    }
+}

--- a/src/service/invoice_line/customer_invoice_line/mod.rs
+++ b/src/service/invoice_line/customer_invoice_line/mod.rs
@@ -2,6 +2,8 @@ pub mod insert;
 pub use self::insert::*;
 pub mod update;
 pub use self::update::*;
+pub mod delete;
+pub use self::delete::*;
 
 pub mod validate;
 pub use self::validate::*;


### PR DESCRIPTION
Closes #455.

Mostly reuses existing supplier invoice line logic. Hopefully not missing anything major!

Example mutation:

```
mutation {
  deleteCustomerInvoiceLine(input: {id: "id", invoiceId: "invoiceId"}) {
    __typename
    ... on DeleteResponse {
      __typename
      id
    }
    ... on DeleteCustomerInvoiceLineError {
      error {
         __typename
        description
      }
    }
  }
}
```