### PR TITLE
506 gql user account endpoints

### DIFF
--- a/configuration/base.yaml
+++ b/configuration/base.yaml
@@ -11,3 +11,5 @@ database:
   username: "postgres"
   password: "password"
   database_name: "omsupply-database"
+auth:
+  token_secret: "token-secret"

--- a/src/database/repository/diesel/user_account.rs
+++ b/src/database/repository/diesel/user_account.rs
@@ -30,11 +30,20 @@ impl<'a> UserAccountRepository<'a> {
         Ok(result)
     }
 
-    pub fn find_one_by_user_name(&self, username: &str) -> Result<UserAccountRow, RepositoryError> {
-        let result = user_account_dsl::user_account
+    pub fn find_one_by_user_name(
+        &self,
+        username: &str,
+    ) -> Result<Option<UserAccountRow>, RepositoryError> {
+        let result: Result<UserAccountRow, diesel::result::Error> = user_account_dsl::user_account
             .filter(user_account_dsl::username.eq(username))
-            .first(&self.connection.connection)?;
-        Ok(result)
+            .first(&self.connection.connection);
+        match result {
+            Ok(row) => Ok(Some(row)),
+            Err(err) => match err {
+                diesel::result::Error::NotFound => Ok(None),
+                _ => Err(RepositoryError::from(err)),
+            },
+        }
     }
 
     pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<UserAccountRow>, RepositoryError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,13 +65,13 @@ async fn main() -> std::io::Result<()> {
         App::new()
             .app_data(repository_registry_data_app.clone())
             .app_data(actor_registry_data.clone())
-            .app_data(auth_data.clone())
             .wrap(logger_middleware())
             .wrap(Cors::permissive())
             .wrap(compress_middleware())
             .configure(graphql_config(
                 repository_registry_data_app.clone(),
                 loader_registry_data.clone(),
+                auth_data.clone(),
             ))
             .configure(rest_config)
     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> std::io::Result<()> {
         configuration::get_configuration().expect("Failed to parse configuration settings");
 
     let auth_data = Data::new(AuthData {
-        auth_token_secret: "TODO: get secret from somewhere else, e.g. DB table?".to_string(),
+        auth_token_secret: settings.auth.token_secret.to_owned(),
         token_bucket: RwLock::new(TokenBucket::new()),
         // TODO: configure ssl
         debug_no_ssl: true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,14 @@ use actix_cors::Cors;
 use remote_server::{
     database::{loader::get_loaders, repository::get_repositories},
     server::{
-        data::{ActorRegistry, LoaderMap, LoaderRegistry, RepositoryMap, RepositoryRegistry},
+        data::{
+            auth::AuthData, ActorRegistry, LoaderMap, LoaderRegistry, RepositoryMap,
+            RepositoryRegistry,
+        },
         middleware::{compress as compress_middleware, logger as logger_middleware},
         service::{graphql::config as graphql_config, rest::config as rest_config},
     },
+    service::token_bucket::TokenBucket,
     util::{
         configuration,
         settings::Settings,
@@ -19,7 +23,7 @@ use actix_web::{web::Data, App, HttpServer};
 use std::{
     env,
     net::TcpListener,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
 
@@ -31,6 +35,12 @@ async fn main() -> std::io::Result<()> {
     let settings: Settings =
         configuration::get_configuration().expect("Failed to parse configuration settings");
 
+    let auth_data = Data::new(AuthData {
+        auth_token_secret: "TODO: get secret from somewhere else, e.g. DB table?".to_string(),
+        token_bucket: RwLock::new(TokenBucket::new()),
+        // TODO: configure ssl
+        debug_no_ssl: true,
+    });
     let repositories: RepositoryMap = get_repositories(&settings).await;
     let loaders: LoaderMap = get_loaders(&settings).await;
     let (mut sync_sender, mut sync_receiver): (SyncSenderActor, SyncReceiverActor) =
@@ -55,6 +65,7 @@ async fn main() -> std::io::Result<()> {
         App::new()
             .app_data(repository_registry_data_app.clone())
             .app_data(actor_registry_data.clone())
+            .app_data(auth_data.clone())
             .wrap(logger_middleware())
             .wrap(Cors::permissive())
             .wrap(compress_middleware())

--- a/src/server/data/auth.rs
+++ b/src/server/data/auth.rs
@@ -1,0 +1,10 @@
+use crate::service::token_bucket::TokenBucket;
+use std::sync::RwLock;
+
+pub struct AuthData {
+    /// Secret to sign and verify auth (JWT) tokens.
+    pub auth_token_secret: String,
+    pub token_bucket: RwLock<TokenBucket>,
+    /// Indicates if we ran in debug mode without ssl certificate
+    pub debug_no_ssl: bool,
+}

--- a/src/server/data/mod.rs
+++ b/src/server/data/mod.rs
@@ -1,4 +1,5 @@
 mod actor;
+pub mod auth;
 mod loader;
 mod repository;
 

--- a/src/server/service/graphql/mod.rs
+++ b/src/server/service/graphql/mod.rs
@@ -1,9 +1,12 @@
 pub mod schema;
 
+use actix_web::cookie::Cookie;
+use actix_web::HttpRequest;
 use actix_web::{guard::fn_guard, web::Data, HttpResponse, Result};
 use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use async_graphql::{Context, EmptySubscription, SchemaBuilder};
 use async_graphql_actix_web::{Request, Response};
+use reqwest::header::COOKIE;
 
 use self::schema::{Mutations, Queries, Schema};
 use crate::server::data::auth::AuthData;
@@ -26,7 +29,7 @@ impl<'a> ContextExt for Context<'a> {
     }
 
     fn get_auth_data(&self) -> &AuthData {
-        self.data_unchecked()
+        self.data_unchecked::<Data<AuthData>>()
     }
 }
 
@@ -39,11 +42,13 @@ pub fn build_schema() -> Builder {
 pub fn config(
     repository_registry: Data<RepositoryRegistry>,
     loader_registry: Data<LoaderRegistry>,
+    auth_data: Data<AuthData>,
 ) -> impl FnOnce(&mut actix_web::web::ServiceConfig) {
     |cfg| {
         let schema = build_schema()
             .data(repository_registry)
             .data(loader_registry)
+            .data(auth_data)
             .finish();
         cfg.service(
             actix_web::web::scope("/graphql")
@@ -63,12 +68,50 @@ pub fn config(
     }
 }
 
-async fn graphql(schema: Data<Schema>, req: Request) -> Response {
-    schema.execute(req.into_inner()).await.into()
+// TODO remove dead_code macro (for auth_token)
+#[allow(dead_code)]
+pub struct RequestUserData {
+    auth_token: Option<String>,
+    refresh_token: Option<String>,
+}
+
+fn auth_data_from_request(http_req: &HttpRequest) -> RequestUserData {
+    let headers = http_req.headers();
+    // retrieve auth token
+    let auth_token = headers.get("Authorization").and_then(|header_value| {
+        header_value.to_str().ok().map(|header| {
+            let jwt_start_index = "Bearer ".len();
+            header[jwt_start_index..header.len()].to_string()
+        })
+    });
+
+    // retrieve refresh token
+    let refresh_token = headers.get(COOKIE).and_then(|header_value| {
+        header_value
+            .to_str()
+            .ok()
+            .and_then(|header| Cookie::parse(header).ok())
+            .map(|cookie| cookie.value().to_owned())
+    });
+
+    RequestUserData {
+        auth_token,
+        refresh_token,
+    }
+}
+
+async fn graphql(schema: Data<Schema>, http_req: HttpRequest, req: Request) -> Response {
+    let user_data = auth_data_from_request(&http_req);
+    let query = req.into_inner().data(user_data);
+    schema.execute(query).await.into()
 }
 
 async fn playground() -> Result<HttpResponse> {
     Ok(HttpResponse::Ok()
         .content_type("text/html; charset=utf-8")
-        .body(playground_source(GraphQLPlaygroundConfig::new("/graphql"))))
+        .body(playground_source(
+            GraphQLPlaygroundConfig::new("/graphql")
+                // allow to set cookies
+                .with_setting("request.credentials", "same-origin"),
+        )))
 }

--- a/src/server/service/graphql/mod.rs
+++ b/src/server/service/graphql/mod.rs
@@ -79,9 +79,11 @@ fn auth_data_from_request(http_req: &HttpRequest) -> RequestUserData {
     let headers = http_req.headers();
     // retrieve auth token
     let auth_token = headers.get("Authorization").and_then(|header_value| {
-        header_value.to_str().ok().map(|header| {
-            let jwt_start_index = "Bearer ".len();
-            header[jwt_start_index..header.len()].to_string()
+        header_value.to_str().ok().and_then(|header| {
+            if header.starts_with("Bearer ") {
+                return Some(header["Bearer ".len()..header.len()].to_string());
+            }
+            None
         })
     });
 

--- a/src/server/service/graphql/mod.rs
+++ b/src/server/service/graphql/mod.rs
@@ -6,12 +6,14 @@ use async_graphql::{Context, EmptySubscription, SchemaBuilder};
 use async_graphql_actix_web::{Request, Response};
 
 use self::schema::{Mutations, Queries, Schema};
+use crate::server::data::auth::AuthData;
 use crate::server::data::{LoaderRegistry, RepositoryRegistry};
 
 // Sugar that helps make things neater and avoid errors that would only crop up at runtime.
 trait ContextExt {
     fn get_repository<T: anymap::any::Any + Send + Sync>(&self) -> &T;
     fn get_loader<T: anymap::any::Any + Send + Sync>(&self) -> &T;
+    fn get_auth_data(&self) -> &AuthData;
 }
 
 impl<'a> ContextExt for Context<'a> {
@@ -21,6 +23,10 @@ impl<'a> ContextExt for Context<'a> {
 
     fn get_loader<T: anymap::any::Any + Send + Sync>(&self) -> &T {
         self.data_unchecked::<Data<LoaderRegistry>>().get::<T>()
+    }
+
+    fn get_auth_data(&self) -> &AuthData {
+        self.data_unchecked()
     }
 }
 

--- a/src/server/service/graphql/mod.rs
+++ b/src/server/service/graphql/mod.rs
@@ -68,8 +68,6 @@ pub fn config(
     }
 }
 
-// TODO remove dead_code macro (for auth_token)
-#[allow(dead_code)]
 pub struct RequestUserData {
     auth_token: Option<String>,
     refresh_token: Option<String>,

--- a/src/server/service/graphql/schema/mutations/mod.rs
+++ b/src/server/service/graphql/schema/mutations/mod.rs
@@ -1,17 +1,28 @@
 mod error;
+
 pub mod inbound_shipment;
 pub mod outbound_shipment;
+pub mod user_register;
 
 use super::types::{get_invoice_response, Connector, InvoiceLineNode, InvoiceResponse};
 use crate::{database::repository::StorageConnectionManager, server::service::graphql::ContextExt};
 use async_graphql::*;
 use inbound_shipment::*;
 use outbound_shipment::*;
+pub use user_register::*;
 
 pub struct Mutations;
 
 #[Object]
 impl Mutations {
+    async fn register_user(
+        &self,
+        ctx: &Context<'_>,
+        input: UserRegisterInput,
+    ) -> UserRegisterResponse {
+        user_register(ctx, input)
+    }
+
     async fn insert_outbound_shipment(
         &self,
         ctx: &Context<'_>,

--- a/src/server/service/graphql/schema/mutations/user_register.rs
+++ b/src/server/service/graphql/schema/mutations/user_register.rs
@@ -5,7 +5,9 @@ use crate::server::service::graphql::ContextExt;
 use crate::{
     database::{repository::StorageConnectionManager, schema::UserAccountRow},
     server::service::graphql::schema::types::{DatabaseError, ErrorWrapper},
-    service::user_account::{CreateUserAccount, UserAccountService},
+    service::user_account::{
+        CreateUserAccount, CreateUserAccountError as ServiceError, UserAccountService,
+    },
 };
 
 use super::RecordAlreadyExist;
@@ -73,15 +75,15 @@ pub fn user_register(ctx: &Context<'_>, input: UserRegisterInput) -> UserRegiste
         Err(err) => {
             return UserRegisterResponse::Error(ErrorWrapper {
                 error: match err {
-                    crate::service::user_account::CreateUserAccountError::UserNameExist => {
+                    ServiceError::UserNameExist => {
                         UserRegisterErrorInterface::RecordAlreadyExist(RecordAlreadyExist)
                     }
-                    crate::service::user_account::CreateUserAccountError::PasswordHashError(_) => {
+                    ServiceError::PasswordHashError(_) => {
                         UserRegisterErrorInterface::InternalError(InternalError(
                             "Failed to hash password".to_string(),
                         ))
                     }
-                    crate::service::user_account::CreateUserAccountError::DatabaseError(err) => {
+                    ServiceError::DatabaseError(err) => {
                         UserRegisterErrorInterface::DatabaseError(DatabaseError(err))
                     }
                 },

--- a/src/server/service/graphql/schema/mutations/user_register.rs
+++ b/src/server/service/graphql/schema/mutations/user_register.rs
@@ -63,12 +63,7 @@ pub fn user_register(ctx: &Context<'_>, input: UserRegisterInput) -> UserRegiste
             })
         }
     };
-    let auth_data = ctx.get_auth_data();
-    let service = UserAccountService::new(
-        &con,
-        &auth_data.token_bucket,
-        auth_data.auth_token_secret.as_bytes(),
-    );
+    let service = UserAccountService::new(&con);
     let user = match service.create_user(CreateUserAccount {
         username: input.username,
         password: input.password,

--- a/src/server/service/graphql/schema/mutations/user_register.rs
+++ b/src/server/service/graphql/schema/mutations/user_register.rs
@@ -1,0 +1,97 @@
+use async_graphql::*;
+
+use crate::server::service::graphql::schema::types::InternalError;
+use crate::server::service::graphql::ContextExt;
+use crate::{
+    database::{repository::StorageConnectionManager, schema::UserAccountRow},
+    server::service::graphql::schema::types::{DatabaseError, ErrorWrapper},
+    service::user_account::{CreateUserAccount, UserAccountService},
+};
+
+use super::RecordAlreadyExist;
+
+pub struct RegisteredUser {
+    pub user: UserAccountRow,
+}
+
+#[Object]
+impl RegisteredUser {
+    pub async fn id(&self) -> &str {
+        &self.user.id
+    }
+
+    pub async fn username(&self) -> &str {
+        &self.user.username
+    }
+
+    pub async fn email(&self) -> &Option<String> {
+        &self.user.email
+    }
+}
+
+#[derive(Interface)]
+#[graphql(field(name = "description", type = "&str"))]
+pub enum UserRegisterErrorInterface {
+    /// User already exists
+    RecordAlreadyExist(RecordAlreadyExist),
+    DatabaseError(DatabaseError),
+    InternalError(InternalError),
+}
+
+pub type UserRegisterError = ErrorWrapper<UserRegisterErrorInterface>;
+
+#[derive(Union)]
+pub enum UserRegisterResponse {
+    Error(UserRegisterError),
+    Response(RegisteredUser),
+}
+
+#[derive(InputObject)]
+pub struct UserRegisterInput {
+    username: String,
+    password: String,
+    email: Option<String>,
+}
+
+pub fn user_register(ctx: &Context<'_>, input: UserRegisterInput) -> UserRegisterResponse {
+    let connection_manager = ctx.get_repository::<StorageConnectionManager>();
+    let con = match connection_manager.connection() {
+        Ok(con) => con,
+        Err(err) => {
+            return UserRegisterResponse::Error(ErrorWrapper {
+                error: UserRegisterErrorInterface::DatabaseError(DatabaseError(err)),
+            })
+        }
+    };
+    let auth_data = ctx.get_auth_data();
+    let service = UserAccountService::new(
+        &con,
+        &auth_data.token_bucket,
+        auth_data.auth_token_secret.as_bytes(),
+    );
+    let user = match service.create_user(CreateUserAccount {
+        username: input.username,
+        password: input.password,
+        email: input.email,
+    }) {
+        Ok(user) => user,
+        Err(err) => {
+            return UserRegisterResponse::Error(ErrorWrapper {
+                error: match err {
+                    crate::service::user_account::CreateUserAccountError::UserNameExist => {
+                        UserRegisterErrorInterface::RecordAlreadyExist(RecordAlreadyExist)
+                    }
+                    crate::service::user_account::CreateUserAccountError::PasswordHashError(_) => {
+                        UserRegisterErrorInterface::InternalError(InternalError(
+                            "Failed to hash password".to_string(),
+                        ))
+                    }
+                    crate::service::user_account::CreateUserAccountError::DatabaseError(err) => {
+                        UserRegisterErrorInterface::DatabaseError(DatabaseError(err))
+                    }
+                },
+            })
+        }
+    };
+    UserRegisterResponse::Response(RegisteredUser { user })
+}

--- a/src/server/service/graphql/schema/queries/auth_token.rs
+++ b/src/server/service/graphql/schema/queries/auth_token.rs
@@ -1,5 +1,4 @@
 use async_graphql::*;
-use log::error;
 use reqwest::header::SET_COOKIE;
 
 use crate::server::service::graphql::schema::types::InternalError;
@@ -90,8 +89,7 @@ pub fn auth_token(ctx: &Context<'_>, username: &str, password: &str) -> AuthToke
                 crate::service::user_account::VerifyPasswordError::InvalidCredentials => {
                     AuthTokenErrorInterface::InvalidCredentials(InvalidCredentials)
                 }
-                crate::service::user_account::VerifyPasswordError::InvalidCredentialsBackend(e) => {
-                    error!("{}", e);
+                crate::service::user_account::VerifyPasswordError::InvalidCredentialsBackend(_) => {
                     AuthTokenErrorInterface::InternalError(InternalError(
                         "Failed to read credentials".to_string(),
                     ))
@@ -118,8 +116,7 @@ pub fn auth_token(ctx: &Context<'_>, username: &str, password: &str) -> AuthToke
                     JWTIssuingError::CanNotCreateToken(_) => {
                         AuthTokenErrorInterface::CanNotCreateToken(CanNotCreateToken)
                     }
-                    JWTIssuingError::ConcurrencyLockError(e) => {
-                        error!("{}", e);
+                    JWTIssuingError::ConcurrencyLockError(_) => {
                         AuthTokenErrorInterface::InternalError(InternalError(
                             "Lock error".to_string(),
                         ))

--- a/src/server/service/graphql/schema/queries/auth_token.rs
+++ b/src/server/service/graphql/schema/queries/auth_token.rs
@@ -21,6 +21,7 @@ pub struct AuthToken {
 
 #[Object]
 impl AuthToken {
+    /// Bearer token
     pub async fn token(&self) -> &str {
         &self.pair.token
     }

--- a/src/server/service/graphql/schema/queries/auth_token.rs
+++ b/src/server/service/graphql/schema/queries/auth_token.rs
@@ -1,0 +1,141 @@
+use async_graphql::*;
+use log::error;
+use reqwest::header::SET_COOKIE;
+
+use crate::server::service::graphql::ContextExt;
+use crate::{
+    database::repository::StorageConnectionManager,
+    service::user_account::{JWTIssuingError, TokenPair, UserAccountService},
+};
+
+use super::{DatabaseError, ErrorWrapper};
+
+pub struct AuthToken {
+    pub pair: TokenPair,
+}
+
+#[Object]
+impl AuthToken {
+    pub async fn token(&self) -> &str {
+        &self.pair.token
+    }
+}
+
+pub struct UserNameDoesNotExist;
+#[Object]
+impl UserNameDoesNotExist {
+    pub async fn description(&self) -> &'static str {
+        "User does not exist"
+    }
+}
+
+pub struct InvalidCredentials;
+#[Object]
+impl InvalidCredentials {
+    pub async fn description(&self) -> &'static str {
+        "Invalid credentials"
+    }
+}
+
+pub struct InternalError;
+#[Object]
+impl InternalError {
+    pub async fn description(&self) -> &'static str {
+        "Internal Error"
+    }
+}
+
+pub struct CanNotCreateToken;
+#[Object]
+impl CanNotCreateToken {
+    pub async fn description(&self) -> &'static str {
+        "Invalid credentials"
+    }
+}
+
+#[derive(Interface)]
+#[graphql(field(name = "description", type = "&str"))]
+pub enum AuthTokenErrorInterface {
+    DatabaseError(DatabaseError),
+    UserNameDoesNotExist(UserNameDoesNotExist),
+    InvalidCredentials(InvalidCredentials),
+    CanNotCreateToken(CanNotCreateToken),
+    InternalError(InternalError),
+}
+
+pub type AuthTokenError = ErrorWrapper<AuthTokenErrorInterface>;
+
+#[derive(Union)]
+pub enum AuthTokenResponse {
+    Error(AuthTokenError),
+    Response(AuthToken),
+}
+
+pub fn auth_token(ctx: &Context<'_>, username: &str, password: &str) -> AuthTokenResponse {
+    let connection_manager = ctx.get_repository::<StorageConnectionManager>();
+    let con = match connection_manager.connection() {
+        Ok(con) => con,
+        Err(err) => {
+            return AuthTokenResponse::Error(ErrorWrapper {
+                error: AuthTokenErrorInterface::DatabaseError(DatabaseError(err)),
+            })
+        }
+    };
+    let auth_data = ctx.get_auth_data();
+    let mut service = UserAccountService::new(
+        &con,
+        &auth_data.token_bucket,
+        auth_data.auth_token_secret.as_bytes(),
+    );
+    let max_age_token = chrono::Duration::minutes(60).num_seconds() as usize;
+    let max_age_refresh = chrono::Duration::hours(6).num_seconds() as usize;
+    let pair = match service.jwt_token(username, &password, max_age_token, max_age_refresh) {
+        Ok(pair) => pair,
+        Err(err) => {
+            return AuthTokenResponse::Error(ErrorWrapper {
+                error: match err {
+                    JWTIssuingError::UserNameDoesNotExist => {
+                        AuthTokenErrorInterface::UserNameDoesNotExist(UserNameDoesNotExist)
+                    }
+                    JWTIssuingError::InvalidCredentials => {
+                        AuthTokenErrorInterface::InvalidCredentials(InvalidCredentials)
+                    }
+                    JWTIssuingError::CanNotCreateToken(_) => {
+                        AuthTokenErrorInterface::CanNotCreateToken(CanNotCreateToken)
+                    }
+                    JWTIssuingError::DatabaseError(err) => {
+                        AuthTokenErrorInterface::DatabaseError(DatabaseError(err))
+                    }
+                    JWTIssuingError::InvalidCredentialsBackend(e) => {
+                        error!("{}", e);
+                        AuthTokenErrorInterface::InternalError(InternalError)
+                    }
+                    JWTIssuingError::ConcurrencyLockError(e) => {
+                        error!("{}", e);
+                        AuthTokenErrorInterface::InternalError(InternalError)
+                    }
+                },
+            })
+        }
+    };
+
+    // Store refresh token in a cookie:
+    // - HttpOnly cookie (not readable from js).
+    // - Secure (https only)
+    // - SameSite (only attached to request originating from the same site)
+    // Also see:
+    // https://hasura.io/blog/best-practices-of-using-jwt-with-graphql/
+    let secure = if auth_data.debug_no_ssl {
+        " Secure;"
+    } else {
+        ""
+    };
+    ctx.insert_http_header(
+        SET_COOKIE,
+        format!(
+            "refresh_token={}; Max-Age={};{} HttpOnly; SameSite=Strict",
+            pair.refresh, max_age_refresh, secure
+        ),
+    );
+    AuthTokenResponse::Response(AuthToken { pair })
+}

--- a/src/server/service/graphql/schema/queries/auth_token.rs
+++ b/src/server/service/graphql/schema/queries/auth_token.rs
@@ -42,21 +42,12 @@ impl InvalidCredentials {
     }
 }
 
-pub struct CanNotCreateToken;
-#[Object]
-impl CanNotCreateToken {
-    pub async fn description(&self) -> &'static str {
-        "Invalid credentials"
-    }
-}
-
 #[derive(Interface)]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum AuthTokenErrorInterface {
     DatabaseError(DatabaseError),
     UserNameDoesNotExist(UserNameDoesNotExist),
     InvalidCredentials(InvalidCredentials),
-    CanNotCreateToken(CanNotCreateToken),
     InternalError(InternalError),
 }
 
@@ -114,7 +105,9 @@ pub fn auth_token(ctx: &Context<'_>, username: &str, password: &str) -> AuthToke
             return AuthTokenResponse::Error(ErrorWrapper {
                 error: match err {
                     JWTIssuingError::CanNotCreateToken(_) => {
-                        AuthTokenErrorInterface::CanNotCreateToken(CanNotCreateToken)
+                        AuthTokenErrorInterface::InternalError(InternalError(
+                            "Can not create token".to_string(),
+                        ))
                     }
                     JWTIssuingError::ConcurrencyLockError(_) => {
                         AuthTokenErrorInterface::InternalError(InternalError(

--- a/src/server/service/graphql/schema/queries/auth_token.rs
+++ b/src/server/service/graphql/schema/queries/auth_token.rs
@@ -2,6 +2,7 @@ use async_graphql::*;
 use log::error;
 use reqwest::header::SET_COOKIE;
 
+use crate::server::service::graphql::schema::types::InternalError;
 use crate::server::service::graphql::ContextExt;
 use crate::{
     database::repository::StorageConnectionManager,
@@ -34,14 +35,6 @@ pub struct InvalidCredentials;
 impl InvalidCredentials {
     pub async fn description(&self) -> &'static str {
         "Invalid credentials"
-    }
-}
-
-pub struct InternalError;
-#[Object]
-impl InternalError {
-    pub async fn description(&self) -> &'static str {
-        "Internal Error"
     }
 }
 
@@ -108,11 +101,15 @@ pub fn auth_token(ctx: &Context<'_>, username: &str, password: &str) -> AuthToke
                     }
                     JWTIssuingError::InvalidCredentialsBackend(e) => {
                         error!("{}", e);
-                        AuthTokenErrorInterface::InternalError(InternalError)
+                        AuthTokenErrorInterface::InternalError(InternalError(
+                            "Failed to read credentials".to_string(),
+                        ))
                     }
                     JWTIssuingError::ConcurrencyLockError(e) => {
                         error!("{}", e);
-                        AuthTokenErrorInterface::InternalError(InternalError)
+                        AuthTokenErrorInterface::InternalError(InternalError(
+                            "Lock error".to_string(),
+                        ))
                     }
                 },
             })

--- a/src/server/service/graphql/schema/queries/login.rs
+++ b/src/server/service/graphql/schema/queries/login.rs
@@ -59,7 +59,7 @@ pub enum AuthTokenResponse {
     Response(AuthToken),
 }
 
-pub fn auth_token(ctx: &Context<'_>, username: &str, password: &str) -> AuthTokenResponse {
+pub fn login(ctx: &Context<'_>, username: &str, password: &str) -> AuthTokenResponse {
     let connection_manager = ctx.get_repository::<StorageConnectionManager>();
     let con = match connection_manager.connection() {
         Ok(con) => con,

--- a/src/server/service/graphql/schema/queries/logout.rs
+++ b/src/server/service/graphql/schema/queries/logout.rs
@@ -1,0 +1,143 @@
+use async_graphql::*;
+use log::error;
+
+use crate::server::service::graphql::schema::types::InternalError;
+use crate::server::service::graphql::{ContextExt, RequestUserData};
+use crate::service::token::TokenService;
+
+use super::{set_refresh_token_cookie, ErrorWrapper};
+
+pub struct Logout {
+    pub user_id: String,
+}
+
+#[Object]
+impl Logout {
+    /// User id of the logged out user
+    pub async fn user_id(&self) -> &str {
+        &self.user_id
+    }
+}
+
+pub struct MissingAuthToken;
+#[Object]
+impl MissingAuthToken {
+    pub async fn description(&self) -> &'static str {
+        "Auth token was not provided"
+    }
+}
+
+pub struct ExpiredSignature;
+#[Object]
+impl ExpiredSignature {
+    pub async fn description(&self) -> &'static str {
+        "Provided token is expired"
+    }
+}
+
+pub struct InvalidToken;
+#[Object]
+impl InvalidToken {
+    pub async fn description(&self) -> &'static str {
+        "Provided token is invalid"
+    }
+}
+
+pub struct TokenInvalided;
+#[Object]
+impl TokenInvalided {
+    pub async fn description(&self) -> &'static str {
+        "Token has been invalidated by the server"
+    }
+}
+
+pub struct NotAnApiToken;
+#[Object]
+impl NotAnApiToken {
+    pub async fn description(&self) -> &'static str {
+        "Not an api token"
+    }
+}
+
+#[derive(Interface)]
+#[graphql(field(name = "description", type = "&str"))]
+pub enum LogoutErrorInterface {
+    MissingAuthToken(MissingAuthToken),
+    ExpiredSignature(ExpiredSignature),
+    InvalidToken(InvalidToken),
+    TokenInvalided(TokenInvalided),
+    NotAnApiToken(NotAnApiToken),
+    InternalError(InternalError),
+}
+
+pub type LogoutError = ErrorWrapper<LogoutErrorInterface>;
+
+#[derive(Union)]
+pub enum LogoutResponse {
+    Error(LogoutError),
+    Response(Logout),
+}
+
+pub fn logout(ctx: &Context<'_>) -> LogoutResponse {
+    let auth_data = ctx.get_auth_data();
+    let mut service = TokenService::new(
+        &auth_data.token_bucket,
+        auth_data.auth_token_secret.as_bytes(),
+    );
+
+    let auth_token = match ctx
+        .data_opt::<RequestUserData>()
+        .and_then(|d| d.auth_token.to_owned())
+    {
+        Some(data) => data,
+        None => {
+            return LogoutResponse::Error(ErrorWrapper {
+                error: LogoutErrorInterface::MissingAuthToken(MissingAuthToken),
+            })
+        }
+    };
+
+    // verify that the provided token is valid
+    let claims = match service.verify_token(&auth_token) {
+        Ok(claims) => claims,
+        Err(err) => {
+            let e = match err {
+                crate::service::token::JWTValidationError::ExpiredSignature => todo!(),
+                crate::service::token::JWTValidationError::NotAnApiToken => {
+                    LogoutErrorInterface::NotAnApiToken(NotAnApiToken)
+                }
+                crate::service::token::JWTValidationError::InvalidToken(e) => {
+                    error!("logout InvalidToken: {}", e);
+                    LogoutErrorInterface::InvalidToken(InvalidToken)
+                }
+                crate::service::token::JWTValidationError::TokenInvalided => {
+                    LogoutErrorInterface::TokenInvalided(TokenInvalided)
+                }
+                crate::service::token::JWTValidationError::ConcurrencyLockError(e) => {
+                    error!("logout ConcurrencyLockError: {}", e);
+                    LogoutErrorInterface::InternalError(InternalError("Lock error".to_string()))
+                }
+            };
+            return LogoutResponse::Error(ErrorWrapper { error: e });
+        }
+    };
+    // do the actual logout
+    let user_id = claims.sub;
+    match service.logout(&user_id) {
+        Ok(_) => {}
+        Err(e) => match e {
+            crate::service::token::JWTLogoutError::ConcurrencyLockError(e) => {
+                error!("logout ConcurrencyLockError: {}", e);
+                return LogoutResponse::Error(ErrorWrapper {
+                    error: LogoutErrorInterface::InternalError(InternalError(
+                        "Lock error".to_string(),
+                    )),
+                });
+            }
+        },
+    };
+    // invalid the refresh token cookie
+    set_refresh_token_cookie(ctx, "logged out", 0, auth_data.debug_no_ssl);
+
+    LogoutResponse::Response(Logout { user_id })
+}

--- a/src/server/service/graphql/schema/queries/logout.rs
+++ b/src/server/service/graphql/schema/queries/logout.rs
@@ -1,5 +1,4 @@
 use async_graphql::*;
-use log::error;
 
 use crate::server::service::graphql::schema::types::InternalError;
 use crate::server::service::graphql::{ContextExt, RequestUserData};
@@ -106,15 +105,13 @@ pub fn logout(ctx: &Context<'_>) -> LogoutResponse {
                 crate::service::token::JWTValidationError::NotAnApiToken => {
                     LogoutErrorInterface::NotAnApiToken(NotAnApiToken)
                 }
-                crate::service::token::JWTValidationError::InvalidToken(e) => {
-                    error!("logout InvalidToken: {}", e);
+                crate::service::token::JWTValidationError::InvalidToken(_) => {
                     LogoutErrorInterface::InvalidToken(InvalidToken)
                 }
                 crate::service::token::JWTValidationError::TokenInvalided => {
                     LogoutErrorInterface::TokenInvalided(TokenInvalided)
                 }
-                crate::service::token::JWTValidationError::ConcurrencyLockError(e) => {
-                    error!("logout ConcurrencyLockError: {}", e);
+                crate::service::token::JWTValidationError::ConcurrencyLockError(_) => {
                     LogoutErrorInterface::InternalError(InternalError("Lock error".to_string()))
                 }
             };
@@ -126,8 +123,7 @@ pub fn logout(ctx: &Context<'_>) -> LogoutResponse {
     match service.logout(&user_id) {
         Ok(_) => {}
         Err(e) => match e {
-            crate::service::token::JWTLogoutError::ConcurrencyLockError(e) => {
-                error!("logout ConcurrencyLockError: {}", e);
+            crate::service::token::JWTLogoutError::ConcurrencyLockError(_) => {
                 return LogoutResponse::Error(ErrorWrapper {
                     error: LogoutErrorInterface::InternalError(InternalError(
                         "Lock error".to_string(),

--- a/src/server/service/graphql/schema/queries/logout.rs
+++ b/src/server/service/graphql/schema/queries/logout.rs
@@ -84,6 +84,9 @@ pub fn logout(ctx: &Context<'_>) -> LogoutResponse {
         auth_data.auth_token_secret.as_bytes(),
     );
 
+    // invalid the refresh token cookie first (just in case an error happens before we do so)
+    set_refresh_token_cookie(ctx, "logged out", 0, auth_data.debug_no_ssl);
+
     let auth_token = match ctx
         .data_opt::<RequestUserData>()
         .and_then(|d| d.auth_token.to_owned())
@@ -119,8 +122,6 @@ pub fn logout(ctx: &Context<'_>) -> LogoutResponse {
         }
     };
 
-    // invalid the refresh token cookie first (just in case logout returns with an error)
-    set_refresh_token_cookie(ctx, "logged out", 0, auth_data.debug_no_ssl);
     // invalided all tokens of the user on the server
     let user_id = claims.sub;
     match service.logout(&user_id) {

--- a/src/server/service/graphql/schema/queries/logout.rs
+++ b/src/server/service/graphql/schema/queries/logout.rs
@@ -118,7 +118,10 @@ pub fn logout(ctx: &Context<'_>) -> LogoutResponse {
             return LogoutResponse::Error(ErrorWrapper { error: e });
         }
     };
-    // do the actual logout
+
+    // invalid the refresh token cookie first (just in case logout returns with an error)
+    set_refresh_token_cookie(ctx, "logged out", 0, auth_data.debug_no_ssl);
+    // invalided all tokens of the user on the server
     let user_id = claims.sub;
     match service.logout(&user_id) {
         Ok(_) => {}
@@ -132,8 +135,6 @@ pub fn logout(ctx: &Context<'_>) -> LogoutResponse {
             }
         },
     };
-    // invalid the refresh token cookie
-    set_refresh_token_cookie(ctx, "logged out", 0, auth_data.debug_no_ssl);
 
     LogoutResponse::Response(Logout { user_id })
 }

--- a/src/server/service/graphql/schema/queries/mod.rs
+++ b/src/server/service/graphql/schema/queries/mod.rs
@@ -14,6 +14,8 @@ pub struct Queries;
 
 pub mod auth_token;
 pub use self::auth_token::*;
+pub mod refresh_token;
+pub use self::refresh_token::*;
 
 #[Object]
 impl Queries {
@@ -31,6 +33,12 @@ impl Queries {
         #[graphql(desc = "Password")] password: String,
     ) -> AuthTokenResponse {
         auth_token(ctx, &username, &password)
+    }
+
+    /// Retrieves a new auth bearer and refresh token
+    /// The refresh token is returned as a cookie
+    pub async fn refresh_token(&self, ctx: &Context<'_>) -> RefreshTokenResponse {
+        refresh_token(ctx)
     }
 
     /// Query omSupply "name" entries

--- a/src/server/service/graphql/schema/queries/mod.rs
+++ b/src/server/service/graphql/schema/queries/mod.rs
@@ -14,6 +14,8 @@ pub struct Queries;
 
 pub mod auth_token;
 pub use self::auth_token::*;
+pub mod logout;
+pub use self::logout::*;
 pub mod refresh_token;
 pub use self::refresh_token::*;
 
@@ -33,6 +35,10 @@ impl Queries {
         #[graphql(desc = "Password")] password: String,
     ) -> AuthTokenResponse {
         auth_token(ctx, &username, &password)
+    }
+
+    pub async fn logout(&self, ctx: &Context<'_>) -> LogoutResponse {
+        logout(ctx)
     }
 
     /// Retrieves a new auth bearer and refresh token

--- a/src/server/service/graphql/schema/queries/mod.rs
+++ b/src/server/service/graphql/schema/queries/mod.rs
@@ -12,8 +12,8 @@ use async_graphql::{Context, Object};
 use super::types::*;
 pub struct Queries;
 
-pub mod auth_token;
-pub use self::auth_token::*;
+pub mod login;
+pub use self::login::*;
 pub mod logout;
 pub use self::logout::*;
 pub mod refresh_token;
@@ -34,7 +34,7 @@ impl Queries {
         #[graphql(desc = "UserName")] username: String,
         #[graphql(desc = "Password")] password: String,
     ) -> AuthTokenResponse {
-        auth_token(ctx, &username, &password)
+        login(ctx, &username, &password)
     }
 
     pub async fn logout(&self, ctx: &Context<'_>) -> LogoutResponse {

--- a/src/server/service/graphql/schema/queries/mod.rs
+++ b/src/server/service/graphql/schema/queries/mod.rs
@@ -12,11 +12,25 @@ use async_graphql::{Context, Object};
 use super::types::*;
 pub struct Queries;
 
+pub mod auth_token;
+pub use self::auth_token::*;
+
 #[Object]
 impl Queries {
     #[allow(non_snake_case)]
     pub async fn apiVersion(&self) -> String {
         "1.0".to_string()
+    }
+
+    /// Retrieves a new auth bearer and refresh token
+    /// The refresh token is returned as a cookie
+    pub async fn auth_token(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(desc = "UserName")] username: String,
+        #[graphql(desc = "Password")] password: String,
+    ) -> AuthTokenResponse {
+        auth_token(ctx, &username, &password)
     }
 
     /// Query omSupply "name" entries

--- a/src/server/service/graphql/schema/queries/refresh_token.rs
+++ b/src/server/service/graphql/schema/queries/refresh_token.rs
@@ -1,5 +1,4 @@
 use async_graphql::*;
-use log::error;
 
 use crate::server::service::graphql::schema::types::InternalError;
 use crate::server::service::graphql::{ContextExt, RequestUserData};
@@ -107,14 +106,12 @@ pub fn refresh_token(ctx: &Context<'_>) -> RefreshTokenResponse {
                     JWTRefreshError::InvalidToken(_) => {
                         RefreshTokenErrorInterface::InvalidToken(InvalidToken)
                     }
-                    JWTRefreshError::FailedToCreateNewToken(e) => {
-                        error!("{}", e);
+                    JWTRefreshError::FailedToCreateNewToken(_) => {
                         RefreshTokenErrorInterface::InternalError(InternalError(
                             "Failed to create new token".to_string(),
                         ))
                     }
-                    JWTRefreshError::ConcurrencyLockError(e) => {
-                        error!("{}", e);
+                    JWTRefreshError::ConcurrencyLockError(_) => {
                         RefreshTokenErrorInterface::InternalError(InternalError(
                             "Lock error".to_string(),
                         ))

--- a/src/server/service/graphql/schema/queries/refresh_token.rs
+++ b/src/server/service/graphql/schema/queries/refresh_token.rs
@@ -1,0 +1,129 @@
+use async_graphql::*;
+use log::error;
+
+use crate::server::service::graphql::schema::types::InternalError;
+use crate::server::service::graphql::{ContextExt, RequestUserData};
+use crate::service::token::{JWTRefreshError, TokenPair, TokenService};
+
+use super::{set_refresh_token_cookie, DatabaseError, ErrorWrapper};
+
+pub struct RefreshToken {
+    pub pair: TokenPair,
+}
+
+#[Object]
+impl RefreshToken {
+    pub async fn token(&self) -> &str {
+        &self.pair.token
+    }
+}
+
+pub struct NoRefreshTokenProvided;
+#[Object]
+impl NoRefreshTokenProvided {
+    pub async fn description(&self) -> &'static str {
+        "No refresh token provided"
+    }
+}
+
+pub struct TokenExpired;
+#[Object]
+impl TokenExpired {
+    pub async fn description(&self) -> &'static str {
+        "Token is expired"
+    }
+}
+
+pub struct NotARefreshToken;
+#[Object]
+impl NotARefreshToken {
+    pub async fn description(&self) -> &'static str {
+        "Not a refresh token"
+    }
+}
+
+pub struct InvalidToken;
+#[Object]
+impl InvalidToken {
+    pub async fn description(&self) -> &'static str {
+        "Invalid token"
+    }
+}
+
+#[derive(Interface)]
+#[graphql(field(name = "description", type = "&str"))]
+pub enum RefreshTokenErrorInterface {
+    NoRefreshTokenProvided(NoRefreshTokenProvided),
+    TokenExpired(TokenExpired),
+    NotARefreshToken(NotARefreshToken),
+    InvalidToken(InvalidToken),
+    DatabaseError(DatabaseError),
+    InternalError(InternalError),
+}
+
+pub type RefreshTokenError = ErrorWrapper<RefreshTokenErrorInterface>;
+
+#[derive(Union)]
+pub enum RefreshTokenResponse {
+    Error(RefreshTokenError),
+    Response(RefreshToken),
+}
+
+pub fn refresh_token(ctx: &Context<'_>) -> RefreshTokenResponse {
+    let auth_data = ctx.get_auth_data();
+    let mut service = TokenService::new(
+        &auth_data.token_bucket,
+        auth_data.auth_token_secret.as_bytes(),
+    );
+
+    let refresh_token = match ctx
+        .data_opt::<RequestUserData>()
+        .and_then(|d| d.refresh_token.to_owned())
+    {
+        Some(data) => data,
+        None => {
+            return RefreshTokenResponse::Error(ErrorWrapper {
+                error: RefreshTokenErrorInterface::NoRefreshTokenProvided(NoRefreshTokenProvided),
+            })
+        }
+    };
+    let max_age_token = chrono::Duration::minutes(60).num_seconds() as usize;
+    let max_age_refresh = chrono::Duration::hours(6).num_seconds() as usize;
+    let pair = match service.refresh_token(&refresh_token, max_age_token, max_age_refresh) {
+        Ok(pair) => pair,
+        Err(err) => {
+            return RefreshTokenResponse::Error(ErrorWrapper {
+                error: match err {
+                    JWTRefreshError::ExpiredSignature => {
+                        RefreshTokenErrorInterface::TokenExpired(TokenExpired)
+                    }
+                    JWTRefreshError::TokenInvalided => {
+                        RefreshTokenErrorInterface::TokenExpired(TokenExpired)
+                    }
+                    JWTRefreshError::NotARefreshToken => {
+                        RefreshTokenErrorInterface::NotARefreshToken(NotARefreshToken)
+                    }
+                    JWTRefreshError::InvalidToken(_) => {
+                        RefreshTokenErrorInterface::InvalidToken(InvalidToken)
+                    }
+                    JWTRefreshError::FailedToCreateNewToken(e) => {
+                        error!("{}", e);
+                        RefreshTokenErrorInterface::InternalError(InternalError(
+                            "Failed to create new token".to_string(),
+                        ))
+                    }
+                    JWTRefreshError::ConcurrencyLockError(e) => {
+                        error!("{}", e);
+                        RefreshTokenErrorInterface::InternalError(InternalError(
+                            "Lock error".to_string(),
+                        ))
+                    }
+                },
+            })
+        }
+    };
+
+    set_refresh_token_cookie(ctx, &pair.refresh, max_age_refresh, auth_data.debug_no_ssl);
+
+    RefreshTokenResponse::Response(RefreshToken { pair })
+}

--- a/src/server/service/graphql/schema/queries/refresh_token.rs
+++ b/src/server/service/graphql/schema/queries/refresh_token.rs
@@ -13,6 +13,7 @@ pub struct RefreshToken {
 
 #[Object]
 impl RefreshToken {
+    /// New Bearer token
     pub async fn token(&self) -> &str {
         &self.pair.token
     }

--- a/src/server/service/graphql/schema/types/mod.rs
+++ b/src/server/service/graphql/schema/types/mod.rs
@@ -2,7 +2,8 @@ use crate::{
     database::repository::RepositoryError,
     domain::PaginationOption,
     server::service::graphql::schema::{
-        mutations::UserRegisterErrorInterface, queries::AuthTokenErrorInterface,
+        mutations::UserRegisterErrorInterface,
+        queries::{AuthTokenErrorInterface, RefreshTokenErrorInterface},
     },
     service::{usize_to_u32, ListError, ListResult, SingleRecordError},
 };
@@ -145,6 +146,7 @@ impl From<PaginationInput> for PaginationOption {
 ))]
 #[graphql(concrete(name = "UserRegisterError", params(UserRegisterErrorInterface)))]
 #[graphql(concrete(name = "AuthTokenError", params(AuthTokenErrorInterface)))]
+#[graphql(concrete(name = "RefreshTokenError", params(RefreshTokenErrorInterface)))]
 pub struct ErrorWrapper<T: OutputType> {
     pub error: T,
 }

--- a/src/server/service/graphql/schema/types/mod.rs
+++ b/src/server/service/graphql/schema/types/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     database::repository::RepositoryError,
     domain::PaginationOption,
+    server::service::graphql::schema::queries::AuthTokenErrorInterface,
     service::{usize_to_u32, ListError, ListResult, SingleRecordError},
 };
 
@@ -140,7 +141,7 @@ impl From<PaginationInput> for PaginationOption {
     name = "DeleteOutboundShipmentLineError",
     params(DeleteOutboundShipmentLineErrorInterface)
 ))]
-
+#[graphql(concrete(name = "AuthTokenError", params(AuthTokenErrorInterface)))]
 pub struct ErrorWrapper<T: OutputType> {
     pub error: T,
 }

--- a/src/server/service/graphql/schema/types/mod.rs
+++ b/src/server/service/graphql/schema/types/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     domain::PaginationOption,
     server::service::graphql::schema::{
         mutations::UserRegisterErrorInterface,
-        queries::{AuthTokenErrorInterface, RefreshTokenErrorInterface},
+        queries::{AuthTokenErrorInterface, LogoutErrorInterface, RefreshTokenErrorInterface},
     },
     service::{usize_to_u32, ListError, ListResult, SingleRecordError},
 };
@@ -147,6 +147,7 @@ impl From<PaginationInput> for PaginationOption {
 #[graphql(concrete(name = "UserRegisterError", params(UserRegisterErrorInterface)))]
 #[graphql(concrete(name = "AuthTokenError", params(AuthTokenErrorInterface)))]
 #[graphql(concrete(name = "RefreshTokenError", params(RefreshTokenErrorInterface)))]
+#[graphql(concrete(name = "LogoutError", params(LogoutErrorInterface)))]
 pub struct ErrorWrapper<T: OutputType> {
     pub error: T,
 }

--- a/src/server/service/graphql/schema/types/mod.rs
+++ b/src/server/service/graphql/schema/types/mod.rs
@@ -1,7 +1,9 @@
 use crate::{
     database::repository::RepositoryError,
     domain::PaginationOption,
-    server::service::graphql::schema::queries::AuthTokenErrorInterface,
+    server::service::graphql::schema::{
+        mutations::UserRegisterErrorInterface, queries::AuthTokenErrorInterface,
+    },
     service::{usize_to_u32, ListError, ListResult, SingleRecordError},
 };
 
@@ -141,6 +143,7 @@ impl From<PaginationInput> for PaginationOption {
     name = "DeleteOutboundShipmentLineError",
     params(DeleteOutboundShipmentLineErrorInterface)
 ))]
+#[graphql(concrete(name = "UserRegisterError", params(UserRegisterErrorInterface)))]
 #[graphql(concrete(name = "AuthTokenError", params(AuthTokenErrorInterface)))]
 pub struct ErrorWrapper<T: OutputType> {
     pub error: T,
@@ -233,6 +236,19 @@ impl DatabaseError {
 
     pub async fn full_error(&self) -> String {
         format!("{:#}", self.0)
+    }
+}
+
+pub struct InternalError(pub String);
+
+#[Object]
+impl InternalError {
+    pub async fn description(&self) -> &'static str {
+        "Internal Error"
+    }
+
+    pub async fn full_error(&self) -> String {
+        format!("Internal Error: {}", self.0)
     }
 }
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -9,6 +9,7 @@ pub mod invoice_line;
 pub mod item;
 pub mod name;
 pub mod stock_line;
+pub mod token;
 pub mod token_bucket;
 pub mod user_account;
 

--- a/src/service/token.rs
+++ b/src/service/token.rs
@@ -1,0 +1,336 @@
+use std::sync::RwLock;
+
+use anyhow::anyhow;
+use chrono::Utc;
+use jsonwebtoken::errors::{Error as JWTError, ErrorKind as JWTErrorKind};
+use serde::{Deserialize, Serialize};
+
+use super::token_bucket::TokenBucket;
+
+#[derive(Debug, Serialize, Deserialize)]
+enum Audience {
+    /// Token is for general api usage
+    Api,
+    /// Token can be used for a token refresh
+    TokenRefresh,
+}
+
+// TODO: make the issuer configurable?
+const ISSUER: &str = "om-supply-remote-server";
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OmSupplyClaim {
+    /// Required (validate_exp defaults to true in validation). Expiration time (as UTC timestamp)
+    exp: usize,
+
+    /// Audience
+    aud: Audience,
+    /// Issued at (as UTC timestamp)
+    iat: usize,
+    /// Issuer
+    iss: String,
+    /// Subject (user id the token refers to)
+    sub: String,
+}
+
+/// Error for getting a JWT token
+#[derive(Debug)]
+pub enum JWTIssuingError {
+    CanNotCreateToken(JWTError),
+    ConcurrencyLockError(anyhow::Error),
+}
+
+#[derive(Debug)]
+pub enum JWTValidationError {
+    ExpiredSignature,
+    NotAnApiToken,
+    InvalidToken(JWTError),
+    /// Token has been invalidated on the backend
+    TokenInvalided,
+    ConcurrencyLockError(anyhow::Error),
+}
+
+#[derive(Debug)]
+pub enum JWTRefreshError {
+    ExpiredSignature,
+    NotARefreshToken,
+    InvalidToken(JWTError),
+    FailedToCreateNewToken(JWTError),
+    /// Token has been invalidated on the backend
+    TokenInvalided,
+    ConcurrencyLockError(anyhow::Error),
+}
+
+#[derive(Debug)]
+pub enum JWTLogoutError {
+    ConcurrencyLockError(anyhow::Error),
+}
+
+#[derive(Debug)]
+pub struct TokenPair {
+    /// The JWT token
+    pub token: String,
+    /// expiry date of the token
+    pub expiry_date: usize,
+    /// The JWT refresh token
+    pub refresh: String,
+    /// Expiry date of the refresh token
+    pub refresh_expiry_date: usize,
+}
+
+pub struct TokenService<'a> {
+    token_bucket: &'a RwLock<TokenBucket>,
+    jwt_token_secret: &'a [u8],
+}
+
+impl<'a> TokenService<'a> {
+    pub fn new(token_bucket: &'a RwLock<TokenBucket>, jwt_token_secret: &'a [u8]) -> Self {
+        TokenService {
+            token_bucket,
+            jwt_token_secret,
+        }
+    }
+
+    /// Creates new json web token for a given user
+    ///
+    /// # Arguments
+    ///
+    /// * `valid_for` - duration (sec) for how long the token will be valid
+    /// * `refresh_token_valid_for` - duration (sec) for how long the refresh token will be valid
+    pub fn jwt_token(
+        &mut self,
+        user_id: &str,
+        valid_for: usize,
+        refresh_token_valid_for: usize,
+    ) -> Result<TokenPair, JWTIssuingError> {
+        let pair = create_jwt_pair(
+            user_id,
+            self.jwt_token_secret,
+            valid_for,
+            refresh_token_valid_for,
+        )
+        .map_err(|err| JWTIssuingError::CanNotCreateToken(err))?;
+
+        // add tokens to bucket
+        let mut token_bucket = self
+            .token_bucket
+            .write()
+            .map_err(|e| JWTIssuingError::ConcurrencyLockError(anyhow!("jwt_token: {}", e)))?;
+        token_bucket.put(user_id, &pair.token, pair.expiry_date);
+        token_bucket.put(user_id, &pair.refresh, pair.refresh_expiry_date);
+
+        Ok(pair)
+    }
+
+    /// Get a new token and also update the refresh token
+    ///
+    /// # Arguments
+    /// * `valid_for` - duration (sec) for how long the token will be valid
+    /// * `refresh_token_valid_for` - duration (sec) for how long the refresh token will be valid
+    pub fn refresh_token(
+        &mut self,
+        refresh_token: &str,
+        valid_for: usize,
+        refresh_token_valid_for: usize,
+    ) -> Result<TokenPair, JWTRefreshError> {
+        let mut validation = jsonwebtoken::Validation::default();
+        validation.set_audience(&vec![format!("{:?}", Audience::TokenRefresh)]);
+        validation.iss = Some(ISSUER.to_string());
+        let decoded = jsonwebtoken::decode::<OmSupplyClaim>(
+            refresh_token,
+            &jsonwebtoken::DecodingKey::from_secret(self.jwt_token_secret),
+            &validation,
+        )
+        .map_err(|err| match err.kind() {
+            JWTErrorKind::ExpiredSignature => JWTRefreshError::ExpiredSignature,
+            JWTErrorKind::InvalidAudience => JWTRefreshError::NotARefreshToken,
+            _ => JWTRefreshError::InvalidToken(err),
+        })?;
+
+        let user_id = decoded.claims.sub;
+        let pair = create_jwt_pair(
+            &user_id,
+            self.jwt_token_secret,
+            valid_for,
+            refresh_token_valid_for,
+        )
+        .map_err(|err| JWTRefreshError::FailedToCreateNewToken(err))?;
+
+        // Check token is still in the list of valid tokens
+        let mut token_bucket = self
+            .token_bucket
+            .write()
+            .map_err(|e| JWTRefreshError::ConcurrencyLockError(anyhow!("refresh_token: {}", e)))?;
+        if !token_bucket.contains(&user_id, refresh_token) {
+            return Err(JWTRefreshError::TokenInvalided);
+        }
+
+        // add new tokens to bucket
+        token_bucket.put(&user_id, &pair.token, pair.expiry_date);
+        token_bucket.put(&user_id, &pair.refresh, pair.refresh_expiry_date);
+        // Shorten the expiry time of the old refresh token.
+        //
+        // Note, if the client goes offline before receiving the new refresh token the user might
+        // need to login again. This might seem random to the user. Lets see if that becomes a real
+        // issue.
+        let reduced_expiry =
+            std::cmp::min(Utc::now().timestamp() as usize + 5 * 60, decoded.claims.exp);
+        token_bucket.put(&user_id, refresh_token, reduced_expiry);
+
+        Ok(pair)
+    }
+
+    pub fn verify_token(&self, token: &str) -> Result<OmSupplyClaim, JWTValidationError> {
+        let mut validation = jsonwebtoken::Validation::default();
+        validation.set_audience(&vec![format!("{:?}", Audience::Api)]);
+        validation.iss = Some(ISSUER.to_string());
+        let decoded = jsonwebtoken::decode::<OmSupplyClaim>(
+            token,
+            &jsonwebtoken::DecodingKey::from_secret(self.jwt_token_secret),
+            &validation,
+        )
+        .map_err(|err| match err.kind() {
+            jsonwebtoken::errors::ErrorKind::ExpiredSignature => {
+                JWTValidationError::ExpiredSignature
+            }
+            jsonwebtoken::errors::ErrorKind::InvalidAudience => JWTValidationError::NotAnApiToken,
+            _ => JWTValidationError::InvalidToken(err),
+        })?;
+
+        // Check token is still in the list of valid tokens
+        let token_bucket = self.token_bucket.read().map_err(|e| {
+            JWTValidationError::ConcurrencyLockError(anyhow!("verify_token: {}", e))
+        })?;
+        if !token_bucket.contains(&decoded.claims.sub, token) {
+            return Err(JWTValidationError::TokenInvalided);
+        }
+        Ok(decoded.claims)
+    }
+
+    /// Log a user out of all sessions
+    pub fn logout(&mut self, user_id: &str) -> Result<(), JWTLogoutError> {
+        let mut token_bucket = self
+            .token_bucket
+            .write()
+            .map_err(|e| JWTLogoutError::ConcurrencyLockError(anyhow!("logout: {}", e)))?;
+        token_bucket.clear(user_id);
+        Ok(())
+    }
+}
+
+/// Creates a token and refresh token pair
+fn create_jwt_pair(
+    user_id: &str,
+    jwt_token_secret: &[u8],
+    valid_for: usize,
+    refresh_valid_for: usize,
+) -> Result<TokenPair, JWTError> {
+    let now = Utc::now().timestamp() as usize;
+    let expiry_date = now + valid_for;
+    let refresh_expiry_date = now + refresh_valid_for;
+
+    // api token
+    let api_claims = OmSupplyClaim {
+        exp: expiry_date,
+        aud: Audience::Api,
+        iat: now,
+        iss: ISSUER.to_string(),
+        sub: user_id.to_owned(),
+    };
+    let api_token = jsonwebtoken::encode(
+        &jsonwebtoken::Header::default(),
+        &api_claims,
+        &jsonwebtoken::EncodingKey::from_secret(jwt_token_secret),
+    )?;
+
+    // refresh token
+    let refresh_claims = OmSupplyClaim {
+        exp: refresh_expiry_date,
+        aud: Audience::TokenRefresh,
+        iat: now,
+        iss: ISSUER.to_string(),
+        sub: user_id.to_owned(),
+    };
+    let refresh_token = jsonwebtoken::encode(
+        &jsonwebtoken::Header::default(),
+        &refresh_claims,
+        &jsonwebtoken::EncodingKey::from_secret(jwt_token_secret),
+    )?;
+
+    Ok(TokenPair {
+        token: api_token,
+        expiry_date,
+        refresh: refresh_token,
+        refresh_expiry_date,
+    })
+}
+
+#[cfg(test)]
+mod user_account_test {
+    use crate::service::token_bucket::TokenBucket;
+
+    use super::*;
+
+    #[actix_rt::test]
+    async fn test_user_auth() {
+        let bucket = RwLock::new(TokenBucket::new());
+        const JWT_TOKEN_SECRET: &[u8] = "some secret".as_bytes();
+        let user_id = "test_user_id";
+        let mut service = TokenService::new(&bucket, JWT_TOKEN_SECRET);
+
+        // should be able to create a new token
+        let token_pair = service.jwt_token(user_id, 60, 120).unwrap();
+
+        // should be able to verify token
+        let claims = service.verify_token(&token_pair.token).unwrap();
+        assert_eq!(user_id, claims.sub);
+
+        // should fail to verify with refresh token
+        let err = service.verify_token(&token_pair.refresh).unwrap_err();
+        assert!(matches!(err, JWTValidationError::NotAnApiToken));
+
+        // should fail to refresh token refresh with api token
+        let err = service
+            .refresh_token(&token_pair.token, 60, 120)
+            .unwrap_err();
+        assert!(matches!(err, JWTRefreshError::NotARefreshToken));
+
+        // should succeed to refresh token
+        let token_pair = service.refresh_token(&token_pair.refresh, 60, 120).unwrap();
+        let claims = service.verify_token(&token_pair.token).unwrap();
+        // important: sub must still match the user id:
+        assert_eq!(user_id, claims.sub);
+
+        // should fail to verify and refresh when logged out
+        service.logout(&user_id).unwrap();
+        let err = service.verify_token(&token_pair.token).unwrap_err();
+        assert!(matches!(err, JWTValidationError::TokenInvalided));
+        let err = service
+            .refresh_token(&token_pair.refresh, 60, 120)
+            .unwrap_err();
+        assert!(matches!(err, JWTRefreshError::TokenInvalided));
+    }
+
+    #[actix_rt::test]
+    async fn test_user_auth_token_expiry() {
+        let bucket = RwLock::new(TokenBucket::new());
+        const JWT_TOKEN_SECRET: &[u8] = "some secret".as_bytes();
+        let user_id = "test_user_id";
+        let mut service = TokenService::new(&bucket, JWT_TOKEN_SECRET);
+
+        // should be able to create a new token
+        let token_pair = service.jwt_token(user_id, 1, 1).unwrap();
+        // should be able to verify token
+        let claims = service.verify_token(&token_pair.token).unwrap();
+        assert_eq!(user_id, claims.sub);
+
+        // granularity is 1 sec so need to wait 2 sec
+        std::thread::sleep(std::time::Duration::from_millis(2000));
+        let err = service.verify_token(&token_pair.token).unwrap_err();
+        assert!(matches!(err, JWTValidationError::ExpiredSignature));
+        let err = service
+            .refresh_token(&token_pair.refresh, 1, 1)
+            .unwrap_err();
+        assert!(matches!(err, JWTRefreshError::ExpiredSignature));
+    }
+}

--- a/src/service/token.rs
+++ b/src/service/token.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use super::token_bucket::TokenBucket;
 
 #[derive(Debug, Serialize, Deserialize)]
-enum Audience {
+pub enum Audience {
     /// Token is for general api usage
     Api,
     /// Token can be used for a token refresh
@@ -21,16 +21,16 @@ const ISSUER: &str = "om-supply-remote-server";
 #[derive(Debug, Serialize, Deserialize)]
 pub struct OmSupplyClaim {
     /// Required (validate_exp defaults to true in validation). Expiration time (as UTC timestamp)
-    exp: usize,
+    pub exp: usize,
 
     /// Audience
-    aud: Audience,
+    pub aud: Audience,
     /// Issued at (as UTC timestamp)
-    iat: usize,
+    pub iat: usize,
     /// Issuer
-    iss: String,
+    pub iss: String,
     /// Subject (user id the token refers to)
-    sub: String,
+    pub sub: String,
 }
 
 /// Error for getting a JWT token

--- a/src/service/token.rs
+++ b/src/service/token.rs
@@ -110,7 +110,10 @@ impl<'a> TokenService<'a> {
             valid_for,
             refresh_token_valid_for,
         )
-        .map_err(|err| JWTIssuingError::CanNotCreateToken(err))?;
+        .map_err(|err| {
+            error!("jwt_token: {}", err);
+            JWTIssuingError::CanNotCreateToken(err)
+        })?;
 
         // add tokens to bucket
         let mut token_bucket = self.token_bucket.write().map_err(|e| {

--- a/src/service/user_account.rs
+++ b/src/service/user_account.rs
@@ -1,5 +1,3 @@
-use std::sync::RwLock;
-
 use crate::{
     database::{
         repository::{RepositoryError, StorageConnection, TransactionError, UserAccountRepository},
@@ -8,39 +6,7 @@ use crate::{
     util::uuid::uuid,
 };
 
-use anyhow::anyhow;
 use bcrypt::{hash, verify, BcryptError, DEFAULT_COST};
-use chrono::Utc;
-use jsonwebtoken::errors::{Error as JWTError, ErrorKind as JWTErrorKind};
-use serde::{Deserialize, Serialize};
-
-use super::token_bucket::TokenBucket;
-
-#[derive(Debug, Serialize, Deserialize)]
-enum Audience {
-    /// Token is for general api usage
-    Api,
-    /// Token can be used for a token refresh
-    TokenRefresh,
-}
-
-// TODO: make the issuer configurable?
-const ISSUER: &str = "om-supply-remote-server";
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct OmSupplyClaim {
-    /// Required (validate_exp defaults to true in validation). Expiration time (as UTC timestamp)
-    exp: usize,
-
-    /// Audience
-    aud: Audience,
-    /// Issued at (as UTC timestamp)
-    iat: usize,
-    /// Issuer
-    iss: String,
-    /// Subject (user id the token refers to)
-    sub: String,
-}
 
 pub struct CreateUserAccount {
     pub username: String,
@@ -63,73 +29,22 @@ impl From<RepositoryError> for CreateUserAccountError {
     }
 }
 
-/// Error for getting a JWT token
 #[derive(Debug)]
-pub enum JWTIssuingError {
-    UserNameDoesNotExist,
+pub enum VerifyPasswordError {
+    UsernameDoesNotExist,
     InvalidCredentials,
     /// Invalid account data on the backend
     InvalidCredentialsBackend(bcrypt::BcryptError),
-    CanNotCreateToken(JWTError),
     DatabaseError(RepositoryError),
-    ConcurrencyLockError(anyhow::Error),
-}
-
-#[derive(Debug)]
-pub enum JWTValidationError {
-    ExpiredSignature,
-    NotAnApiToken,
-    InvalidToken(JWTError),
-    /// Token has been invalidated on the backend
-    TokenInvalided,
-    ConcurrencyLockError(anyhow::Error),
-}
-
-#[derive(Debug)]
-pub enum JWTRefreshError {
-    ExpiredSignature,
-    NotARefreshToken,
-    InvalidToken(JWTError),
-    FailedToCreateNewToken(JWTError),
-    /// Token has been invalidated on the backend
-    TokenInvalided,
-    ConcurrencyLockError(anyhow::Error),
-}
-
-#[derive(Debug)]
-pub enum JWTLogoutError {
-    ConcurrencyLockError(anyhow::Error),
-}
-
-#[derive(Debug)]
-pub struct TokenPair {
-    /// The JWT token
-    pub token: String,
-    /// expiry date of the token
-    pub expiry_date: usize,
-    /// The JWT refresh token
-    pub refresh: String,
-    /// Expiry date of the refresh token
-    pub refresh_expiry_date: usize,
 }
 
 pub struct UserAccountService<'a> {
     connection: &'a StorageConnection,
-    token_bucket: &'a RwLock<TokenBucket>,
-    jwt_token_secret: &'a [u8],
 }
 
 impl<'a> UserAccountService<'a> {
-    pub fn new(
-        connection: &'a StorageConnection,
-        token_bucket: &'a RwLock<TokenBucket>,
-        jwt_token_secret: &'a [u8],
-    ) -> Self {
-        UserAccountService {
-            connection,
-            token_bucket,
-            jwt_token_secret,
-        }
+    pub fn new(connection: &'a StorageConnection) -> Self {
+        UserAccountService { connection }
     }
 
     pub fn create_user(
@@ -139,7 +54,10 @@ impl<'a> UserAccountService<'a> {
         self.connection
             .transaction_sync(|con| {
                 let repo = UserAccountRepository::new(con);
-                if let Ok(_) = repo.find_one_by_user_name(&user.username) {
+                if let Some(_) = repo
+                    .find_one_by_user_name(&user.username)
+                    .map_err(|e| CreateUserAccountError::DatabaseError(e))?
+                {
                     return Err(CreateUserAccountError::UserNameExist);
                 }
                 let hashed_password = match hash(user.password, DEFAULT_COST) {
@@ -165,200 +83,35 @@ impl<'a> UserAccountService<'a> {
             )
     }
 
-    /// Creates new json web token for a given user
-    ///
-    /// # Arguments
-    ///
-    /// * `valid_for` - duration (sec) for how long the token will be valid
-    /// * `refresh_token_valid_for` - duration (sec) for how long the refresh token will be valid
-    pub fn jwt_token(
-        &mut self,
+    /// Finds a user account and verifies that the password is ok
+    pub fn verify_password(
+        &self,
         username: &str,
         password: &str,
-        valid_for: usize,
-        refresh_token_valid_for: usize,
-    ) -> Result<TokenPair, JWTIssuingError> {
+    ) -> Result<UserAccount, VerifyPasswordError> {
         let repo = UserAccountRepository::new(self.connection);
-        let user = repo
+        let user = match repo
             .find_one_by_user_name(username)
-            .map_err(|err| match err {
-                RepositoryError::NotFound => JWTIssuingError::UserNameDoesNotExist,
-                _ => JWTIssuingError::DatabaseError(err),
-            })?;
+            .map_err(|e| VerifyPasswordError::DatabaseError(e))?
+        {
+            Some(user) => user,
+            None => return Err(VerifyPasswordError::UsernameDoesNotExist),
+        };
         // verify password
         if !verify(password, &user.password)
-            .map_err(|err| JWTIssuingError::InvalidCredentialsBackend(err))?
+            .map_err(|err| VerifyPasswordError::InvalidCredentialsBackend(err))?
         {
-            return Err(JWTIssuingError::InvalidCredentials);
+            return Err(VerifyPasswordError::InvalidCredentials);
         }
 
-        let pair = create_jwt_pair(
-            &user.id,
-            self.jwt_token_secret,
-            valid_for,
-            refresh_token_valid_for,
-        )
-        .map_err(|err| JWTIssuingError::CanNotCreateToken(err))?;
-
-        // add tokens to bucket
-        let mut token_bucket = self
-            .token_bucket
-            .write()
-            .map_err(|e| JWTIssuingError::ConcurrencyLockError(anyhow!("jwt_token: {}", e)))?;
-        token_bucket.put(&user.id, &pair.token, pair.expiry_date);
-        token_bucket.put(&user.id, &pair.refresh, pair.refresh_expiry_date);
-
-        Ok(pair)
+        Ok(user)
     }
-
-    /// Get a new token and also update the refresh token
-    ///
-    /// # Arguments
-    /// * `valid_for` - duration (sec) for how long the token will be valid
-    /// * `refresh_token_valid_for` - duration (sec) for how long the refresh token will be valid
-    pub fn refresh_token(
-        &mut self,
-        refresh_token: &str,
-        valid_for: usize,
-        refresh_token_valid_for: usize,
-    ) -> Result<TokenPair, JWTRefreshError> {
-        let mut validation = jsonwebtoken::Validation::default();
-        validation.set_audience(&vec![format!("{:?}", Audience::TokenRefresh)]);
-        validation.iss = Some(ISSUER.to_string());
-        let decoded = jsonwebtoken::decode::<OmSupplyClaim>(
-            refresh_token,
-            &jsonwebtoken::DecodingKey::from_secret(self.jwt_token_secret),
-            &validation,
-        )
-        .map_err(|err| match err.kind() {
-            JWTErrorKind::ExpiredSignature => JWTRefreshError::ExpiredSignature,
-            JWTErrorKind::InvalidAudience => JWTRefreshError::NotARefreshToken,
-            _ => JWTRefreshError::InvalidToken(err),
-        })?;
-
-        let user_id = decoded.claims.sub;
-        let pair = create_jwt_pair(
-            &user_id,
-            self.jwt_token_secret,
-            valid_for,
-            refresh_token_valid_for,
-        )
-        .map_err(|err| JWTRefreshError::FailedToCreateNewToken(err))?;
-
-        // Check token is still in the list of valid tokens
-        let mut token_bucket = self
-            .token_bucket
-            .write()
-            .map_err(|e| JWTRefreshError::ConcurrencyLockError(anyhow!("refresh_token: {}", e)))?;
-        if !token_bucket.contains(&user_id, refresh_token) {
-            return Err(JWTRefreshError::TokenInvalided);
-        }
-
-        // add new tokens to bucket
-        token_bucket.put(&user_id, &pair.token, pair.expiry_date);
-        token_bucket.put(&user_id, &pair.refresh, pair.refresh_expiry_date);
-        // Shorten the expiry time of the old refresh token.
-        //
-        // Note, if the client goes offline before receiving the new refresh token the user might
-        // need to login again. This might seem random to the user. Lets see if that becomes a real
-        // issue.
-        let reduced_expiry =
-            std::cmp::min(Utc::now().timestamp() as usize + 5 * 60, decoded.claims.exp);
-        token_bucket.put(&user_id, refresh_token, reduced_expiry);
-
-        Ok(pair)
-    }
-
-    pub fn verify_token(&self, token: &str) -> Result<OmSupplyClaim, JWTValidationError> {
-        let mut validation = jsonwebtoken::Validation::default();
-        validation.set_audience(&vec![format!("{:?}", Audience::Api)]);
-        validation.iss = Some(ISSUER.to_string());
-        let decoded = jsonwebtoken::decode::<OmSupplyClaim>(
-            token,
-            &jsonwebtoken::DecodingKey::from_secret(self.jwt_token_secret),
-            &validation,
-        )
-        .map_err(|err| match err.kind() {
-            jsonwebtoken::errors::ErrorKind::ExpiredSignature => {
-                JWTValidationError::ExpiredSignature
-            }
-            jsonwebtoken::errors::ErrorKind::InvalidAudience => JWTValidationError::NotAnApiToken,
-            _ => JWTValidationError::InvalidToken(err),
-        })?;
-
-        // Check token is still in the list of valid tokens
-        let token_bucket = self.token_bucket.read().map_err(|e| {
-            JWTValidationError::ConcurrencyLockError(anyhow!("verify_token: {}", e))
-        })?;
-        if !token_bucket.contains(&decoded.claims.sub, token) {
-            return Err(JWTValidationError::TokenInvalided);
-        }
-        Ok(decoded.claims)
-    }
-
-    /// Log a user out of all sessions
-    pub fn logout(&mut self, user_id: &str) -> Result<(), JWTLogoutError> {
-        let mut token_bucket = self
-            .token_bucket
-            .write()
-            .map_err(|e| JWTLogoutError::ConcurrencyLockError(anyhow!("logout: {}", e)))?;
-        token_bucket.clear(user_id);
-        Ok(())
-    }
-}
-
-/// Creates a token and refresh token pair
-fn create_jwt_pair(
-    user_id: &str,
-    jwt_token_secret: &[u8],
-    valid_for: usize,
-    refresh_valid_for: usize,
-) -> Result<TokenPair, JWTError> {
-    let now = Utc::now().timestamp() as usize;
-    let expiry_date = now + valid_for;
-    let refresh_expiry_date = now + refresh_valid_for;
-
-    // api token
-    let api_claims = OmSupplyClaim {
-        exp: expiry_date,
-        aud: Audience::Api,
-        iat: now,
-        iss: ISSUER.to_string(),
-        sub: user_id.to_owned(),
-    };
-    let api_token = jsonwebtoken::encode(
-        &jsonwebtoken::Header::default(),
-        &api_claims,
-        &jsonwebtoken::EncodingKey::from_secret(jwt_token_secret),
-    )?;
-
-    // refresh token
-    let refresh_claims = OmSupplyClaim {
-        exp: refresh_expiry_date,
-        aud: Audience::TokenRefresh,
-        iat: now,
-        iss: ISSUER.to_string(),
-        sub: user_id.to_owned(),
-    };
-    let refresh_token = jsonwebtoken::encode(
-        &jsonwebtoken::Header::default(),
-        &refresh_claims,
-        &jsonwebtoken::EncodingKey::from_secret(jwt_token_secret),
-    )?;
-
-    Ok(TokenPair {
-        token: api_token,
-        expiry_date,
-        refresh: refresh_token,
-        refresh_expiry_date,
-    })
 }
 
 #[cfg(test)]
 mod user_account_test {
     use crate::{
         database::repository::{get_repositories, StorageConnectionManager},
-        service::token_bucket::TokenBucket,
         util::test_db,
     };
 
@@ -372,86 +125,32 @@ mod user_account_test {
         let connection_manager = registry.get::<StorageConnectionManager>().unwrap();
         let connection = connection_manager.connection().unwrap();
 
-        let bucket = RwLock::new(TokenBucket::new());
-        const JWT_TOKEN_SECRET: &[u8] = "some secret".as_bytes();
-        let mut service = UserAccountService::new(&connection, &bucket, JWT_TOKEN_SECRET);
+        let service = UserAccountService::new(&connection);
 
         // should be able to create a new user
-        let password: &str = "passw0rd";
-        let user = service
+        let username = "testuser";
+        let password = "passw0rd";
+        service
             .create_user(CreateUserAccount {
-                username: "testuser".to_string(),
+                username: username.to_string(),
                 password: password.to_string(),
                 email: None,
             })
             .unwrap();
-        let token_pair = service
-            .jwt_token(&user.username, password, 60, 120)
-            .unwrap();
 
-        // should be able to verify token
-        let claims = service.verify_token(&token_pair.token).unwrap();
-        assert_eq!(user.id, claims.sub);
+        // should be able to verify correct username and password
+        service.verify_password(username, password).unwrap();
 
-        // should fail to verify with refresh token
-        let err = service.verify_token(&token_pair.refresh).unwrap_err();
-        assert!(matches!(err, JWTValidationError::NotAnApiToken));
+        // should fail to verify wrong password
+        let err = service.verify_password(username, "wrong").unwrap_err();
+        assert!(matches!(err, VerifyPasswordError::InvalidCredentials));
 
-        // should fail to refresh token refresh with api token
-        let err = service
-            .refresh_token(&token_pair.token, 60, 120)
-            .unwrap_err();
-        assert!(matches!(err, JWTRefreshError::NotARefreshToken));
-
-        // should succeed to refresh token
-        let token_pair = service.refresh_token(&token_pair.refresh, 60, 120).unwrap();
-        let claims = service.verify_token(&token_pair.token).unwrap();
-        // important: sub must still match the user id:
-        assert_eq!(user.id, claims.sub);
-
-        // should fail to verify and refresh when logged out
-        service.logout(&user.id).unwrap();
-        let err = service.verify_token(&token_pair.token).unwrap_err();
-        assert!(matches!(err, JWTValidationError::TokenInvalided));
-        let err = service
-            .refresh_token(&token_pair.refresh, 60, 120)
-            .unwrap_err();
-        assert!(matches!(err, JWTRefreshError::TokenInvalided));
-    }
-
-    #[actix_rt::test]
-    async fn test_user_auth_token_expiry() {
-        let settings = test_db::get_test_settings("omsupply-database-user-account-token-expiry");
-        test_db::setup(&settings.database).await;
-        let registry = get_repositories(&settings).await;
-        let connection_manager = registry.get::<StorageConnectionManager>().unwrap();
-        let connection = connection_manager.connection().unwrap();
-
-        let bucket = RwLock::new(TokenBucket::new());
-        const JWT_TOKEN_SECRET: &[u8] = "some secret".as_bytes();
-        let mut service = UserAccountService::new(&connection, &bucket, JWT_TOKEN_SECRET);
-
-        // should be able to create a new user
-        let password: &str = "passw0rd";
-        let user = service
-            .create_user(CreateUserAccount {
-                username: "testuser".to_string(),
-                password: password.to_string(),
-                email: None,
-            })
-            .unwrap();
-        let token_pair = service.jwt_token(&user.username, password, 1, 1).unwrap();
-        // should be able to verify token
-        let claims = service.verify_token(&token_pair.token).unwrap();
-        assert_eq!(user.id, claims.sub);
-
-        // granularity is 1 sec so need to wait 2 sec
-        std::thread::sleep(std::time::Duration::from_millis(2000));
-        let err = service.verify_token(&token_pair.token).unwrap_err();
-        assert!(matches!(err, JWTValidationError::ExpiredSignature));
-        let err = service
-            .refresh_token(&token_pair.refresh, 1, 1)
-            .unwrap_err();
-        assert!(matches!(err, JWTRefreshError::ExpiredSignature));
+        // should fail to find invalid user
+        let err = service.verify_password("invalid", password).unwrap_err();
+        assert!(
+            matches!(err, VerifyPasswordError::UsernameDoesNotExist),
+            "{:?}",
+            err
+        );
     }
 }

--- a/src/util/settings.rs
+++ b/src/util/settings.rs
@@ -10,6 +10,7 @@ pub struct Settings {
     pub server: ServerSettings,
     pub database: DatabaseSettings,
     pub sync: SyncSettings,
+    pub auth: AuthSettings,
 }
 
 #[derive(serde::Deserialize)]
@@ -68,6 +69,11 @@ impl DatabaseSettings {
     pub fn connection_string_without_db(&self) -> String {
         return self.connection_string();
     }
+}
+
+#[derive(serde::Deserialize)]
+pub struct AuthSettings {
+    pub token_secret: String,
 }
 
 pub enum SettingsError {

--- a/src/util/test_db.rs
+++ b/src/util/test_db.rs
@@ -3,7 +3,7 @@ use crate::database::{
     repository::{DBBackendConnection, StorageConnection, StorageConnectionManager},
 };
 
-use super::settings::{DatabaseSettings, ServerSettings, Settings, SyncSettings};
+use super::settings::{AuthSettings, DatabaseSettings, ServerSettings, Settings, SyncSettings};
 
 use diesel::r2d2::{ConnectionManager, Pool};
 use diesel_migrations::{find_migrations_directory, mark_migrations_in_directory};
@@ -111,6 +111,9 @@ pub fn get_test_settings(db_name: &str) -> Settings {
             port: 5432,
             host: "localhost".to_string(),
             interval: 100000000,
+        },
+        auth: AuthSettings {
+            token_secret: "testtokensecret".to_string(),
         },
     }
 }

--- a/tests/graphql/mod.rs
+++ b/tests/graphql/mod.rs
@@ -45,7 +45,7 @@ where
     let loader_registry = actix_web::web::Data::new(LoaderRegistry { loaders });
 
     let auth_data = Data::new(AuthData {
-        auth_token_secret: "secret".to_string(),
+        auth_token_secret: settings.auth.token_secret.to_owned(),
         token_bucket: RwLock::new(TokenBucket::new()),
         // TODO: configure ssl
         debug_no_ssl: true,
@@ -92,7 +92,7 @@ async fn run_gql_query(
     let loader_registry = actix_web::web::Data::new(LoaderRegistry { loaders });
 
     let auth_data = Data::new(AuthData {
-        auth_token_secret: "secret".to_string(),
+        auth_token_secret: settings.auth.token_secret.to_owned(),
         token_bucket: RwLock::new(TokenBucket::new()),
         // TODO: configure ssl
         debug_no_ssl: true,

--- a/tests/graphql/mod.rs
+++ b/tests/graphql/mod.rs
@@ -1,10 +1,13 @@
-use actix_web::test::read_body;
+use std::sync::RwLock;
+
+use actix_web::{test::read_body, web::Data};
 use remote_server::{
     database::{loader::get_loaders, repository::get_repositories},
     server::{
-        data::{LoaderRegistry, RepositoryRegistry},
+        data::{auth::AuthData, LoaderRegistry, RepositoryRegistry},
         service::graphql::config as graphql_config,
     },
+    service::token_bucket::TokenBucket,
     util::settings::Settings,
 };
 
@@ -41,11 +44,22 @@ where
     let repository_registry = actix_web::web::Data::new(RepositoryRegistry { repositories });
     let loader_registry = actix_web::web::Data::new(LoaderRegistry { loaders });
 
+    let auth_data = Data::new(AuthData {
+        auth_token_secret: "secret".to_string(),
+        token_bucket: RwLock::new(TokenBucket::new()),
+        // TODO: configure ssl
+        debug_no_ssl: true,
+    });
+
     let mut app = actix_web::test::init_service(
         actix_web::App::new()
             .data(repository_registry.clone())
             .data(loader_registry.clone())
-            .configure(graphql_config(repository_registry, loader_registry)),
+            .configure(graphql_config(
+                repository_registry,
+                loader_registry,
+                auth_data,
+            )),
     )
     .await;
 
@@ -77,11 +91,22 @@ async fn run_gql_query(
     let repository_registry = actix_web::web::Data::new(RepositoryRegistry { repositories });
     let loader_registry = actix_web::web::Data::new(LoaderRegistry { loaders });
 
+    let auth_data = Data::new(AuthData {
+        auth_token_secret: "secret".to_string(),
+        token_bucket: RwLock::new(TokenBucket::new()),
+        // TODO: configure ssl
+        debug_no_ssl: true,
+    });
+
     let mut app = actix_web::test::init_service(
         actix_web::App::new()
             .data(repository_registry.clone())
             .data(loader_registry.clone())
-            .configure(graphql_config(repository_registry, loader_registry)),
+            .configure(graphql_config(
+                repository_registry,
+                loader_registry,
+                auth_data,
+            )),
     )
     .await;
 


### PR DESCRIPTION
Add gql endpoints:
- registerUser
- authToken (rename to login?)
- refreshToken
- logout

I only manually tested the full flow in the playground so far...

@andreievg you where right asking why token methods where in the UserAccountService. I now moved them into a TokenService and think this is cleaner and more flexible now.

I extract the Bearer token and refresh cookie from the http request and then make the them accessible (if present) in the gql context. I had a look how to do this in a middleware but actix-web seems to make that overly complicated so I didn't follow this approach for now.

Only the logout method validates the bearer token so far. I think the errors in the logout methods are a bit to detailed right now and should be merged into a single generic "Authentication/Permission" error...