### PR TITLE
474 finalise supplier invoice mutations

### DIFF
--- a/src/database/mock/name.rs
+++ b/src/database/mock/name.rs
@@ -30,10 +30,21 @@ pub fn mock_name_store_c() -> NameRow {
     }
 }
 
+pub fn mock_name_a() -> NameRow {
+    NameRow {
+        id: String::from("name_a"),
+        name: String::from("name_a"),
+        code: String::from("name_a"),
+        is_customer: false,
+        is_supplier: true,
+    }
+}
+
 pub fn mock_names() -> Vec<NameRow> {
     vec![
         mock_name_store_a(),
         mock_name_store_b(),
         mock_name_store_c(),
+        mock_name_a(),
     ]
 }

--- a/src/database/mock/name_store_join.rs
+++ b/src/database/mock/name_store_join.rs
@@ -30,10 +30,21 @@ pub fn mock_name_store_join_c() -> NameStoreJoinRow {
     }
 }
 
+pub fn mock_name_store_join_d() -> NameStoreJoinRow {
+    NameStoreJoinRow {
+        id: String::from("mock_name_store_join_d"),
+        name_id: String::from("name_a"),
+        store_id: String::from("store_a"),
+        name_is_customer: false,
+        name_is_supplier: true,
+    }
+}
+
 pub fn mock_name_store_joins() -> Vec<NameStoreJoinRow> {
     vec![
         mock_name_store_join_a(),
         mock_name_store_join_b(),
         mock_name_store_join_c(),
+        mock_name_store_join_d(),
     ]
 }

--- a/tests/graphql/common.rs
+++ b/tests/graphql/common.rs
@@ -18,6 +18,16 @@ macro_rules! get_invoice_lines_inline {
     }};
 }
 
+macro_rules! get_name_inline {
+    ($filter:expr, $connection:expr) => {{
+        remote_server::database::repository::NameQueryRepository::new($connection)
+            .query(Pagination::one(), Some($filter), None)
+            .unwrap()
+            .pop()
+            .unwrap()
+    }};
+}
+
 macro_rules! assert_unwrap_enum {
     ($enum:ident, $variant:path) => {{
         let debug = format!("{:#?}", $enum);
@@ -71,8 +81,20 @@ where
     serde_json::from_str(&serde_json::to_string(&f).unwrap()).unwrap()
 }
 
+pub fn compare_option<A, B>(a: &Option<A>, b: &B) -> bool
+where
+    B: PartialEq<A>,
+{
+    if let Some(a) = a {
+        b == a
+    } else {
+        true
+    }
+}
+
 pub(crate) use assert_matches;
 pub(crate) use assert_unwrap_enum;
 pub(crate) use assert_unwrap_optional_key;
 pub(crate) use get_invoice_inline;
 pub(crate) use get_invoice_lines_inline;
+pub(crate) use get_name_inline;

--- a/tests/graphql/delete_supplier_invoice.rs
+++ b/tests/graphql/delete_supplier_invoice.rs
@@ -1,17 +1,57 @@
 mod graphql {
+    use crate::graphql::common::{assert_matches, get_invoice_lines_inline};
+    use crate::graphql::common::{
+        assert_unwrap_enum, assert_unwrap_optional_key, get_invoice_inline,
+    };
     use crate::graphql::get_gql_result;
     use crate::graphql::{
         delete_supplier_invoice_full as delete, DeleteSupplierInvoiceFull as Delete,
     };
 
     use graphql_client::{GraphQLQuery, Response};
-    use remote_server::database::repository::InvoiceLineRepository;
+    use remote_server::database::repository::{InvoiceLineRepository, RepositoryError};
     use remote_server::{
-        database::{mock::MockDataInserts, repository::InvoiceQueryRepository},
+        database::mock::MockDataInserts,
         domain::{invoice::InvoiceFilter, Pagination},
         util::test_db,
     };
-    use std::convert::TryInto;
+
+    use delete::DeleteSupplierInvoiceErrorInterface::*;
+
+    macro_rules! assert_unwrap_response_variant {
+        ($response:ident) => {
+            assert_unwrap_optional_key!($response, data).delete_supplier_invoice
+        };
+    }
+
+    macro_rules! assert_unwrap_delete {
+        ($response:ident) => {{
+            let response_variant = assert_unwrap_response_variant!($response);
+            assert_unwrap_enum!(
+                response_variant,
+                delete::DeleteSupplierInvoiceResponse::DeleteResponse
+            )
+        }};
+    }
+
+    macro_rules! assert_unwrap_error {
+        ($response:ident) => {{
+            let response_variant = assert_unwrap_response_variant!($response);
+            let error_wrapper = assert_unwrap_enum!(
+                response_variant,
+                delete::DeleteSupplierInvoiceResponse::DeleteSupplierInvoiceError
+            );
+            error_wrapper.error
+        }};
+    }
+
+    macro_rules! assert_error {
+        ($response:ident, $error:expr) => {{
+            let lhs = assert_unwrap_error!($response);
+            let rhs = $error;
+            assert_eq!(lhs, rhs);
+        }};
+    }
 
     #[actix_rt::test]
     async fn test_delete_supplier_invoice() {
@@ -19,150 +59,108 @@ mod graphql {
             test_db::setup_all("test_delete_supplier_invoice_query", MockDataInserts::all()).await;
 
         // Setup
-        let id1 = "invalid";
         let invoice_with_lines_id = "supplier_invoice_a";
         let empty_draft_invoice_id = "empty_draft_supplier_invoice";
 
-        let finalised_supplier_invoice = InvoiceQueryRepository::new(&connection)
-            .query(
-                Pagination::one(),
-                Some(
-                    InvoiceFilter::new()
-                        .match_supplier_invoice()
-                        .match_finalised(),
-                ),
-                None,
-            )
-            .unwrap()
-            .pop()
-            .unwrap();
-        let customer_invoice = InvoiceQueryRepository::new(&connection)
-            .query(
-                Pagination::one(),
-                Some(InvoiceFilter::new().match_customer_invoice()),
-                None,
-            )
-            .unwrap()
-            .pop()
-            .unwrap();
+        let finalised_supplier_invoice = get_invoice_inline!(
+            InvoiceFilter::new()
+                .match_supplier_invoice()
+                .match_finalised(),
+            &connection
+        );
 
-        let lines_in_invoice_with_lines = InvoiceLineRepository::new(&connection)
-            .find_many_by_invoice_id(&invoice_with_lines_id)
-            .unwrap();
+        let customer_invoice =
+            get_invoice_inline!(InvoiceFilter::new().match_customer_invoice(), &connection);
+        let lines_in_invoice = get_invoice_lines_inline!(invoice_with_lines_id, &connection);
+
+        let base_variables = delete::Variables {
+            id: empty_draft_invoice_id.to_string(),
+        };
 
         // Test RecordDoesNotExist
 
-        let current_id = id1.to_string();
+        let mut variables = base_variables.clone();
+        variables.id = "invalid".to_string();
 
-        let query = Delete::build_query(delete::Variables { id: current_id });
+        let query = Delete::build_query(variables);
         let response: Response<delete::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = delete::ResponseData {
-            delete_supplier_invoice:
-                delete::DeleteSupplierInvoiceResponse::DeleteSupplierInvoiceError(
-                    delete::DeleteSupplierInvoiceError {
-                        error: delete::DeleteSupplierInvoiceErrorInterface::RecordDoesNotExist(
-                            delete::RecordDoesNotExist {
-                                description: "Record does not exist".to_string(),
-                            },
-                        ),
-                    },
-                ),
-        };
-        println!("{:#?}", response);
-        assert_eq!(response.data.unwrap(), expected);
+
+        assert_error!(
+            response,
+            RecordDoesNotExist(delete::RecordDoesNotExist {
+                description: "Record does not exist".to_string(),
+            },)
+        );
 
         // Test NotASupplierInvoice
 
-        let current_id = customer_invoice.id.clone();
+        let mut variables = base_variables.clone();
+        variables.id = customer_invoice.id.clone();
 
-        let query = Delete::build_query(delete::Variables { id: current_id });
+        let query = Delete::build_query(variables);
         let response: Response<delete::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = delete::ResponseData {
-            delete_supplier_invoice:
-                delete::DeleteSupplierInvoiceResponse::DeleteSupplierInvoiceError(
-                    delete::DeleteSupplierInvoiceError {
-                        error: delete::DeleteSupplierInvoiceErrorInterface::NotASupplierInvoice(
-                            delete::NotASupplierInvoice {
-                                description: "Invoice is not Supplier Invoice".to_string(),
-                            },
-                        ),
-                    },
-                ),
-        };
-        assert_eq!(response.data.unwrap(), expected);
+
+        assert_error!(
+            response,
+            NotASupplierInvoice(delete::NotASupplierInvoice {
+                description: "Invoice is not Supplier Invoice".to_string(),
+            },)
+        );
 
         // Test CannotEditFinalisedInvoice
 
-        let current_id = finalised_supplier_invoice.id.clone();
+        let mut variables = base_variables.clone();
+        variables.id = finalised_supplier_invoice.id.clone();
 
-        let query = Delete::build_query(delete::Variables { id: current_id });
+        let query = Delete::build_query(variables);
         let response: Response<delete::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = delete::ResponseData {
-            delete_supplier_invoice:
-                delete::DeleteSupplierInvoiceResponse::DeleteSupplierInvoiceError(
-                    delete::DeleteSupplierInvoiceError {
-                        error:
-                            delete::DeleteSupplierInvoiceErrorInterface::CannotEditFinalisedInvoice(
-                                delete::CannotEditFinalisedInvoice {
-                                    description: "Cannot edit finalised invoice".to_string(),
-                                },
-                            ),
-                    },
-                ),
-        };
 
-        assert_eq!(response.data.unwrap(), expected);
+        assert_error!(
+            response,
+            CannotEditFinalisedInvoice(delete::CannotEditFinalisedInvoice {
+                description: "Cannot edit finalised invoice".to_string(),
+            },)
+        );
 
         // Test CannotDeleteInvoiceWithLines
 
-        let current_id = invoice_with_lines_id.to_string();
+        let mut variables = base_variables.clone();
+        variables.id = invoice_with_lines_id.to_string();
 
-        let query = Delete::build_query(delete::Variables { id: current_id });
+        let query = Delete::build_query(variables);
         let response: Response<delete::ResponseData> = get_gql_result(&settings, query).await;
 
-        let mut lines_count: usize = 0;
-        if let delete::DeleteSupplierInvoiceResponse::DeleteSupplierInvoiceError(
-            delete::DeleteSupplierInvoiceError {
-                error: error_interface,
-            },
-        ) = response.data.unwrap().delete_supplier_invoice
-        {
-            if let delete::DeleteSupplierInvoiceErrorInterface::CannotDeleteInvoiceWithLines(
-                delete::CannotDeleteInvoiceWithLines { lines, .. },
-            ) = error_interface
-            {
-                lines_count = lines.total_count.try_into().unwrap();
-            }
-        }
+        let error_variant = assert_unwrap_error!(response);
+        let error = assert_unwrap_enum!(error_variant, CannotDeleteInvoiceWithLines);
+        let lines = error.lines.nodes;
 
-        assert_eq!(lines_count, lines_in_invoice_with_lines.len());
+        let mut api_lines: Vec<String> = lines.into_iter().map(|line| line.id).collect();
+
+        let mut db_lines: Vec<String> = lines_in_invoice.into_iter().map(|line| line.id).collect();
+
+        api_lines.sort();
+        db_lines.sort();
+
+        assert_eq!(api_lines, db_lines);
 
         // Test Success
 
-        let current_id = empty_draft_invoice_id.to_string();
+        let mut variables = base_variables.clone();
+        variables.id = empty_draft_invoice_id.to_string();
 
-        let query = Delete::build_query(delete::Variables {
-            id: current_id.clone(),
-        });
+        let query = Delete::build_query(variables.clone());
         let response: Response<delete::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = delete::ResponseData {
-            delete_supplier_invoice: delete::DeleteSupplierInvoiceResponse::DeleteResponse(
-                delete::DeleteResponse {
-                    id: current_id.clone(),
-                },
-            ),
-        };
+        let delete_response = assert_unwrap_delete!(response);
 
-        assert_eq!(response.data.unwrap(), expected);
+        let deleted_invoice = InvoiceLineRepository::new(&connection).find_one_by_id(&variables.id);
 
-        let deleted_invoice = InvoiceQueryRepository::new(&connection)
-            .query(
-                Pagination::one(),
-                Some(InvoiceFilter::new().match_id(&current_id)),
-                None,
-            )
-            .unwrap();
+        assert_eq!(
+            delete_response,
+            delete::DeleteResponse {
+                id: variables.id.clone()
+            }
+        );
 
-        assert_eq!(0, deleted_invoice.len());
+        assert_matches!(deleted_invoice, Err(RepositoryError::NotFound));
     }
 }

--- a/tests/graphql/insert_supplier_invoice.rs
+++ b/tests/graphql/insert_supplier_invoice.rs
@@ -1,36 +1,60 @@
 mod graphql {
-    use crate::graphql::get_gql_result;
+    use crate::graphql::{
+        common::{assert_unwrap_enum, assert_unwrap_optional_key, get_name_inline},
+        get_gql_result,
+    };
     use chrono::{Duration, Utc};
     use graphql_client::{GraphQLQuery, Response};
     use remote_server::{
         database::{
             mock::MockDataInserts,
-            repository::{InvoiceQueryRepository, NameQueryRepository},
+            repository::InvoiceRepository,
+            schema::{InvoiceRow, InvoiceRowStatus, InvoiceRowType},
         },
-        domain::{
-            invoice::InvoiceFilter,
-            name::{Name, NameFilter},
-            DatetimeFilter, Pagination,
-        },
+        domain::{name::NameFilter, Pagination},
         util::test_db,
     };
     use uuid::Uuid;
 
     use crate::graphql::{
-        insert_supplier_invoice_full as full, insert_supplier_invoice_partial as partial,
-        InsertSupplierInvoiceFull as Full, InsertSupplierInvoicePartial as Partial,
+        insert_supplier_invoice_full as insert, InsertSupplierInvoiceFull as Insert,
     };
 
-    impl From<Name> for full::NameNode {
-        fn from(n: Name) -> Self {
-            full::NameNode {
-                code: n.code,
-                id: n.id,
-                is_customer: n.is_customer,
-                is_supplier: n.is_supplier,
-                name: n.name,
-            }
-        }
+    use insert::InsertSupplierInvoiceErrorInterface::*;
+
+    macro_rules! assert_unwrap_response_variant {
+        ($response:ident) => {
+            assert_unwrap_optional_key!($response, data).insert_supplier_invoice
+        };
+    }
+
+    macro_rules! assert_unwrap_invoice_response {
+        ($response:ident) => {{
+            let response_variant = assert_unwrap_response_variant!($response);
+            assert_unwrap_enum!(
+                response_variant,
+                insert::InsertSupplierInvoiceResponse::InvoiceNode
+            )
+        }};
+    }
+
+    macro_rules! assert_unwrap_error {
+        ($response:ident) => {{
+            let response_variant = assert_unwrap_response_variant!($response);
+            let error_wrapper = assert_unwrap_enum!(
+                response_variant,
+                insert::InsertSupplierInvoiceResponse::InsertSupplierInvoiceError
+            );
+            error_wrapper.error
+        }};
+    }
+
+    macro_rules! assert_error {
+        ($response:ident, $error:expr) => {{
+            let lhs = assert_unwrap_error!($response);
+            let rhs = $error;
+            assert_eq!(lhs, rhs);
+        }};
     }
 
     #[actix_rt::test]
@@ -44,230 +68,171 @@ mod graphql {
             .naive_utc()
             .checked_add_signed(Duration::seconds(5))
             .unwrap();
-        let id1 = Uuid::new_v4().to_string();
-        let id2 = Uuid::new_v4().to_string();
-        let id3 = Uuid::new_v4().to_string();
-        let id4 = Uuid::new_v4().to_string();
-        let id5 = Uuid::new_v4().to_string();
-        let comment = "some comment";
-        let their_reference = "some reference";
-        let not_supplier = NameQueryRepository::new(&connection)
-            .query(
-                Pagination::one(),
-                Some(NameFilter::new().match_is_supplier(false)),
-                None,
-            )
-            .unwrap()
-            .pop()
-            .unwrap();
-        let supplier = NameQueryRepository::new(&connection)
-            .query(
-                Pagination::one(),
-                Some(NameFilter::new().match_is_supplier(true)),
-                None,
-            )
-            .unwrap()
-            .pop()
-            .unwrap();
+
+        let not_supplier =
+            get_name_inline!(NameFilter::new().match_is_supplier(false), &connection);
+        let supplier = get_name_inline!(NameFilter::new().match_is_supplier(true), &connection);
+
+        let base_variables = insert::Variables {
+            id: Uuid::new_v4().to_string(),
+            other_party_id_isi: supplier.id.clone(),
+            status_isi: insert::InvoiceNodeStatus::Draft,
+            comment_isi: Some("some comment".to_string()),
+            their_reference_isi: Some("some reference".to_string()),
+        };
 
         // Test ForeingKeyError
 
-        let current_id = id1;
+        let mut variables = base_variables.clone();
+        variables.other_party_id_isi = "invalid".to_string();
 
-        let query = Full::build_query(full::Variables {
-            id: current_id,
-            other_party_id_isi: "invalid".to_string(),
-            status_isi: full::InvoiceNodeStatus::Draft,
-            comment_isi: None,
-            their_reference_isi: None,
-        });
-        let response: Response<full::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = full::ResponseData {
-            insert_supplier_invoice:
-                full::InsertSupplierInvoiceResponse::InsertSupplierInvoiceError(
-                    full::InsertSupplierInvoiceError {
-                        error: full::InsertSupplierInvoiceErrorInterface::ForeignKeyError(
-                            full::ForeignKeyError {
-                                description: "FK record doesn't exist".to_string(),
-                                key: full::ForeignKey::OtherPartyId,
-                            },
-                        ),
-                    },
-                ),
-        };
-        assert_eq!(response.data.unwrap(), expected);
+        let query = Insert::build_query(variables);
+        let response: Response<insert::ResponseData> = get_gql_result(&settings, query).await;
+
+        assert_error!(
+            response,
+            ForeignKeyError(insert::ForeignKeyError {
+                description: "FK record doesn't exist".to_string(),
+                key: insert::ForeignKey::OtherPartyId,
+            },)
+        );
 
         // Test OtherPartyNotASupplier
 
-        let current_id = id2;
+        let mut variables = base_variables.clone();
+        variables.other_party_id_isi = not_supplier.id.clone();
 
-        let query = Full::build_query(full::Variables {
-            id: current_id,
-            other_party_id_isi: not_supplier.id.clone(),
-            status_isi: full::InvoiceNodeStatus::Draft,
-            comment_isi: None,
-            their_reference_isi: None,
-        });
-        let response: Response<full::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = full::ResponseData {
-            insert_supplier_invoice:
-                full::InsertSupplierInvoiceResponse::InsertSupplierInvoiceError(
-                    full::InsertSupplierInvoiceError {
-                        error: full::InsertSupplierInvoiceErrorInterface::OtherPartyNotASupplier(
-                            full::OtherPartyNotASupplier {
-                                description: "Other party name is not a supplier".to_string(),
-                                other_party: not_supplier.into(),
-                            },
-                        ),
-                    },
-                ),
-        };
-        assert_eq!(response.data.unwrap(), expected);
+        let query = Insert::build_query(variables);
+        let response: Response<insert::ResponseData> = get_gql_result(&settings, query).await;
+
+        let error_variant = assert_unwrap_error!(response);
+        let error = assert_unwrap_enum!(error_variant, OtherPartyNotASupplier);
+
+        assert_eq!(error.other_party.id, not_supplier.id.clone());
 
         // Test Success
 
-        let current_id = id3.clone();
+        let variables = base_variables.clone();
 
-        let query = Partial::build_query(partial::Variables {
-            id: current_id.clone(),
-            other_party_id_isi: supplier.id.clone(),
-            status_isi: partial::InvoiceNodeStatus::Draft,
-            comment_isi: None,
-            their_reference_isi: None,
-        });
-        let response: Response<partial::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = partial::ResponseData {
-            insert_supplier_invoice: partial::InsertSupplierInvoiceResponsePartial::InvoiceNode(
-                partial::PartialInvoiceNode {
-                    id: current_id.clone(),
-                    status: partial::InvoiceNodeStatus::Draft,
-                    type_: partial::InvoiceNodeType::SupplierInvoice,
-                },
-            ),
-        };
-        assert_eq!(response.data.unwrap(), expected);
-        let invoice = InvoiceQueryRepository::new(&connection)
-            .query(
-                Pagination::one(),
-                Some(
-                    InvoiceFilter::new()
-                        .match_id(&current_id)
-                        .set_entry_datetime(DatetimeFilter::date_range(start, end)),
-                ),
-                None,
-            )
-            .unwrap()
-            .pop()
+        let query = Insert::build_query(variables.clone());
+        let response: Response<insert::ResponseData> = get_gql_result(&settings, query).await;
+
+        let invoice = assert_unwrap_invoice_response!(response);
+        assert_eq!(invoice.id, variables.id);
+
+        let new_invoice = InvoiceRepository::new(&connection)
+            .find_one_by_id(&variables.id)
             .unwrap();
-        assert_eq!(invoice.id, current_id);
-        assert_eq!(invoice.other_party_name, supplier.name);
-        assert_eq!(invoice.confirm_datetime, None);
-        assert_eq!(invoice.finalised_datetime, None);
+
+        assert_eq!(new_invoice.r#type, InvoiceRowType::SupplierInvoice);
+
+        assert_eq!(new_invoice, variables);
+        assert!(new_invoice.entry_datetime > start);
+        assert!(new_invoice.entry_datetime < end);
+        assert_eq!(new_invoice.confirm_datetime, None);
+        assert_eq!(new_invoice.finalised_datetime, None);
 
         // Test RecordAlreadyExist
 
-        let duplicated_id = id3;
-        let query = Full::build_query(full::Variables {
-            id: duplicated_id,
-            other_party_id_isi: supplier.id.clone(),
-            status_isi: full::InvoiceNodeStatus::Draft,
-            comment_isi: None,
-            their_reference_isi: None,
-        });
-        let response: Response<full::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = full::ResponseData {
-            insert_supplier_invoice:
-                full::InsertSupplierInvoiceResponse::InsertSupplierInvoiceError(
-                    full::InsertSupplierInvoiceError {
-                        error: full::InsertSupplierInvoiceErrorInterface::RecordAlreadyExist(
-                            full::RecordAlreadyExist {
-                                description: "Record already exists".to_string(),
-                            },
-                        ),
-                    },
-                ),
-        };
-        assert_eq!(response.data.unwrap(), expected);
+        let variables = base_variables.clone();
+
+        let query = Insert::build_query(variables.clone());
+        let response: Response<insert::ResponseData> = get_gql_result(&settings, query).await;
+
+        assert_error!(
+            response,
+            RecordAlreadyExist(insert::RecordAlreadyExist {
+                description: "Record already exists".to_string(),
+            },)
+        );
 
         // Test Confirmed
 
-        let current_id = id4;
-        let query = Partial::build_query(partial::Variables {
-            id: current_id.clone(),
-            other_party_id_isi: supplier.id.clone(),
-            status_isi: partial::InvoiceNodeStatus::Confirmed,
-            comment_isi: None,
-            their_reference_isi: None,
-        });
-        let response: Response<partial::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = partial::ResponseData {
-            insert_supplier_invoice: partial::InsertSupplierInvoiceResponsePartial::InvoiceNode(
-                partial::PartialInvoiceNode {
-                    id: current_id.clone(),
-                    status: partial::InvoiceNodeStatus::Confirmed,
-                    type_: partial::InvoiceNodeType::SupplierInvoice,
-                },
-            ),
-        };
-        assert_eq!(response.data.unwrap(), expected);
-        let invoice = InvoiceQueryRepository::new(&connection)
-            .query(
-                Pagination::one(),
-                Some(
-                    InvoiceFilter::new()
-                        .match_id(&current_id)
-                        .set_entry_datetime(DatetimeFilter::date_range(start, end))
-                        .set_confirm_datetime(DatetimeFilter::date_range(start, end)),
-                ),
-                None,
-            )
-            .unwrap()
-            .pop()
+        let mut variables = base_variables.clone();
+        variables.id = Uuid::new_v4().to_string();
+        variables.status_isi = insert::InvoiceNodeStatus::Confirmed;
+        variables.comment_isi = None;
+        variables.their_reference_isi = None;
+
+        let query = Insert::build_query(variables.clone());
+        let response: Response<insert::ResponseData> = get_gql_result(&settings, query).await;
+
+        let invoice = assert_unwrap_invoice_response!(response);
+        assert_eq!(invoice.id, variables.id);
+
+        let new_invoice = InvoiceRepository::new(&connection)
+            .find_one_by_id(&variables.id)
             .unwrap();
 
-        assert_eq!(invoice.id, current_id);
-        assert_eq!(invoice.finalised_datetime, None);
-        assert_eq!(invoice.comment, None);
-        assert_eq!(invoice.their_reference, None);
+        assert_eq!(new_invoice.r#type, InvoiceRowType::SupplierInvoice);
 
-        // Test Finaized, comment and thier_reference
+        assert_eq!(new_invoice, variables);
+        assert!(new_invoice.entry_datetime > start);
+        assert!(new_invoice.entry_datetime < end);
 
-        let current_id = id5;
-        let query = Partial::build_query(partial::Variables {
-            id: current_id.clone(),
-            other_party_id_isi: supplier.id.clone(),
-            status_isi: partial::InvoiceNodeStatus::Finalised,
-            comment_isi: Some(comment.to_string()),
-            their_reference_isi: Some(their_reference.to_string()),
-        });
-        let response: Response<partial::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = partial::ResponseData {
-            insert_supplier_invoice: partial::InsertSupplierInvoiceResponsePartial::InvoiceNode(
-                partial::PartialInvoiceNode {
-                    id: current_id.clone(),
-                    status: partial::InvoiceNodeStatus::Finalised,
-                    type_: partial::InvoiceNodeType::SupplierInvoice,
-                },
-            ),
-        };
-        assert_eq!(response.data.unwrap(), expected);
-        let invoice = InvoiceQueryRepository::new(&connection)
-            .query(
-                Pagination::one(),
-                Some(
-                    InvoiceFilter::new()
-                        .match_id(&current_id)
-                        .set_entry_datetime(DatetimeFilter::date_range(start, end))
-                        .set_confirm_datetime(DatetimeFilter::date_range(start, end))
-                        .set_finalised_datetime(DatetimeFilter::date_range(start, end)),
-                ),
-                None,
-            )
-            .unwrap()
-            .pop()
+        let confirmed_datetime = new_invoice.confirm_datetime.unwrap();
+        assert!(confirmed_datetime > start);
+        assert!(confirmed_datetime < end);
+
+        assert_eq!(new_invoice.finalised_datetime, None);
+
+        // Test Finaized
+
+        let mut variables = base_variables.clone();
+        variables.id = Uuid::new_v4().to_string();
+        variables.status_isi = insert::InvoiceNodeStatus::Finalised;
+
+        let query = Insert::build_query(variables.clone());
+        let response: Response<insert::ResponseData> = get_gql_result(&settings, query).await;
+
+        let invoice = assert_unwrap_invoice_response!(response);
+        assert_eq!(invoice.id, variables.id);
+
+        let new_invoice = InvoiceRepository::new(&connection)
+            .find_one_by_id(&variables.id)
             .unwrap();
-        assert_eq!(invoice.id, current_id);
-        assert_eq!(invoice.comment, Some(comment.to_string()));
-        assert_eq!(invoice.their_reference, Some(their_reference.to_string()));
+
+        assert_eq!(new_invoice.r#type, InvoiceRowType::SupplierInvoice);
+        assert_eq!(new_invoice, variables);
+
+        assert!(new_invoice.entry_datetime > start);
+        assert!(new_invoice.entry_datetime < end);
+
+        let confirmed_datetime = new_invoice.confirm_datetime.unwrap();
+        assert!(confirmed_datetime > start);
+        assert!(confirmed_datetime < end);
+
+        let finalised_datetime = new_invoice.confirm_datetime.unwrap();
+        assert!(finalised_datetime > start);
+        assert!(finalised_datetime < end);
+    }
+
+    impl From<InvoiceRowStatus> for insert::InvoiceNodeStatus {
+        fn from(status: InvoiceRowStatus) -> Self {
+            use insert::InvoiceNodeStatus::*;
+            match status {
+                InvoiceRowStatus::Draft => Draft,
+                InvoiceRowStatus::Confirmed => Confirmed,
+                InvoiceRowStatus::Finalised => Finalised,
+            }
+        }
+    }
+
+    impl PartialEq<insert::Variables> for InvoiceRow {
+        fn eq(&self, other: &insert::Variables) -> bool {
+            let insert::Variables {
+                id,
+                other_party_id_isi,
+                status_isi,
+                comment_isi,
+                their_reference_isi,
+            } = other;
+
+            *id == self.id
+                && *other_party_id_isi == self.name_id
+                && *status_isi == self.status.clone().into()
+                && *comment_isi == self.comment
+                && *their_reference_isi == self.their_reference
+        }
     }
 }

--- a/tests/graphql/mod.rs
+++ b/tests/graphql/mod.rs
@@ -147,16 +147,7 @@ type DateTime = ChronoDateTime<Utc>;
     normalization = "Rust"
 )]
 pub struct InsertSupplierInvoiceFull;
-#[derive(GraphQLQuery)]
-#[graphql(
-    schema_path = "tests/graphql/schema.graphql",
-    query_path = "tests/graphql/query.graphql",
-    response_derives = "Debug,PartialEq,Clone,Serialize",
-    variables_derives = "Debug,PartialEq",
-    Clone,
-    normalization = "Rust"
-)]
-pub struct InsertSupplierInvoicePartial;
+
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "tests/graphql/schema.graphql",
@@ -166,15 +157,6 @@ pub struct InsertSupplierInvoicePartial;
     normalization = "Rust"
 )]
 pub struct UpdateSupplierInvoiceFull;
-#[derive(GraphQLQuery)]
-#[graphql(
-    schema_path = "tests/graphql/schema.graphql",
-    query_path = "tests/graphql/query.graphql",
-    response_derives = "Debug,PartialEq,Clone,Serialize",
-    variables_derives = "Debug,PartialEq,Clone",
-    normalization = "Rust"
-)]
-pub struct UpdateSupplierInvoicePartial;
 
 #[derive(GraphQLQuery)]
 #[graphql(

--- a/tests/graphql/names.rs
+++ b/tests/graphql/names.rs
@@ -25,7 +25,9 @@ mod graphql {
         let name_repository = NameRepository::new(&connection);
         let store_repository = StoreRepository::new(&connection);
         let name_store_repository = NameStoreJoinRepository::new(&connection);
-        let mock_names: Vec<NameRow> = mock_names();
+        let mut mock_names: Vec<NameRow> = mock_names();
+        mock_names.sort_by(|a, b| a.id.cmp(&b.id));
+
         let mock_stores: Vec<StoreRow> = mock_stores();
         let mock_name_store_joins: Vec<NameStoreJoinRow> = mock_name_store_joins();
         for name in &mock_names {

--- a/tests/graphql/query.graphql
+++ b/tests/graphql/query.graphql
@@ -22,38 +22,11 @@ mutation insertSupplierInvoiceFull(
   }
 }
 
-mutation insertSupplierInvoicePartial(
-  $id: String!
-  $otherPartyId_isi: String!
-  $status_isi: InvoiceNodeStatus!
-  $comment_isi: String
-  $theirReference_isi: String
-) {
-  insertSupplierInvoice(
-    input: {
-      id: $id
-      otherPartyId: $otherPartyId_isi
-      status: $status_isi
-      theirReference: $theirReference_isi
-      comment: $comment_isi
-    }
-  ) {
-    ...InsertSupplierInvoiceResponsePartial
-  }
-}
-
 fragment InsertSupplierInvoiceResponse on InsertSupplierInvoiceResponse {
   __typename
   ...InsertSupplierInvoiceError
   ...NodeError
   ...InvoiceNode
-}
-
-fragment InsertSupplierInvoiceResponsePartial on InsertSupplierInvoiceResponse {
-  __typename
-  ...InsertSupplierInvoiceError
-  ...NodeError
-  ...PartialInvoiceNode
 }
 
 fragment InsertSupplierInvoiceError on InsertSupplierInvoiceError {
@@ -92,38 +65,11 @@ mutation updateSupplierInvoiceFull(
   }
 }
 
-mutation updateSupplierInvoicePartial(
-  $id: String!
-  $otherPartyId_usi: String
-  $status_usi: InvoiceNodeStatus
-  $comment_usi: String
-  $theirReference_usi: String
-) {
-  updateSupplierInvoice(
-    input: {
-      id: $id
-      otherPartyId: $otherPartyId_usi
-      status: $status_usi
-      theirReference: $theirReference_usi
-      comment: $comment_usi
-    }
-  ) {
-    ...UpdateSupplierInvoiceResponsePartial
-  }
-}
-
 fragment UpdateSupplierInvoiceResponse on UpdateSupplierInvoiceResponse {
   __typename
   ...UpdateSupplierInvoiceError
   ...NodeError
   ...InvoiceNode
-}
-
-fragment UpdateSupplierInvoiceResponsePartial on UpdateSupplierInvoiceResponse {
-  __typename
-  ...UpdateSupplierInvoiceError
-  ...NodeError
-  ...PartialInvoiceNode
 }
 
 fragment UpdateSupplierInvoiceError on UpdateSupplierInvoiceError {
@@ -330,12 +276,6 @@ fragment InvoiceResponse on InvoiceResponse {
   __typename
   ...InvoiceNode
   ...NodeError
-}
-
-fragment PartialInvoiceNode on InvoiceNode {
-  id
-  status
-  type
 }
 
 fragment InvoiceNode on InvoiceNode {

--- a/tests/graphql/update_supplier_invoice.rs
+++ b/tests/graphql/update_supplier_invoice.rs
@@ -1,34 +1,61 @@
 mod graphql {
-    use crate::graphql::get_gql_result;
     use crate::graphql::{
-        update_supplier_invoice_full as full, update_supplier_invoice_partial as partial,
-        UpdateSupplierInvoiceFull as Full, UpdateSupplierInvoicePartial as Partial,
+        common::{
+            assert_unwrap_enum, assert_unwrap_optional_key, compare_option, get_invoice_inline,
+            get_name_inline,
+        },
+        get_gql_result,
+    };
+    use crate::graphql::{
+        update_supplier_invoice_full as update, UpdateSupplierInvoiceFull as Update,
     };
     use chrono::{Duration, Utc};
     use graphql_client::{GraphQLQuery, Response};
     use remote_server::{
         database::{
             mock::MockDataInserts,
-            repository::{InvoiceQueryRepository, NameQueryRepository},
+            repository::InvoiceRepository,
+            schema::{InvoiceRow, InvoiceRowStatus, InvoiceRowType},
         },
-        domain::{
-            invoice::InvoiceFilter,
-            name::{Name, NameFilter},
-            DatetimeFilter, Pagination,
-        },
+        domain::{invoice::InvoiceFilter, name::NameFilter, Pagination},
         util::test_db,
     };
 
-    impl From<Name> for full::NameNode {
-        fn from(n: Name) -> Self {
-            full::NameNode {
-                code: n.code,
-                id: n.id,
-                is_customer: n.is_customer,
-                is_supplier: n.is_supplier,
-                name: n.name,
-            }
-        }
+    use update::UpdateSupplierInvoiceErrorInterface::*;
+
+    macro_rules! assert_unwrap_response_variant {
+        ($response:ident) => {
+            assert_unwrap_optional_key!($response, data).update_supplier_invoice
+        };
+    }
+
+    macro_rules! assert_unwrap_invoice_response {
+        ($response:ident) => {{
+            let response_variant = assert_unwrap_response_variant!($response);
+            assert_unwrap_enum!(
+                response_variant,
+                update::UpdateSupplierInvoiceResponse::InvoiceNode
+            )
+        }};
+    }
+
+    macro_rules! assert_unwrap_error {
+        ($response:ident) => {{
+            let response_variant = assert_unwrap_response_variant!($response);
+            let error_wrapper = assert_unwrap_enum!(
+                response_variant,
+                update::UpdateSupplierInvoiceResponse::UpdateSupplierInvoiceError
+            );
+            error_wrapper.error
+        }};
+    }
+
+    macro_rules! assert_error {
+        ($response:ident, $error:expr) => {{
+            let lhs = assert_unwrap_error!($response);
+            let rhs = $error;
+            assert_eq!(lhs, rhs);
+        }};
     }
 
     #[actix_rt::test]
@@ -42,258 +69,215 @@ mod graphql {
             .naive_utc()
             .checked_add_signed(Duration::seconds(5))
             .unwrap();
-        let id1 = "invalid";
-        let comment = "some comment";
-        let their_reference = "some reference";
-        let not_supplier = NameQueryRepository::new(&connection)
-            .query(
-                Pagination::one(),
-                Some(NameFilter::new().match_is_supplier(false)),
-                None,
-            )
-            .unwrap()
-            .pop()
-            .unwrap();
-        let supplier = NameQueryRepository::new(&connection)
-            .query(
-                Pagination::one(),
-                Some(NameFilter::new().match_is_supplier(true)),
-                None,
-            )
-            .unwrap()
-            .pop()
-            .unwrap();
-        let draft_supplier_invoice = InvoiceQueryRepository::new(&connection)
-            .query(
-                Pagination::one(),
-                Some(InvoiceFilter::new().match_supplier_invoice().match_draft()),
-                None,
-            )
-            .unwrap()
-            .pop()
-            .unwrap();
-        let customer_invoice = InvoiceQueryRepository::new(&connection)
-            .query(
-                Pagination::one(),
-                Some(InvoiceFilter::new().match_customer_invoice()),
-                None,
-            )
-            .unwrap()
-            .pop()
-            .unwrap();
+
+        let not_supplier =
+            get_name_inline!(NameFilter::new().match_is_supplier(false), &connection);
+        let supplier = get_name_inline!(
+            NameFilter::new()
+                .match_is_supplier(true)
+                .match_id("name_store_c"),
+            &connection
+        );
+        let another_name = get_name_inline!(
+            NameFilter::new().match_is_supplier(true).match_id("name_a"),
+            &connection
+        );
+
+        let draft_supplier_invoice = get_invoice_inline!(
+            InvoiceFilter::new().match_supplier_invoice().match_draft(),
+            &connection
+        );
+        let customer_invoice =
+            get_invoice_inline!(InvoiceFilter::new().match_customer_invoice(), &connection);
+
+        let base_variables = update::Variables {
+            id: draft_supplier_invoice.id.clone(),
+            other_party_id_usi: Some(supplier.id.clone()),
+            status_usi: Some(update::InvoiceNodeStatus::Draft),
+            comment_usi: Some("some comment".to_string()),
+            their_reference_usi: Some("some reference".to_string()),
+        };
 
         // Test RecordDoesNotExist
-        let current_id = id1.to_string();
 
-        let query = Full::build_query(full::Variables {
-            id: current_id,
-            other_party_id_usi: None,
-            status_usi: None,
-            comment_usi: None,
-            their_reference_usi: None,
-        });
-        let response: Response<full::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = full::ResponseData {
-            update_supplier_invoice:
-                full::UpdateSupplierInvoiceResponse::UpdateSupplierInvoiceError(
-                    full::UpdateSupplierInvoiceError {
-                        error: full::UpdateSupplierInvoiceErrorInterface::RecordDoesNotExist(
-                            full::RecordDoesNotExist {
-                                description: "Record does not exist".to_string(),
-                            },
-                        ),
-                    },
-                ),
-        };
-        println!("{:#?}", response);
-        assert_eq!(response.data.unwrap(), expected);
+        let mut variables = base_variables.clone();
+        variables.id = "invalid".to_string();
+
+        let query = Update::build_query(variables);
+        let response: Response<update::ResponseData> = get_gql_result(&settings, query).await;
+
+        assert_error!(
+            response,
+            RecordDoesNotExist(update::RecordDoesNotExist {
+                description: "Record does not exist".to_string(),
+            },)
+        );
 
         // Test ForeingKeyError
-        let current_id = draft_supplier_invoice.id.clone();
 
-        let query = Full::build_query(full::Variables {
-            id: current_id,
-            other_party_id_usi: Some("invalid".to_string()),
-            status_usi: None,
-            comment_usi: None,
-            their_reference_usi: None,
-        });
-        let response: Response<full::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = full::ResponseData {
-            update_supplier_invoice:
-                full::UpdateSupplierInvoiceResponse::UpdateSupplierInvoiceError(
-                    full::UpdateSupplierInvoiceError {
-                        error: full::UpdateSupplierInvoiceErrorInterface::ForeignKeyError(
-                            full::ForeignKeyError {
-                                description: "FK record doesn't exist".to_string(),
-                                key: full::ForeignKey::OtherPartyId,
-                            },
-                        ),
-                    },
-                ),
-        };
-        assert_eq!(response.data.unwrap(), expected);
+        let mut variables = base_variables.clone();
+        variables.other_party_id_usi = Some("invalid".to_string());
+
+        let query = Update::build_query(variables);
+        let response: Response<update::ResponseData> = get_gql_result(&settings, query).await;
+
+        assert_error!(
+            response,
+            ForeignKeyError(update::ForeignKeyError {
+                description: "FK record doesn't exist".to_string(),
+                key: update::ForeignKey::OtherPartyId,
+            },)
+        );
 
         // Test OtherPartyNotASupplier
 
-        let current_id = draft_supplier_invoice.id.clone();
+        let mut variables = base_variables.clone();
+        variables.other_party_id_usi = Some(not_supplier.id.clone());
 
-        let query = Full::build_query(full::Variables {
-            id: current_id,
-            other_party_id_usi: Some(not_supplier.id.clone()),
-            status_usi: None,
-            comment_usi: None,
-            their_reference_usi: None,
-        });
-        let response: Response<full::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = full::ResponseData {
-            update_supplier_invoice:
-                full::UpdateSupplierInvoiceResponse::UpdateSupplierInvoiceError(
-                    full::UpdateSupplierInvoiceError {
-                        error: full::UpdateSupplierInvoiceErrorInterface::OtherPartyNotASupplier(
-                            full::OtherPartyNotASupplier {
-                                description: "Other party name is not a supplier".to_string(),
-                                other_party: not_supplier.into(),
-                            },
-                        ),
-                    },
-                ),
-        };
-        assert_eq!(response.data.unwrap(), expected);
+        let query = Update::build_query(variables);
+        let response: Response<update::ResponseData> = get_gql_result(&settings, query).await;
+
+        let error_variant = assert_unwrap_error!(response);
+        let error = assert_unwrap_enum!(error_variant, OtherPartyNotASupplier);
+
+        assert_eq!(error.other_party.id, not_supplier.id.clone());
 
         // Test NotASupplierInvoice
 
-        let current_id = customer_invoice.id.clone();
+        let mut variables = base_variables.clone();
+        variables.id = customer_invoice.id.clone();
 
-        let query = Full::build_query(full::Variables {
-            id: current_id,
-            other_party_id_usi: None,
-            status_usi: None,
-            comment_usi: None,
-            their_reference_usi: None,
-        });
-        let response: Response<full::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = full::ResponseData {
-            update_supplier_invoice:
-                full::UpdateSupplierInvoiceResponse::UpdateSupplierInvoiceError(
-                    full::UpdateSupplierInvoiceError {
-                        error: full::UpdateSupplierInvoiceErrorInterface::NotASupplierInvoice(
-                            full::NotASupplierInvoice {
-                                description: "Invoice is not Supplier Invoice".to_string(),
-                            },
-                        ),
-                    },
-                ),
-        };
-        assert_eq!(response.data.unwrap(), expected);
+        let query = Update::build_query(variables);
+        let response: Response<update::ResponseData> = get_gql_result(&settings, query).await;
+
+        assert_error!(
+            response,
+            NotASupplierInvoice(update::NotASupplierInvoice {
+                description: "Invoice is not Supplier Invoice".to_string(),
+            },)
+        );
 
         // Test Confirm
 
-        let current_id = draft_supplier_invoice.id.clone();
+        let mut variables = base_variables.clone();
+        variables.status_usi = Some(update::InvoiceNodeStatus::Confirmed);
+        variables.other_party_id_usi = Some(another_name.id.clone());
 
-        let query = Partial::build_query(partial::Variables {
-            id: current_id.clone(),
-            other_party_id_usi: Some(supplier.id.clone()),
-            status_usi: Some(partial::InvoiceNodeStatus::Confirmed),
-            comment_usi: Some(comment.to_string()),
-            their_reference_usi: Some(their_reference.to_string()),
-        });
-        let response: Response<partial::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = partial::ResponseData {
-            update_supplier_invoice: partial::UpdateSupplierInvoiceResponsePartial::InvoiceNode(
-                partial::PartialInvoiceNode {
-                    id: current_id.clone(),
-                    status: partial::InvoiceNodeStatus::Confirmed,
-                    type_: partial::InvoiceNodeType::SupplierInvoice,
-                },
-            ),
-        };
-        assert_eq!(response.data.unwrap(), expected);
-        let invoice = InvoiceQueryRepository::new(&connection)
-            .query(
-                Pagination::one(),
-                Some(
-                    InvoiceFilter::new()
-                        .match_id(&current_id)
-                        .set_confirm_datetime(DatetimeFilter::date_range(start, end)),
-                ),
-                None,
-            )
-            .unwrap()
-            .pop()
+        let query = Update::build_query(variables.clone());
+        let response: Response<update::ResponseData> = get_gql_result(&settings, query).await;
+
+        let invoice = assert_unwrap_invoice_response!(response);
+        assert_eq!(invoice.id, variables.id);
+
+        let updated_invoice = InvoiceRepository::new(&connection)
+            .find_one_by_id(&variables.id)
             .unwrap();
-        assert_eq!(invoice.id, current_id);
-        assert_eq!(invoice.comment, Some(comment.to_string()));
-        assert_eq!(invoice.their_reference, Some(their_reference.to_string()));
-        assert_eq!(invoice.finalised_datetime, None);
 
-        // Test Finaized, comment and thier_reference
+        assert_eq!(updated_invoice.r#type, InvoiceRowType::SupplierInvoice);
 
-        let current_id = draft_supplier_invoice.id.clone();
+        assert_eq!(updated_invoice, variables);
 
-        let query = Partial::build_query(partial::Variables {
-            id: current_id.clone(),
-            other_party_id_usi: Some(supplier.id.clone()),
-            status_usi: Some(partial::InvoiceNodeStatus::Finalised),
-            comment_usi: Some(comment.to_string()),
-            their_reference_usi: Some(their_reference.to_string()),
-        });
-        let response: Response<partial::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = partial::ResponseData {
-            update_supplier_invoice: partial::UpdateSupplierInvoiceResponsePartial::InvoiceNode(
-                partial::PartialInvoiceNode {
-                    id: current_id.clone(),
-                    status: partial::InvoiceNodeStatus::Finalised,
-                    type_: partial::InvoiceNodeType::SupplierInvoice,
-                },
-            ),
-        };
-        assert_eq!(response.data.unwrap(), expected);
-        let invoice = InvoiceQueryRepository::new(&connection)
-            .query(
-                Pagination::one(),
-                Some(
-                    InvoiceFilter::new()
-                        .match_id(&current_id)
-                        .set_confirm_datetime(DatetimeFilter::date_range(start, end))
-                        .set_finalised_datetime(DatetimeFilter::date_range(start, end)),
-                ),
-                None,
-            )
-            .unwrap()
-            .pop()
+        let confirmed_datetime = updated_invoice.confirm_datetime.unwrap();
+        assert!(confirmed_datetime > start);
+        assert!(confirmed_datetime < end);
+
+        assert_eq!(updated_invoice.finalised_datetime, None);
+
+        // Test unchanged
+
+        let mut variables = base_variables.clone();
+
+        variables.status_usi = None;
+        variables.comment_usi = None;
+        variables.their_reference_usi = None;
+
+        let start_invoice = InvoiceRepository::new(&connection)
+            .find_one_by_id(&variables.id)
             .unwrap();
-        assert_eq!(invoice.id, current_id);
-        assert_eq!(invoice.comment, Some(comment.to_string()));
-        assert_eq!(invoice.their_reference, Some(their_reference.to_string()));
+
+        let query = Update::build_query(variables.clone());
+        let response: Response<update::ResponseData> = get_gql_result(&settings, query).await;
+
+        let invoice = assert_unwrap_invoice_response!(response);
+        assert_eq!(invoice.id, variables.id);
+
+        let end_invoice = InvoiceRepository::new(&connection)
+            .find_one_by_id(&variables.id)
+            .unwrap();
+
+        assert_eq!(start_invoice.id, end_invoice.id);
+
+        // Test Finaized
+
+        let mut variables = base_variables.clone();
+        variables.status_usi = Some(update::InvoiceNodeStatus::Finalised);
+
+        let query = Update::build_query(variables.clone());
+        let response: Response<update::ResponseData> = get_gql_result(&settings, query).await;
+
+        let invoice = assert_unwrap_invoice_response!(response);
+        assert_eq!(invoice.id, variables.id);
+
+        let updated_invoice = InvoiceRepository::new(&connection)
+            .find_one_by_id(&variables.id)
+            .unwrap();
+
+        assert_eq!(updated_invoice.r#type, InvoiceRowType::SupplierInvoice);
+
+        assert_eq!(updated_invoice, variables);
+
+        let confirmed_datetime = updated_invoice.confirm_datetime.unwrap();
+        assert!(confirmed_datetime > start);
+        assert!(confirmed_datetime < end);
+
+        let finalised_datetime = updated_invoice.confirm_datetime.unwrap();
+        assert!(finalised_datetime > start);
+        assert!(finalised_datetime < end);
 
         // Test CannotEditFinalisedInvoice
 
-        let current_id = draft_supplier_invoice.id.clone();
+        let variables = base_variables.clone();
 
-        let query = Full::build_query(full::Variables {
-            id: current_id,
-            other_party_id_usi: None,
-            status_usi: None,
-            comment_usi: None,
-            their_reference_usi: None,
-        });
-        let response: Response<full::ResponseData> = get_gql_result(&settings, query).await;
-        let expected = full::ResponseData {
-            update_supplier_invoice:
-                full::UpdateSupplierInvoiceResponse::UpdateSupplierInvoiceError(
-                    full::UpdateSupplierInvoiceError {
-                        error:
-                            full::UpdateSupplierInvoiceErrorInterface::CannotEditFinalisedInvoice(
-                                full::CannotEditFinalisedInvoice {
-                                    description: "Cannot edit finalised invoice".to_string(),
-                                },
-                            ),
-                    },
-                ),
-        };
-        assert_eq!(response.data.unwrap(), expected);
+        let query = Update::build_query(variables);
+        let response: Response<update::ResponseData> = get_gql_result(&settings, query).await;
+
+        assert_error!(
+            response,
+            CannotEditFinalisedInvoice(update::CannotEditFinalisedInvoice {
+                description: "Cannot edit finalised invoice".to_string(),
+            },)
+        );
 
         // TODO check stock lines updating when changed to confirmed
+    }
+
+    impl From<InvoiceRowStatus> for update::InvoiceNodeStatus {
+        fn from(status: InvoiceRowStatus) -> Self {
+            use update::InvoiceNodeStatus::*;
+            match status {
+                InvoiceRowStatus::Draft => Draft,
+                InvoiceRowStatus::Confirmed => Confirmed,
+                InvoiceRowStatus::Finalised => Finalised,
+            }
+        }
+    }
+
+    impl PartialEq<update::Variables> for InvoiceRow {
+        fn eq(&self, other: &update::Variables) -> bool {
+            let update::Variables {
+                id,
+                other_party_id_usi,
+                status_usi,
+                comment_usi: _,         // Nullable option ?
+                their_reference_usi: _, // Nullable option ?
+            } = other;
+
+            *id == self.id
+                && compare_option(other_party_id_usi, &self.name_id)
+                && compare_option(
+                    status_usi,
+                    &update::InvoiceNodeStatus::from(self.status.clone()),
+                )
+        }
     }
 }

--- a/tests/graphql/update_supplier_invoice_line.rs
+++ b/tests/graphql/update_supplier_invoice_line.rs
@@ -1,7 +1,7 @@
 mod graphql {
     use crate::graphql::common::{
-        assert_unwrap_enum, assert_unwrap_optional_key, convert_graphql_client_type,
-        get_invoice_inline, get_invoice_lines_inline,
+        assert_unwrap_enum, assert_unwrap_optional_key, compare_option,
+        convert_graphql_client_type, get_invoice_inline, get_invoice_lines_inline,
     };
     use crate::graphql::get_gql_result;
     use crate::graphql::{
@@ -367,17 +367,6 @@ mod graphql {
 
         assert_eq!(start_line, end_line);
         assert_eq!(start_batch, end_batch);
-    }
-
-    fn compare_option<A, B>(a: &Option<A>, b: &B) -> bool
-    where
-        B: PartialEq<A>,
-    {
-        if let Some(a) = a {
-            b == a
-        } else {
-            true
-        }
     }
 
     impl PartialEq<update::Variables> for InvoiceLineRow {


### PR DESCRIPTION
Closes #474 

* Refactored supplier invoice insert/update/delete to use helpers from line mutations tests
* Added more specific check in delete, to confirm correct lines are returned in `CannotDeleteInvoiceWithLines`
* Added check to confirm stock line is generated correctly and linked to invoice lines when supplier invoice status is updated (from draft).
* Fix logic error for the last bulletpoint