### PR TITLE
Add support for user logout

### DIFF
--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -9,6 +9,7 @@ pub mod invoice_line;
 pub mod item;
 pub mod name;
 pub mod stock_line;
+pub mod token_bucket;
 pub mod user_account;
 
 pub struct ListResult<T> {

--- a/src/service/token_bucket.rs
+++ b/src/service/token_bucket.rs
@@ -1,0 +1,92 @@
+use std::collections::{hash_map::Entry, HashMap};
+
+use chrono::Utc;
+
+use crate::util::auth::sha256;
+
+/// Tracks if a token is valid or if a user has been logged out
+pub trait TokenBucket {
+    /// Checks if the token is known for the given user
+    fn contains(&self, user_id: &str, token: &str) -> bool;
+    /// Adds a token for a given user.
+    /// If token is already known the expiry_date is updated.
+    /// This can be used to reduce the expiry date of a token on the server
+    fn put(&mut self, user_id: &str, token: &str, expiry_date: usize);
+    /// Removes all known tokens for a given user
+    fn clear(&mut self, user_id: &str);
+}
+
+struct TokenInfo {
+    token_hash: String,
+    expiry_date: usize,
+}
+
+pub struct InMemoryTokenBucket {
+    users: HashMap<String, Vec<TokenInfo>>,
+}
+
+impl InMemoryTokenBucket {
+    pub fn new() -> Self {
+        InMemoryTokenBucket {
+            users: HashMap::new(),
+        }
+    }
+}
+
+fn token_hash(token: &str) -> String {
+    sha256(token)
+}
+
+impl TokenBucket for InMemoryTokenBucket {
+    fn contains(&self, user_id: &str, token: &str) -> bool {
+        let user_tokens = match self.users.get(user_id) {
+            Some(value) => value,
+            None => return false,
+        };
+
+        let token_hash = token_hash(token);
+        let existing_token = match user_tokens
+            .iter()
+            .find(|item| item.token_hash == token_hash)
+        {
+            Some(value) => value,
+            None => return false,
+        };
+
+        let now = Utc::now().timestamp() as usize;
+        existing_token.expiry_date >= now
+    }
+
+    fn put(&mut self, user_id: &str, token: &str, expiry_date: usize) {
+        let now = Utc::now().timestamp() as usize;
+        if expiry_date < now {
+            return;
+        }
+        let user_tokens = match self.users.entry(user_id.to_string()) {
+            Entry::Occupied(o) => o.into_mut(),
+            Entry::Vacant(v) => v.insert(Vec::new()),
+        };
+
+        // clean up expired tokens
+        user_tokens.retain(|item| item.expiry_date > now);
+
+        // update existing
+        let token_hash = token_hash(token);
+        if let Some(value) = user_tokens
+            .iter_mut()
+            .find(|item| item.token_hash == token_hash)
+        {
+            value.expiry_date = expiry_date;
+            return;
+        }
+
+        user_tokens.push(TokenInfo {
+            token_hash,
+            expiry_date,
+        });
+    }
+
+    fn clear(&mut self, user_id: &str) {
+        self.users.remove(user_id);
+    }
+}

--- a/src/service/user_account.rs
+++ b/src/service/user_account.rs
@@ -106,11 +106,11 @@ pub struct TokenPair {
 
 pub struct UserAccountService<'a> {
     connection: &'a StorageConnection,
-    token_bucket: &'a mut dyn TokenBucket,
+    token_bucket: &'a mut TokenBucket,
 }
 
 impl<'a> UserAccountService<'a> {
-    pub fn new(connection: &'a StorageConnection, token_bucket: &'a mut dyn TokenBucket) -> Self {
+    pub fn new(connection: &'a StorageConnection, token_bucket: &'a mut TokenBucket) -> Self {
         UserAccountService {
             connection,
             token_bucket,
@@ -320,7 +320,7 @@ fn create_jwt_pair(
 mod user_account_test {
     use crate::{
         database::repository::{get_repositories, StorageConnectionManager},
-        service::token_bucket::InMemoryTokenBucket,
+        service::token_bucket::TokenBucket,
         util::test_db,
     };
 
@@ -334,7 +334,7 @@ mod user_account_test {
         let connection_manager = registry.get::<StorageConnectionManager>().unwrap();
         let connection = connection_manager.connection().unwrap();
 
-        let mut bucket = InMemoryTokenBucket::new();
+        let mut bucket = TokenBucket::new();
         let mut service = UserAccountService::new(&connection, &mut bucket);
 
         // should be able to create a new user
@@ -388,7 +388,7 @@ mod user_account_test {
         let connection_manager = registry.get::<StorageConnectionManager>().unwrap();
         let connection = connection_manager.connection().unwrap();
 
-        let mut bucket = InMemoryTokenBucket::new();
+        let mut bucket = TokenBucket::new();
         let mut service = UserAccountService::new(&connection, &mut bucket);
 
         // should be able to create a new user


### PR DESCRIPTION
Currently all user tokens are invalidated on logout. Tokens are stored in memory but there is a trait to have a different backend.

Not sure if I am going to far here, e.g. some open questions:
- should we really invalidate all tokens if a user logs out or just the token for a certain client
- after a token refresh, should the expiry time for old tokens be reduced, e.g. down to 5min