### PR TITLE
535 add unit to item query

### DIFF
--- a/src/database/mock/full_master_list.rs
+++ b/src/database/mock/full_master_list.rs
@@ -1,0 +1,66 @@
+use std::collections::HashMap;
+
+use crate::database::{
+    repository::{
+        MasterListLineRepository, MasterListNameJoinRepository, MasterListRepository,
+        StorageConnection,
+    },
+    schema::{MasterListLineRow, MasterListNameJoinRow, MasterListRow},
+};
+
+pub struct FullMockMasterList {
+    pub master_list: MasterListRow,
+    pub joins: Vec<MasterListNameJoinRow>,
+    pub lines: Vec<MasterListLineRow>,
+}
+
+pub fn mock_master_list_item_query_test1() -> FullMockMasterList {
+    FullMockMasterList {
+        master_list: MasterListRow {
+            id: "item_query_test1".to_owned(),
+            name: "name_item_query_test1".to_owned(),
+            code: "code_item_query_test1".to_owned(),
+            description: "description_item_query_test1".to_owned(),
+        },
+        joins: vec![MasterListNameJoinRow {
+            id: "item_query_test1".to_owned(),
+            master_list_id: "item_query_test1".to_owned(),
+            name_id: "name_store_a".to_owned(),
+        }],
+        lines: vec![MasterListLineRow {
+            id: "item_query_test1".to_owned(),
+            item_id: "item_query_test1".to_owned(),
+            master_list_id: "item_query_test1".to_owned(),
+        }],
+    }
+}
+
+pub fn insert_full_mock_master_list(
+    full_master_list: &FullMockMasterList,
+    connection: &StorageConnection,
+) {
+    MasterListRepository::new(&connection)
+        .upsert_one(&full_master_list.master_list)
+        .unwrap();
+
+    for line in full_master_list.lines.iter() {
+        MasterListLineRepository::new(&connection)
+            .upsert_one(line)
+            .unwrap();
+    }
+
+    for join in full_master_list.joins.iter() {
+        MasterListNameJoinRepository::new(&connection)
+            .upsert_one(join)
+            .unwrap();
+    }
+}
+
+pub fn mock_full_master_list() -> HashMap<String, FullMockMasterList> {
+    vec![(
+        "item_query_test1".to_string(),
+        mock_master_list_item_query_test1(),
+    )]
+    .into_iter()
+    .collect()
+}

--- a/src/database/mock/item.rs
+++ b/src/database/mock/item.rs
@@ -37,11 +37,31 @@ pub fn mock_item_with_no_stock_line() -> ItemRow {
     }
 }
 
+pub fn item_query_test1() -> ItemRow {
+    ItemRow {
+        id: String::from("item_query_test1"),
+        name: String::from("name_item_query_test1"),
+        code: String::from("code_item_query_test1"),
+        unit_id: None,
+    }
+}
+
+pub fn item_query_test2() -> ItemRow {
+    ItemRow {
+        id: String::from("item_query_test2"),
+        name: String::from("name_item_query_test2"),
+        code: String::from("code_item_query_test2"),
+        unit_id: Some("item_query_test2".to_owned()),
+    }
+}
+
 pub fn mock_items() -> Vec<ItemRow> {
     vec![
         mock_item_a(),
         mock_item_b(),
         mock_item_c(),
         mock_item_with_no_stock_line(),
+        item_query_test1(),
+        item_query_test2(),
     ]
 }

--- a/src/database/mock/stock_line.rs
+++ b/src/database/mock/stock_line.rs
@@ -169,6 +169,23 @@ pub fn mock_stock_line_ci_d() -> Vec<StockLineRow> {
     vec![mock_stock_line_ci_d_siline_a]
 }
 
+pub fn mock_item_query_test1() -> Vec<StockLineRow> {
+    let mock_item_query_test1: StockLineRow = StockLineRow {
+        id: "item_query_test1".to_owned(),
+        item_id: "item_query_test1".to_owned(),
+        store_id: "store_a".to_owned(),
+        batch: None,
+        available_number_of_packs: 3,
+        pack_size: 12,
+        cost_price_per_pack: 2.0,
+        sell_price_per_pack: 11.0,
+        total_number_of_packs: 3,
+        expiry_date: None,
+    };
+
+    vec![mock_item_query_test1]
+}
+
 pub fn mock_stock_lines() -> Vec<StockLineRow> {
     let mut mock_stock_lines: Vec<StockLineRow> = Vec::new();
 
@@ -178,6 +195,7 @@ pub fn mock_stock_lines() -> Vec<StockLineRow> {
     mock_stock_lines.extend(mock_stock_line_si_d());
     mock_stock_lines.extend(mock_stock_line_ci_c());
     mock_stock_lines.extend(mock_stock_line_ci_d());
+    mock_stock_lines.extend(mock_item_query_test1());
 
     mock_stock_lines
 }

--- a/src/database/mock/unit.rs
+++ b/src/database/mock/unit.rs
@@ -1,0 +1,14 @@
+use crate::database::schema::UnitRow;
+
+pub fn item_query_test2_unit() -> UnitRow {
+    UnitRow {
+        id: "item_query_test2".to_owned(),
+        description: Some("description_item_query_test2".to_owned()),
+        name: "name_item_query_test2".to_owned(),
+        index: 1,
+    }
+}
+
+pub fn mock_units() -> Vec<UnitRow> {
+    vec![item_query_test2_unit()]
+}

--- a/src/domain/item.rs
+++ b/src/domain/item.rs
@@ -7,6 +7,7 @@ pub struct Item {
     pub code: String,
     // Is visible is from master list join
     pub is_visible: bool,
+    pub unit_name: Option<String>,
 }
 #[derive(Clone)]
 pub struct ItemFilter {

--- a/src/server/service/graphql/schema/types/item.rs
+++ b/src/server/service/graphql/schema/types/item.rs
@@ -58,6 +58,10 @@ impl ItemNode {
         self.item.is_visible
     }
 
+    pub async fn unit_name(&self) -> &Option<String> {
+        &self.item.unit_name
+    }
+
     async fn available_batches(&self, ctx: &Context<'_>) -> StockLinesResponse {
         let loader = ctx.get_loader::<DataLoader<StockLineByItemIdLoader>>();
         match loader.load_one(self.item.id.to_string()).await {

--- a/tests/graphql/items.rs
+++ b/tests/graphql/items.rs
@@ -1,0 +1,55 @@
+mod graphql {
+    use crate::graphql::assert_gql_query;
+    use remote_server::{database::mock::MockDataInserts, util::test_db};
+    use serde_json::json;
+
+    #[actix_rt::test]
+    async fn test_graphql_items_query() {
+        let (_, _, settings) = test_db::setup_all("test_items_query", MockDataInserts::all()).await;
+
+        let query = r#"query items($itemFilter: ItemFilterInput!) {
+            items(filter: $itemFilter) {
+                ... on ItemConnector {
+                  nodes {
+                      id
+                      name
+                      code
+                      isVisible
+                      unitName
+                  }
+               }
+            }
+        }"#;
+
+        let variables = json!({
+            "itemFilter": {
+                "name": {
+                    "like": "item_query_test"
+                }
+            }
+        });
+
+        let expected = json!({
+              "items": {
+                  "nodes": [
+                      {
+                          "id": "item_query_test1",
+                          "name": "name_item_query_test1",
+                          "code": "code_item_query_test1",
+                          "isVisible": true,
+                          "unitName": null,
+                      },
+                      {
+                          "id": "item_query_test2",
+                          "name": "name_item_query_test2",
+                          "code": "code_item_query_test2",
+                          "isVisible": false,
+                          "unitName": "name_item_query_test2"
+                      }
+                  ]
+              }
+          }
+        );
+        assert_gql_query(&settings, query, &Some(variables), &expected).await;
+    }
+}

--- a/tests/graphql/items.rs
+++ b/tests/graphql/items.rs
@@ -16,6 +16,13 @@ mod graphql {
                       code
                       isVisible
                       unitName
+                      availableBatches {
+                         ... on StockLineConnector {
+                            nodes {
+                                id
+                            }
+                          }
+                      }
                   }
                }
             }
@@ -38,13 +45,19 @@ mod graphql {
                           "code": "code_item_query_test1",
                           "isVisible": true,
                           "unitName": null,
+                          "availableBatches": {
+                              "nodes": [ { "id": "item_query_test1" } ]
+                          }
                       },
                       {
                           "id": "item_query_test2",
                           "name": "name_item_query_test2",
                           "code": "code_item_query_test2",
                           "isVisible": false,
-                          "unitName": "name_item_query_test2"
+                          "unitName": "name_item_query_test2",
+                           "availableBatches": {
+                              "nodes": []
+                          }
                       }
                   ]
               }

--- a/tests/graphql/mod.rs
+++ b/tests/graphql/mod.rs
@@ -21,6 +21,7 @@ mod inbound_shipment_line_update;
 mod inbound_shipment_update;
 mod invoice_query;
 mod invoices;
+mod items;
 mod names;
 mod outbound_shipment_delete;
 mod outbound_shipment_insert;

--- a/tests/graphql/outbound_shipment_delete.rs
+++ b/tests/graphql/outbound_shipment_delete.rs
@@ -4,59 +4,20 @@ mod graphql {
     use crate::graphql::assert_gql_query;
     use remote_server::{
         database::{
-            mock::{
-                mock_invoice_lines, mock_invoices, mock_items, mock_names, mock_stock_lines,
-                mock_stores,
-            },
-            repository::{
-                get_repositories, InvoiceLineRepository, InvoiceRepository, ItemRepository,
-                NameRepository, RepositoryError, StockLineRepository, StorageConnectionManager,
-                StoreRepository,
-            },
+            mock::MockDataInserts,
+            repository::{InvoiceRepository, RepositoryError},
         },
         util::test_db,
     };
     use serde_json::json;
 
     #[actix_rt::test]
-    async fn test_graphql_outbound_shipment_insert() {
-        let settings = test_db::get_test_settings("omsupply-database-gql-outbound_shipment_delete");
-        test_db::setup(&settings.database).await;
-        let repositories = get_repositories(&settings).await;
-        let connection_manager = repositories.get::<StorageConnectionManager>().unwrap();
-        let connection = connection_manager.connection().unwrap();
-
-        // setup
-        let name_repository = NameRepository::new(&connection);
-        let store_repository = StoreRepository::new(&connection);
-        let item_repository = ItemRepository::new(&connection);
-        let stock_line_repository = StockLineRepository::new(&connection);
-        let invoice_repository = InvoiceRepository::new(&connection);
-        let invoice_line_repository = InvoiceLineRepository::new(&connection);
-        let mock_names = mock_names();
-        let mock_stores = mock_stores();
-        let mock_items = mock_items();
-        let mock_stock_lines = mock_stock_lines();
-        let mock_invoices = mock_invoices();
-        let mock_invoice_lines = mock_invoice_lines();
-        for name in &mock_names {
-            name_repository.insert_one(&name).await.unwrap();
-        }
-        for store in mock_stores {
-            store_repository.insert_one(&store).await.unwrap();
-        }
-        for item in &mock_items {
-            item_repository.upsert_one(item).unwrap();
-        }
-        for stock_line in &mock_stock_lines {
-            stock_line_repository.upsert_one(stock_line).unwrap();
-        }
-        for invoice in &mock_invoices {
-            invoice_repository.upsert_one(invoice).unwrap();
-        }
-        for invoice_line in &mock_invoice_lines {
-            invoice_line_repository.upsert_one(invoice_line).unwrap();
-        }
+    async fn test_graphql_outbound_shipment_delete() {
+        let (_, connection, settings) = test_db::setup_all(
+            "omsupply-database-gql-outbound_shipment_delete",
+            MockDataInserts::all(),
+        )
+        .await;
 
         let query = r#"mutation DeleteOutboundShipment($id: String!) {
             deleteOutboundShipment(id: $id) {
@@ -140,7 +101,7 @@ mod graphql {
         assert_gql_query(&settings, query, &variables, &expected).await;
         // test entry has been deleted
         assert_eq!(
-            invoice_repository
+            InvoiceRepository::new(&connection)
                 .find_one_by_id("outbound_shipment_no_lines")
                 .expect_err("Invoice not deleted"),
             RepositoryError::NotFound

--- a/tests/graphql/outbound_shipment_insert.rs
+++ b/tests/graphql/outbound_shipment_insert.rs
@@ -3,46 +3,21 @@
 mod graphql {
     use crate::graphql::assert_gql_query;
     use remote_server::{
-        database::{
-            mock::{mock_name_store_joins, mock_names, mock_stores},
-            repository::{
-                get_repositories, InvoiceRepository, NameRepository, NameStoreJoinRepository,
-                StorageConnectionManager, StoreRepository,
-            },
-            schema::{NameRow, NameStoreJoinRow, StoreRow},
-        },
+        database::{mock::MockDataInserts, repository::InvoiceRepository},
         util::test_db,
     };
     use serde_json::json;
 
     #[actix_rt::test]
     async fn test_graphql_outbound_shipment_insert() {
-        let settings = test_db::get_test_settings("omsupply-database-gql-outbound_shipment_insert");
-        test_db::setup(&settings.database).await;
-        let repositories = get_repositories(&settings).await;
-        let connection_manager = repositories.get::<StorageConnectionManager>().unwrap();
-        let connection = connection_manager.connection().unwrap();
+        let (mock_data, connection, settings) = test_db::setup_all(
+            "omsupply-database-gql-outbound_shipment_insert",
+            MockDataInserts::all(),
+        )
+        .await;
 
-        // setup
-        let name_repository = NameRepository::new(&connection);
-        let store_repository = StoreRepository::new(&connection);
-        let name_store_repository = NameStoreJoinRepository::new(&connection);
-        let invoice_repository = InvoiceRepository::new(&connection);
-        let mock_names: Vec<NameRow> = mock_names();
-        let mock_stores: Vec<StoreRow> = mock_stores();
-        let mock_name_store_joins: Vec<NameStoreJoinRow> = mock_name_store_joins();
-        for name in &mock_names {
-            name_repository.insert_one(&name).await.unwrap();
-        }
-        for store in mock_stores {
-            store_repository.insert_one(&store).await.unwrap();
-        }
-        for name_store_join in &mock_name_store_joins {
-            name_store_repository.upsert_one(name_store_join).unwrap();
-        }
-
-        let other_party_supplier = &mock_names[2];
-        let other_party_customer = &mock_names[0];
+        let other_party_supplier = &mock_data.names[2];
+        let other_party_customer = &mock_data.names[0];
 
         let query = r#"mutation InsertOutboundShipment($input: InsertOutboundShipmentInput!) {
             insertOutboundShipment(input: $input) {
@@ -135,7 +110,9 @@ mod graphql {
         );
         assert_gql_query(&settings, query, &variables, &expected).await;
         // make sure item has been inserted
-        invoice_repository.find_one_by_id("ci_insert_1").unwrap();
+        InvoiceRepository::new(&connection)
+            .find_one_by_id("ci_insert_1")
+            .unwrap();
 
         // Test succeeding insert on_hold and their_reference
         let variables = Some(json!({

--- a/tests/graphql/outbound_shipment_update.rs
+++ b/tests/graphql/outbound_shipment_update.rs
@@ -4,14 +4,8 @@ mod graphql {
     use crate::graphql::assert_gql_query;
     use remote_server::{
         database::{
-            mock::{
-                insert_mock_data, mock_invoice_lines, mock_invoices, mock_items, mock_names,
-                mock_stock_lines, mock_stores, MockDataInserts,
-            },
-            repository::{
-                get_repositories, InvoiceLineRepository, InvoiceRepository, ItemRepository,
-                NameRepository, StockLineRepository, StorageConnectionManager, StoreRepository,
-            },
+            mock::MockDataInserts,
+            repository::{InvoiceLineRepository, StockLineRepository},
             schema::InvoiceLineRow,
         },
         domain::stock_line::StockLine,
@@ -21,46 +15,11 @@ mod graphql {
 
     #[actix_rt::test]
     async fn test_graphql_outbound_shipment_update() {
-        let settings = test_db::get_test_settings("omsupply-database-gql-outbound_shipment_update");
-        test_db::setup(&settings.database).await;
-        let repositories = get_repositories(&settings).await;
-        let connection_manager = repositories.get::<StorageConnectionManager>().unwrap();
-        let connection = connection_manager.connection().unwrap();
-
-        // setup
-        let name_repository = NameRepository::new(&connection);
-        let store_repository = StoreRepository::new(&connection);
-        let item_repository = ItemRepository::new(&connection);
-        let stock_line_repository = StockLineRepository::new(&connection);
-        let invoice_repository = InvoiceRepository::new(&connection);
-        let invoice_line_repository = InvoiceLineRepository::new(&connection);
-        let mock_names = mock_names();
-        let mock_stores = mock_stores();
-        let mock_items = mock_items();
-        let mock_stock_lines = mock_stock_lines();
-        let mock_invoices = mock_invoices();
-        let mock_invoice_lines = mock_invoice_lines();
-        for name in &mock_names {
-            name_repository.insert_one(&name).await.unwrap();
-        }
-        for store in mock_stores {
-            store_repository.insert_one(&store).await.unwrap();
-        }
-        for item in &mock_items {
-            item_repository.upsert_one(item).unwrap();
-        }
-        for stock_line in &mock_stock_lines {
-            stock_line_repository.upsert_one(stock_line).unwrap();
-        }
-        for invoice in &mock_invoices {
-            invoice_repository.upsert_one(invoice).unwrap();
-        }
-        for invoice_line in &mock_invoice_lines {
-            invoice_line_repository.upsert_one(invoice_line).unwrap();
-        }
-
-        let mock_data =
-            insert_mock_data(&connection, MockDataInserts::none().full_invoices()).await;
+        let (mock_data, connection, settings) = test_db::setup_all(
+            "omsupply-database-gql-outbound_shipment_update",
+            MockDataInserts::all(),
+        )
+        .await;
 
         let query = r#"mutation DeleteOutboundShipment($input: UpdateOutboundShipmentInput!) {
             updateOutboundShipment(input: $input) {
@@ -144,7 +103,7 @@ mod graphql {
         assert_gql_query(&settings, query, &variables, &expected).await;
 
         // OtherPartyNotACustomerError
-        let other_party_supplier = &mock_names[2];
+        let other_party_supplier = &mock_data.names[2];
         let variables = Some(json!({
           "input": {
             "id": "outbound_shipment_a",
@@ -200,7 +159,7 @@ mod graphql {
                 .iter()
                 .filter_map(|invoice| invoice.stock_line_id.to_owned())
                 .collect();
-            stock_line_repository
+            StockLineRepository::new(&connection)
                 .find_many_by_ids(&stock_line_ids)
                 .unwrap()
         };
@@ -230,7 +189,7 @@ mod graphql {
             };
 
         // test DRAFT to CONFIRMED
-        let invoice_lines = invoice_line_repository
+        let invoice_lines = InvoiceLineRepository::new(&connection)
             .find_many_by_invoice_id("outbound_shipment_c")
             .unwrap();
         let expected_totals = expected_stock_line_totals(&invoice_lines);


### PR DESCRIPTION
Closes #535 

Ended up with more changes then i hoped:

* Needed to add item query test which required
  * Item query test items
  * Full master list
  * One unit
* The above meant that foreign key integrity will be broken unless unit is also inserted in other test, thus refactored other tests slightly to insert all data
* Relocated `invoices` entry date filter from invoice_query to invoices test