### PR TITLE
#486 add additional sync logging

### DIFF
--- a/src/database/repository/diesel/storage_connection.rs
+++ b/src/database/repository/diesel/storage_connection.rs
@@ -24,7 +24,10 @@ pub enum TransactionError<E> {
 impl From<TransactionError<RepositoryError>> for RepositoryError {
     fn from(error: TransactionError<RepositoryError>) -> Self {
         match error {
-            TransactionError::Transaction { msg } => RepositoryError::DBError { msg },
+            TransactionError::Transaction { msg } => RepositoryError::DBError {
+                msg: msg.clone(),
+                source_msg: msg.clone(),
+            },
             TransactionError::Inner(e) => e,
         }
     }

--- a/src/database/repository/mod.rs
+++ b/src/database/repository/mod.rs
@@ -1,3 +1,4 @@
+use diesel::result::Error as DieselError;
 use thiserror::Error;
 
 #[derive(Clone, Error, Debug, PartialEq)]
@@ -15,8 +16,8 @@ pub enum RepositoryError {
     #[error("actix thread pool canceled")]
     ThreadPoolCanceled,
     /// Other DB related errors
-    #[error("DBError: {msg:?}")]
-    DBError { msg: String },
+    #[error("{msg:?} ({source_msg:?})")]
+    DBError { msg: String, source_msg: String },
 }
 
 #[cfg_attr(any(feature = "sqlite", feature = "postgres"), path = "diesel/mod.rs")]

--- a/src/service/invoice/customer_invoice/delete/mod.rs
+++ b/src/service/invoice/customer_invoice/delete/mod.rs
@@ -41,7 +41,10 @@ impl From<TransactionError<DeleteCustomerInvoiceError>> for DeleteCustomerInvoic
     fn from(error: TransactionError<DeleteCustomerInvoiceError>) -> Self {
         match error {
             TransactionError::Transaction { msg } => {
-                DeleteCustomerInvoiceError::DatabaseError(RepositoryError::DBError { msg })
+                DeleteCustomerInvoiceError::DatabaseError(RepositoryError::DBError {
+                    msg: msg.clone(),
+                    source_msg: msg.clone(),
+                })
             }
             TransactionError::Inner(e) => e,
         }

--- a/src/service/invoice/customer_invoice/insert/mod.rs
+++ b/src/service/invoice/customer_invoice/insert/mod.rs
@@ -29,7 +29,10 @@ impl From<TransactionError<InsertCustomerInvoiceError>> for InsertCustomerInvoic
     fn from(error: TransactionError<InsertCustomerInvoiceError>) -> Self {
         match error {
             TransactionError::Transaction { msg } => {
-                InsertCustomerInvoiceError::DatabaseError(RepositoryError::DBError { msg })
+                InsertCustomerInvoiceError::DatabaseError(RepositoryError::DBError {
+                    msg: msg.clone(),
+                    source_msg: msg.clone(),
+                })
             }
             TransactionError::Inner(e) => e,
         }

--- a/src/service/invoice/customer_invoice/update/mod.rs
+++ b/src/service/invoice/customer_invoice/update/mod.rs
@@ -58,7 +58,10 @@ impl From<TransactionError<UpdateCustomerInvoiceError>> for UpdateCustomerInvoic
     fn from(error: TransactionError<UpdateCustomerInvoiceError>) -> Self {
         match error {
             TransactionError::Transaction { msg } => {
-                UpdateCustomerInvoiceError::DatabaseError(RepositoryError::DBError { msg })
+                UpdateCustomerInvoiceError::DatabaseError(RepositoryError::DBError {
+                    msg: msg.clone(),
+                    source_msg: msg.clone(),
+                })
             }
             TransactionError::Inner(e) => e,
         }

--- a/src/util/sync/actor.rs
+++ b/src/util/sync/actor.rs
@@ -77,18 +77,18 @@ impl SyncReceiverActor {
                             CentralSyncError::PullCentralSyncRecordsError { source } => {
                                 let sync_connection_error = source;
                                 info!("{}", sync_connection_error);
-                                if let SyncConnectionError::ConnectError { source }
-                                | SyncConnectionError::TimedoutError { source }
-                                | SyncConnectionError::BadRequestError { source }
-                                | SyncConnectionError::UnauthorisedError { source }
-                                | SyncConnectionError::NotFoundError { source }
-                                | SyncConnectionError::MethodNotAllowedError { source }
-                                | SyncConnectionError::InternalServerError { source }
-                                | SyncConnectionError::UnknownError { source } =
-                                    sync_connection_error
-                                {
-                                    let reqwest_error = source;
-                                    info!("{}", reqwest_error);
+                                match sync_connection_error {
+                                    SyncConnectionError::ConnectError { source }
+                                    | SyncConnectionError::TimedoutError { source }
+                                    | SyncConnectionError::BadRequestError { source }
+                                    | SyncConnectionError::UnauthorisedError { source }
+                                    | SyncConnectionError::NotFoundError { source }
+                                    | SyncConnectionError::MethodNotAllowedError { source }
+                                    | SyncConnectionError::InternalServerError { source }
+                                    | SyncConnectionError::UnknownError { source } => {
+                                        let reqwest_error = source;
+                                        info!("{}", reqwest_error);
+                                    }
                                 }
                             }
                             CentralSyncError::ImportCentralSyncRecordsError { source } => {

--- a/src/util/sync/synchroniser.rs
+++ b/src/util/sync/synchroniser.rs
@@ -84,24 +84,34 @@ impl Synchroniser {
         const BATCH_SIZE: u32 = 500;
 
         Ok(loop {
-            info!("Pulling central sync records...");
+            info!("Pulling {} central sync records...", BATCH_SIZE);
             let sync_batch: CentralSyncBatch = self
                 .connection
                 .pull_central_records(cursor, BATCH_SIZE)
                 .await
                 .map_err(|source| CentralSyncError::PullCentralSyncRecordsError { source })?;
-            info!("Pulled central sync records");
 
-            if let Some(central_sync_records) = sync_batch.data {
-                for central_sync_record in central_sync_records {
-                    central_sync_buffer_repository
-                        .insert_one_and_update_cursor(&central_sync_record)
-                        .await
-                        .map_err(|source| {
-                            CentralSyncError::UpdateCentralSyncBufferRecordsError { source }
-                        })?;
-                }
+            let central_sync_records = sync_batch.data.map_or(vec![], |records| records);
+
+            if central_sync_records.len() == 0 {
+                info!("Central sync buffer is up-to-date");
+                break;
             }
+
+            info!(
+                "Inserting {} central sync records into central sync buffer",
+                central_sync_records.len()
+            );
+
+            for central_sync_record in central_sync_records {
+                central_sync_buffer_repository
+                    .insert_one_and_update_cursor(&central_sync_record)
+                    .await
+                    .map_err(
+                        |source| CentralSyncError::UpdateCentralSyncBufferRecordsError { source },
+                    )?;
+            }
+            info!("Successfully inserted central sync records into central sync buffer");
 
             cursor = central_sync_cursor_repository
                 .get_cursor()
@@ -131,7 +141,7 @@ impl Synchroniser {
 
         let mut records: Vec<RemoteSyncRecord> = Vec::new();
         while sync_batch.queue_length > 0 {
-            info!("Pulling remote sync records...");
+            info!("Pulling {} remote sync records...", sync_batch.queue_length);
             sync_batch = self
                 .connection
                 .pull_remote_records()
@@ -140,7 +150,7 @@ impl Synchroniser {
                     msg: "Failed to pull remote sync records",
                     source: anyhow::Error::from(source),
                 })?;
-            info!("Pulled remote sync records");
+            info!("Pulled {} remote sync records", sync_batch.queue_length);
 
             // TODO: acknowledge after integration.
             if let Some(data) = sync_batch.data {
@@ -172,21 +182,34 @@ impl Synchroniser {
 
         let mut records: Vec<CentralSyncBufferRow> = Vec::new();
         for table_name in TRANSLATION_RECORDS {
+            info!("Querying central sync buffer for {} records", table_name);
+
             let mut buffer_rows = central_sync_buffer_repository
                 .get_sync_entries(table_name)
                 .await
                 .map_err(|source| CentralSyncError::GetCentralSyncBufferRecordsError { source })?;
+
+            info!(
+                "Found {} {} records in central sync buffer",
+                buffer_rows.len(),
+                table_name
+            );
+
             records.append(&mut buffer_rows);
         }
 
+        info!("Importing {} central sync buffer records...", records.len());
         import_sync_records(registry, &records)
             .await
             .map_err(|source| CentralSyncError::ImportCentralSyncRecordsError { source })?;
+        info!("Successfully Imported central sync buffer records",);
 
+        info!("Clearing central sync buffer");
         central_sync_buffer_repository
             .remove_all()
             .await
             .map_err(|source| CentralSyncError::RemoveCentralSyncBufferRecordsError { source })?;
+        info!("Successfully cleared central sync buffer");
 
         Ok(())
     }

--- a/src/util/sync/translation/mod.rs
+++ b/src/util/sync/translation/mod.rs
@@ -32,8 +32,8 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 #[error("Failed to translate {table_name} sync record")]
 pub struct SyncTranslationError {
-    table_name: &'static str,
-    source: serde_json::Error,
+    pub table_name: &'static str,
+    pub source: serde_json::Error,
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
Closes #486.

Just adds some additional `info` logging and more exhaustive error matching. Note that this is pretty hacky, should really be done recursively (but at this stage I think that would be overkill). It's tempting to expand the errors out with a macro of some kind, but I think this would just obfuscate what is going on and make the code harder to understand/maintain.