### PR TITLE
Versioned document

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,6 +1322,9 @@ name = "domain"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "serde 1.0.130",
+ "serde_json",
+ "util",
 ]
 
 [[package]]
@@ -3259,6 +3262,7 @@ version = "0.1.0"
 dependencies = [
  "actix-rt",
  "anyhow",
+ "assert-json-diff",
  "bcrypt",
  "chrono",
  "domain",
@@ -3931,6 +3935,8 @@ dependencies = [
 name = "util"
 version = "0.1.0"
 dependencies = [
+ "serde 1.0.130",
+ "serde_json",
  "sha2",
  "uuid",
 ]

--- a/domain/Cargo.toml
+++ b/domain/Cargo.toml
@@ -8,4 +8,8 @@ edition = "2018"
 path = "src/lib.rs"
 
 [dependencies]
+util = { path = "../util" }
+
 chrono = { version = "0.4", features = ["serde"] }
+serde = "1.0.126"
+serde_json = "1.0.66"

--- a/domain/src/document.rs
+++ b/domain/src/document.rs
@@ -1,0 +1,99 @@
+use chrono::{DateTime, NaiveDateTime, Utc};
+use serde::{self, Deserialize, Serialize};
+use util::{canonical_json::CanonicalJsonValue, hash::sha256};
+
+#[derive(Debug)]
+pub struct Document {
+    /// The document data hash
+    pub id: String,
+    /// Document path and name
+    pub name: String,
+    /// Document parents
+    pub parents: Vec<String>,
+    /// Id of the author who edited this document version
+    pub author: String,
+    /// The timestamp of this document version
+    pub timestamp: DateTime<Utc>,
+    /// Type of the containing data
+    pub type_: String,
+    /// The actual document data
+    pub data: serde_json::Value,
+}
+
+/// Like Document but without id
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RawDocument {
+    pub name: String,
+    pub parents: Vec<String>,
+    pub author: String,
+    pub timestamp: DateTime<Utc>,
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub data: serde_json::Value,
+}
+
+impl RawDocument {
+    /// Calculates the document id
+    pub fn document_id(&self) -> Result<String, String> {
+        let value = serde_json::to_value(self).map_err(|err| format!("{:?}", err))?;
+        let canonical_value = CanonicalJsonValue::from(value);
+        let str = canonical_value.to_string();
+        Ok(sha256(&str))
+    }
+
+    /// RawDocument can't be used afterwards (self parameter ensures that)
+    pub fn finalise(self) -> Result<Document, String> {
+        let id = self.document_id()?;
+        let RawDocument {
+            name,
+            parents,
+            author,
+            timestamp,
+            type_,
+            data,
+        } = self;
+        Ok(Document {
+            id,
+            name,
+            parents,
+            author,
+            timestamp,
+            type_,
+            data,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct AncestorDetail {
+    pub id: String,
+    pub parents: Vec<String>,
+    pub timestamp: NaiveDateTime,
+}
+
+#[cfg(test)]
+mod document_id_test {
+    use chrono::TimeZone;
+    use serde_json::*;
+
+    use super::*;
+
+    #[test]
+    fn test_document_id() {
+        let raw = RawDocument {
+            name: "name".to_string(),
+            parents: vec!["p1".to_string()],
+            author: "author".to_string(),
+            timestamp: Utc.timestamp_millis(1000),
+            type_: "test".to_string(),
+            data: json!({
+              "b": 0.3453333,
+              "a": "avalue",
+            }),
+        };
+        let document = raw.finalise().unwrap();
+        let expected_json_string = r#"{"author":"author","data":{"a":"avalue","b":0.3453333},"name":"name","parents":["p1"],"timestamp":"1970-01-01T00:00:01Z","type":"test"}"#;
+        let expected_id = sha256(expected_json_string);
+        assert_eq!(document.id, expected_id);
+    }
+}

--- a/domain/src/lib.rs
+++ b/domain/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod document;
 pub mod inbound_shipment;
 pub mod invoice;
 pub mod invoice_line;

--- a/repository/migrations/postgres/00000300_create_document_table/down.sql
+++ b/repository/migrations/postgres/00000300_create_document_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS document CASCADE;

--- a/repository/migrations/postgres/00000300_create_document_table/up.sql
+++ b/repository/migrations/postgres/00000300_create_document_table/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE document (
+    id TEXT NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL,
+    parents TEXT NOT NULL,
+    author TEXT NOT NULL,
+    timestamp TIMESTAMP NOT NULL,
+    type TEXT NOT NULL,
+    data TEXT NOT NULL
+)

--- a/repository/migrations/postgres/00000301_create_document_head_table/down.sql
+++ b/repository/migrations/postgres/00000301_create_document_head_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS document_head CASCADE;

--- a/repository/migrations/postgres/00000301_create_document_head_table/up.sql
+++ b/repository/migrations/postgres/00000301_create_document_head_table/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE document_head (
+    id TEXT NOT NULL PRIMARY KEY,
+    store TEXT NOT NULL,
+    name TEXT NOT NULL,
+    head TEXT NOT NULL REFERENCES document(id)
+)

--- a/repository/migrations/sqlite/00000300_create_document_table/down.sql
+++ b/repository/migrations/sqlite/00000300_create_document_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS document CASCADE;

--- a/repository/migrations/sqlite/00000300_create_document_table/up.sql
+++ b/repository/migrations/sqlite/00000300_create_document_table/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE document (
+    id TEXT NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL,
+    parents TEXT NOT NULL,
+    author TEXT NOT NULL,
+    timestamp TIMESTAMP NOT NULL,
+    type TEXT NOT NULL,
+    data TEXT NOT NULL
+)

--- a/repository/migrations/sqlite/00000301_create_document_head_table/down.sql
+++ b/repository/migrations/sqlite/00000301_create_document_head_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS document_head CASCADE;

--- a/repository/migrations/sqlite/00000301_create_document_head_table/up.sql
+++ b/repository/migrations/sqlite/00000301_create_document_head_table/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE document_head (
+    id TEXT NOT NULL PRIMARY KEY,
+    store TEXT NOT NULL,
+    name TEXT NOT NULL,
+    head TEXT NOT NULL REFERENCES document(id)
+)

--- a/repository/src/db_diesel/document.rs
+++ b/repository/src/db_diesel/document.rs
@@ -1,0 +1,179 @@
+use super::StorageConnection;
+
+use crate::{
+    schema::{
+        diesel_schema::{document::dsl as document_dsl, document_head::dsl as document_head_dsl},
+        DocumentHeadRow, DocumentRow,
+    },
+    RepositoryError,
+};
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+use diesel::prelude::*;
+use domain::document::{AncestorDetail, Document};
+
+pub struct DocumentRepository<'a> {
+    connection: &'a StorageConnection,
+}
+
+fn document_from_row(row: DocumentRow) -> Result<Document, RepositoryError> {
+    let parents: Vec<String> =
+        serde_json::from_str(&row.parents).map_err(|err| RepositoryError::DBError {
+            msg: "Invalid parents data".to_string(),
+            extra: format!("{}", err),
+        })?;
+    let data: serde_json::Value =
+        serde_json::from_str(&row.data).map_err(|err| RepositoryError::DBError {
+            msg: "Invalid data".to_string(),
+            extra: format!("{}", err),
+        })?;
+    Ok(Document {
+        id: row.id,
+        name: row.name,
+        parents,
+        author: row.author,
+        timestamp: DateTime::<Utc>::from_utc(row.timestamp, Utc),
+        type_: row.type_,
+        data,
+    })
+}
+
+fn row_from_document(doc: &Document) -> Result<DocumentRow, RepositoryError> {
+    let parents = serde_json::to_string(&doc.parents).map_err(|err| RepositoryError::DBError {
+        msg: "Can't serialize parents".to_string(),
+        extra: format!("{}", err),
+    })?;
+    let data = serde_json::to_string(&doc.data).map_err(|err| RepositoryError::DBError {
+        msg: "Can't serialize data".to_string(),
+        extra: format!("{}", err),
+    })?;
+    Ok(DocumentRow {
+        id: doc.id.to_owned(),
+        name: doc.name.to_owned(),
+        parents,
+        author: doc.author.to_owned(),
+        timestamp: doc.timestamp.naive_utc(),
+        type_: doc.type_.to_owned(),
+        data,
+    })
+}
+
+fn make_head_id(name: &str, store: &str) -> String {
+    format!("{}@{}", name, store)
+}
+
+impl<'a> DocumentRepository<'a> {
+    pub fn new(connection: &'a StorageConnection) -> Self {
+        DocumentRepository { connection }
+    }
+
+    /// Inserts a document
+    pub fn insert_document(&self, doc: &Document) -> Result<(), RepositoryError> {
+        diesel::insert_into(document_dsl::document)
+            .values(row_from_document(doc)?)
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+
+    #[cfg(all(feature = "postgres", not(feature = "sqlite")))]
+    pub fn update_document_head(&self, store: &str, doc: &Document) -> Result<(), RepositoryError> {
+        let row = DocumentHeadRow {
+            id: make_head_id(&doc.name, store),
+            store: store.to_owned(),
+            name: doc.name.to_owned(),
+            head: doc.id.to_owned(),
+        };
+        diesel::insert_into(document_head_dsl::document_head)
+            .values(&row)
+            .on_conflict(document_head_dsl::id)
+            .do_update()
+            .set(&row)
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+
+    /// Set document head to the provided version
+    #[cfg(feature = "sqlite")]
+    pub fn update_document_head(&self, store: &str, doc: &Document) -> Result<(), RepositoryError> {
+        diesel::replace_into(document_head_dsl::document_head)
+            .values(DocumentHeadRow {
+                id: make_head_id(&doc.name, store),
+                store: store.to_owned(),
+                name: doc.name.to_owned(),
+                head: doc.id.to_owned(),
+            })
+            .execute(&self.connection.connection)?;
+        Ok(())
+    }
+
+    /// Get a specific document version
+    pub fn find_one_by_id(&self, document_id: &str) -> Result<Document, RepositoryError> {
+        let row: DocumentRow = document_dsl::document
+            .filter(document_dsl::id.eq(document_id))
+            .first(&self.connection.connection)?;
+
+        document_from_row(row)
+    }
+
+    /// Get the latest version of a document
+    pub fn find_one_by_name(
+        &self,
+        document_name: &str,
+        store: &str,
+    ) -> Result<Document, RepositoryError> {
+        let head = self.head(document_name, store)?;
+        self.find_one_by_id(&head.head)
+    }
+
+    /// Gets all document versions
+    pub fn find_many_by_name(&self, document_name: &str) -> Result<Vec<Document>, RepositoryError> {
+        let rows: Vec<DocumentRow> = document_dsl::document
+            .filter(document_dsl::name.eq(document_name))
+            .load(&self.connection.connection)?;
+        let mut result = Vec::<Document>::new();
+        for row in rows {
+            result.push(document_from_row(row)?);
+        }
+        Ok(result)
+    }
+
+    pub fn head(
+        &self,
+        document_name: &str,
+        store: &str,
+    ) -> Result<DocumentHeadRow, RepositoryError> {
+        let result: DocumentHeadRow = document_head_dsl::document_head
+            .filter(document_head_dsl::id.eq(make_head_id(document_name, store)))
+            .first(&self.connection.connection)?;
+        Ok(result)
+    }
+
+    /// Gets ancestor details for the full document history.
+    pub fn ancestor_details(
+        &self,
+        document_name: &str,
+    ) -> Result<Vec<AncestorDetail>, RepositoryError> {
+        let rows: Vec<(String, String, NaiveDateTime)> = document_dsl::document
+            .filter(document_dsl::name.eq(document_name))
+            .select((
+                document_dsl::id,
+                document_dsl::parents,
+                document_dsl::timestamp,
+            ))
+            .load(&self.connection.connection)?;
+        let mut ancestors = Vec::<AncestorDetail>::new();
+        for row in rows {
+            let parents: Vec<String> =
+                serde_json::from_str(&row.1).map_err(|err| RepositoryError::DBError {
+                    msg: "Invalid parents data".to_string(),
+                    extra: format!("{}", err),
+                })?;
+            ancestors.push(AncestorDetail {
+                id: row.0,
+                parents,
+                timestamp: row.2,
+            })
+        }
+        Ok(ancestors)
+    }
+}

--- a/repository/src/db_diesel/mod.rs
+++ b/repository/src/db_diesel/mod.rs
@@ -2,6 +2,7 @@ use crate::repository_error::RepositoryError;
 
 mod central_sync_buffer;
 mod central_sync_cursor;
+mod document;
 mod invoice;
 mod invoice_line;
 mod invoice_line_query;
@@ -24,6 +25,7 @@ mod user_account;
 
 pub use central_sync_buffer::CentralSyncBufferRepository;
 pub use central_sync_cursor::CentralSyncCursorRepository;
+pub use document::DocumentRepository;
 pub use invoice::{InvoiceRepository, OutboundShipmentRepository};
 pub use invoice_line::InvoiceLineRepository;
 pub use invoice_line_query::{InvoiceLineQueryRepository, InvoiceLineStats};

--- a/repository/src/schema/diesel_schema.rs
+++ b/repository/src/schema/diesel_schema.rs
@@ -185,6 +185,27 @@ table! {
     }
 }
 
+table! {
+    document (id) {
+        id -> Text,
+        name -> Text,
+        parents -> Text,
+        author -> Text,
+        timestamp -> Timestamp,
+        #[sql_name = "type"] type_ -> Text,
+        data -> Text,
+    }
+}
+
+table! {
+    document_head (id) {
+        id -> Text,
+        store -> Text,
+        name -> Text,
+        head -> Text,
+    }
+}
+
 joinable!(item -> unit (unit_id));
 joinable!(stock_line -> item (item_id));
 joinable!(stock_line -> store (store_id));

--- a/repository/src/schema/document.rs
+++ b/repository/src/schema/document.rs
@@ -1,0 +1,22 @@
+use super::diesel_schema::document;
+
+use chrono::NaiveDateTime;
+
+#[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq)]
+#[table_name = "document"]
+pub struct DocumentRow {
+    /// The document data hash
+    pub id: String,
+    /// Document path and name
+    pub name: String,
+    /// Stringified array of parents
+    pub parents: String,
+    /// Id of the author who edited this document version
+    pub author: String,
+    /// The timestamp of this document version
+    pub timestamp: NaiveDateTime,
+    /// Type of the containing data
+    pub type_: String,
+    /// The actual document data
+    pub data: String,
+}

--- a/repository/src/schema/document_head.rs
+++ b/repository/src/schema/document_head.rs
@@ -1,0 +1,16 @@
+use super::diesel_schema::document_head;
+
+/// Hold the a reference to the latest document version
+#[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq)]
+#[table_name = "document_head"]
+pub struct DocumentHeadRow {
+    /// Row id in the format "{name}@{store}"
+    pub id: String,
+    /// The store this head refers too. This mean we can keep track of heads from multiple stores
+    /// and merge them when needed.
+    pub store: String,
+    /// The document name
+    pub name: String,
+    /// The current document version (hash)
+    pub head: String,
+}

--- a/repository/src/schema/mod.rs
+++ b/repository/src/schema/mod.rs
@@ -1,5 +1,7 @@
 mod central_sync_buffer;
 mod central_sync_cursor;
+mod document;
+mod document_head;
 mod invoice;
 mod invoice_line;
 mod item;
@@ -36,6 +38,8 @@ pub enum DatabaseRow {
 
 pub use central_sync_buffer::CentralSyncBufferRow;
 pub use central_sync_cursor::CentralSyncCursorRow;
+pub use document::DocumentRow;
+pub use document_head::DocumentHeadRow;
 pub use invoice::{InvoiceRow, InvoiceRowStatus, InvoiceRowType};
 pub use invoice_line::InvoiceLineRow;
 pub use item::ItemRow;

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -21,3 +21,4 @@ serde_json = "1.0.66"
 
 [dev-dependencies]
 actix-rt = "1.1.1" # for Tokio 0.2
+assert-json-diff = "2.0.1"

--- a/service/src/document/common_ancestor.rs
+++ b/service/src/document/common_ancestor.rs
@@ -1,0 +1,252 @@
+use std::collections::{HashMap, HashSet};
+
+use domain::document::AncestorDetail;
+
+#[derive(Debug)]
+pub enum CommonAncestorError {
+    NoCommonAncestorFound,
+    /// History data is corrupted and ids couldn't be found
+    InvalidAncestorData,
+}
+
+/// Abstract away how details are retrieved from the underlying storage
+pub trait AncestorDB {
+    fn get_details(&self, id: &str) -> Option<AncestorDetail>;
+}
+
+/// Keep all ancestors loaded in memory
+pub struct InMemoryAncestorDB {
+    map: HashMap<String, AncestorDetail>,
+}
+
+impl InMemoryAncestorDB {
+    pub fn new() -> Self {
+        InMemoryAncestorDB {
+            map: HashMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, items: &Vec<AncestorDetail>) {
+        for item in items {
+            self.map.insert(item.id.clone(), item.clone());
+        }
+    }
+}
+
+impl AncestorDB for InMemoryAncestorDB {
+    fn get_details(&self, id: &str) -> Option<AncestorDetail> {
+        self.map.get(id).map(|v| v.clone())
+    }
+}
+
+/// Finds the latest common ancestor of two document versions
+pub fn common_ancestors<T: AncestorDB>(
+    db: &T,
+    v1: &str,
+    v2: &str,
+) -> Result<String, CommonAncestorError> {
+    // collect all parents reachable from v1
+    let mut v1_ancestors = HashSet::<String>::new();
+    let mut v1_queue = Vec::<String>::new();
+    v1_queue.push(String::from(v1));
+    while let Some(candidate) = v1_queue.pop() {
+        if v1_ancestors.insert(candidate.to_owned()) == false {
+            continue;
+        }
+        let detail = db
+            .get_details(&candidate)
+            .ok_or(CommonAncestorError::InvalidAncestorData)?;
+        for parent in detail.parents {
+            v1_queue.push(parent);
+        }
+    }
+
+    // follow v2 and find latest common ancestor
+
+    // just to keep track of already handled branches
+    let mut v2_ancestors = HashSet::<String>::new();
+    // use AncestorDetail here to be able to sort by latest timestamp
+    let mut v2_queue = Vec::<AncestorDetail>::new();
+    let detail = db
+        .get_details(&v2)
+        .ok_or(CommonAncestorError::InvalidAncestorData)?;
+    v2_queue.push(detail);
+    while let Some(candidate) = v2_queue.pop() {
+        if v1_ancestors.contains(&candidate.id) {
+            return Ok(candidate.id);
+        }
+        if v2_ancestors.insert(candidate.id) == false {
+            continue;
+        }
+
+        for parent in candidate.parents {
+            let detail = db
+                .get_details(&parent)
+                .ok_or(CommonAncestorError::InvalidAncestorData)?;
+            v2_queue.push(detail);
+        }
+        // sort so that most recent items get tested first
+        v2_queue.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    }
+
+    Err(CommonAncestorError::NoCommonAncestorFound)
+}
+
+#[cfg(test)]
+mod common_ancestor_test {
+    use chrono::NaiveDateTime;
+    use domain::document::AncestorDetail;
+
+    use crate::document::common_ancestor::{common_ancestors, InMemoryAncestorDB};
+
+    #[test]
+    fn test_simple() {
+        let local = vec![
+            AncestorDetail {
+                id: "a0".to_owned(),
+                parents: vec![],
+                timestamp: NaiveDateTime::from_timestamp(1, 0),
+            },
+            AncestorDetail {
+                id: "a1".to_owned(),
+                parents: vec!["a0".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(2, 0),
+            },
+        ];
+        let remote = vec![
+            AncestorDetail {
+                id: "a0".to_owned(),
+                parents: vec![],
+                timestamp: NaiveDateTime::from_timestamp(1, 0),
+            },
+            AncestorDetail {
+                id: "b0".to_owned(),
+                parents: vec!["a0".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(3, 0),
+            },
+            AncestorDetail {
+                id: "b1".to_owned(),
+                parents: vec!["b0".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(3, 0),
+            },
+        ];
+
+        let mut db = InMemoryAncestorDB::new();
+        db.insert(&local);
+        db.insert(&remote);
+
+        let result = common_ancestors(&db, "b1", "a1");
+        assert_eq!(result.unwrap(), "a0");
+    }
+
+    #[test]
+    fn test_complex_ancestor() {
+        let local = vec![
+            AncestorDetail {
+                id: "a00".to_owned(),
+                parents: vec![],
+                timestamp: NaiveDateTime::from_timestamp(1, 0),
+            },
+            AncestorDetail {
+                id: "a0".to_owned(),
+                parents: vec!["a00".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(2, 0),
+            },
+            AncestorDetail {
+                id: "a1".to_owned(),
+                parents: vec!["a0".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(3, 0),
+            },
+            AncestorDetail {
+                id: "a2".to_owned(),
+                parents: vec!["a1".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(4, 0),
+            },
+            AncestorDetail {
+                id: "a3".to_owned(),
+                parents: vec!["a2".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(5, 0),
+            },
+            AncestorDetail {
+                id: "a4".to_owned(),
+                parents: vec!["a3".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(6, 0),
+            },
+            AncestorDetail {
+                id: "b0".to_owned(),
+                parents: vec!["a1".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(30, 0),
+            },
+            AncestorDetail {
+                id: "b1".to_owned(),
+                parents: vec!["b0".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(31, 0),
+            },
+            AncestorDetail {
+                id: "b2".to_owned(),
+                parents: vec!["b1".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(32, 0),
+            },
+            AncestorDetail {
+                id: "b3".to_owned(),
+                parents: vec!["a4".to_owned(), "b2".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(33, 0),
+            },
+        ];
+
+        let remote = vec![
+            AncestorDetail {
+                id: "a00".to_owned(),
+                parents: vec![],
+                timestamp: NaiveDateTime::from_timestamp(1, 0),
+            },
+            AncestorDetail {
+                id: "a0".to_owned(),
+                parents: vec!["a00".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(2, 0),
+            },
+            AncestorDetail {
+                id: "a1".to_owned(),
+                parents: vec!["a0".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(3, 0),
+            },
+            AncestorDetail {
+                id: "a2".to_owned(),
+                parents: vec!["a1".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(4, 0),
+            },
+            AncestorDetail {
+                id: "a3".to_owned(),
+                parents: vec!["a2".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(5, 0),
+            },
+            AncestorDetail {
+                id: "a4".to_owned(),
+                parents: vec!["a3".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(6, 0),
+            },
+            AncestorDetail {
+                id: "a5".to_owned(),
+                parents: vec!["a4".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(7, 0),
+            },
+            AncestorDetail {
+                id: "a6".to_owned(),
+                parents: vec!["a4".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(8, 0),
+            },
+            AncestorDetail {
+                id: "a7".to_owned(),
+                parents: vec!["a5".to_owned(), "a6".to_owned()],
+                timestamp: NaiveDateTime::from_timestamp(9, 0),
+            },
+        ];
+
+        let mut db = InMemoryAncestorDB::new();
+        db.insert(&local);
+        db.insert(&remote);
+
+        let result = common_ancestors(&db, "b3", "a7");
+        assert_eq!(result.unwrap(), "a4");
+    }
+}

--- a/service/src/document/document_service.rs
+++ b/service/src/document/document_service.rs
@@ -1,0 +1,399 @@
+use chrono::Utc;
+
+use domain::document::{AncestorDetail, Document, RawDocument};
+use repository::{DocumentRepository, RepositoryError, StorageConnection};
+
+use super::{
+    common_ancestor::{common_ancestors, AncestorDB, CommonAncestorError, InMemoryAncestorDB},
+    merge::{three_way_merge, two_way_merge, TakeLatestConflictSolver},
+};
+
+#[derive(Debug)]
+pub enum DocumentInsertError {
+    /// Document version needs to be merged first. Contains an automerged document which can be
+    /// reviewed and/or inserted.
+    MergeRequired(RawDocument),
+    InvalidDocumentHistory,
+    /// Unable to finalise a document (assign an id)
+    FinalisationError(String),
+    DatabaseError(RepositoryError),
+    InternalError(String),
+}
+
+pub struct DocumentService<'a> {
+    connection: &'a StorageConnection,
+}
+
+impl From<RepositoryError> for DocumentInsertError {
+    fn from(err: RepositoryError) -> Self {
+        match err {
+            RepositoryError::NotFound => DocumentInsertError::InvalidDocumentHistory,
+            _ => DocumentInsertError::DatabaseError(err),
+        }
+    }
+}
+
+fn two_way_document_merge(our: RawDocument, their: Document) -> RawDocument {
+    let our_data = our.data;
+    let their_data = their.data;
+
+    let solver = TakeLatestConflictSolver::new(our.timestamp.clone(), their.timestamp.clone());
+    let merged = two_way_merge(&our_data, &their_data, &solver);
+
+    let mut new_parents = our.parents;
+    new_parents.push(their.id);
+
+    RawDocument {
+        name: our.name,
+        parents: new_parents,
+        author: our.author,
+        timestamp: Utc::now(),
+        type_: our.type_,
+        data: merged,
+    }
+}
+
+fn three_way_document_merge(our: RawDocument, their: Document, base: Document) -> RawDocument {
+    let our_data = our.data;
+    let their_data = their.data;
+    let base_data = base.data;
+
+    let solver = TakeLatestConflictSolver::new(our.timestamp.clone(), their.timestamp.clone());
+    let merged = three_way_merge(&our_data, &their_data, &base_data, &solver);
+
+    let mut new_parents = our.parents;
+    new_parents.push(their.id);
+
+    RawDocument {
+        name: our.name,
+        parents: new_parents,
+        author: our.author,
+        timestamp: Utc::now(),
+        type_: our.type_,
+        data: merged,
+    }
+}
+
+impl<'a> DocumentService<'a> {
+    pub fn new(connection: &'a StorageConnection) -> Self {
+        DocumentService { connection }
+    }
+
+    pub fn get_document(&self, name: &str, store: &str) -> Result<Document, RepositoryError> {
+        DocumentRepository::new(self.connection).find_one_by_name(name, store)
+    }
+
+    /// Must be called in a transaction
+    pub fn insert_document(
+        &self,
+        store: &str,
+        doc: RawDocument,
+    ) -> Result<Document, DocumentInsertError> {
+        let repo = DocumentRepository::new(self.connection);
+        let head_option =
+            repo.head(&doc.name, store)
+                .map(|v| Some(v))
+                .or_else(|err| match err {
+                    RepositoryError::NotFound => Ok(None),
+                    _ => return Err(DocumentInsertError::DatabaseError(err)),
+                })?;
+        // do a unchecked insert of the doc and update the head
+        let insert_doc_and_head = |raw_doc: RawDocument| -> Result<Document, DocumentInsertError> {
+            let doc = raw_doc
+                .finalise()
+                .map_err(|err| DocumentInsertError::FinalisationError(err))?;
+            repo.insert_document(&doc)?;
+            repo.update_document_head(store, &doc)?;
+            Ok(doc)
+        };
+        let head = match head_option {
+            Some(head) => {
+                if doc.parents.contains(&head.head) {
+                    return Ok(insert_doc_and_head(doc)?);
+                }
+                head
+            }
+            None => {
+                if doc.parents.is_empty() {
+                    return Ok(insert_doc_and_head(doc)?);
+                }
+                return Err(DocumentInsertError::InvalidDocumentHistory);
+            }
+        };
+
+        // Leaving the happy path; propose a auto merged doc:
+        // 1) if has common ancestor -> 3 way merge
+        // 2) else -> 2 way merge
+
+        // prepare some common data:
+        let their_doc = repo.find_one_by_id(&head.head)?;
+        let mut db = InMemoryAncestorDB::new();
+        db.insert(&repo.ancestor_details(&doc.name)?);
+
+        // use our latest parent to find the common ancestor
+        let mut our_parents = Vec::<AncestorDetail>::new();
+        for parent in &doc.parents {
+            match db.get_details(parent) {
+                Some(detail) => our_parents.push(detail),
+                None => return Err(DocumentInsertError::InvalidDocumentHistory),
+            }
+        }
+        our_parents.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        let latest_parent = our_parents.first();
+        let latest_parent_id = match latest_parent {
+            Some(p) => p.id.to_owned(),
+            None => {
+                // no parents try a two way merge
+                let merged = two_way_document_merge(doc, their_doc);
+                return Err(DocumentInsertError::MergeRequired(merged));
+            }
+        };
+        let ancestor = match common_ancestors(&db, &latest_parent_id, &their_doc.id) {
+            Ok(a) => Some(a),
+            Err(err) => match err {
+                CommonAncestorError::NoCommonAncestorFound => None,
+                CommonAncestorError::InvalidAncestorData => {
+                    return Err(DocumentInsertError::InvalidDocumentHistory);
+                }
+            },
+        };
+
+        match ancestor {
+            Some(base) => {
+                let base_doc = repo.find_one_by_id(&base)?;
+                let merged = three_way_document_merge(doc, their_doc, base_doc);
+                Err(DocumentInsertError::MergeRequired(merged))
+            }
+            None => {
+                // no common ancestor try a two way merge
+                let merged = two_way_document_merge(doc, their_doc);
+                Err(DocumentInsertError::MergeRequired(merged))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod document_service_test {
+    use assert_json_diff::assert_json_eq;
+    use chrono::{DateTime, NaiveDateTime, Utc};
+    use repository::{get_storage_connection_manager, test_db};
+    use serde_json::json;
+
+    use super::*;
+
+    #[actix_rt::test]
+    async fn test_insert_and_auto_resolve_conflict() {
+        let settings = test_db::get_test_db_settings("omsupply-database-document_service");
+        test_db::setup(&settings).await;
+        let connection_manager = get_storage_connection_manager(&settings);
+        let connection = connection_manager.connection().unwrap();
+
+        let service = DocumentService::new(&connection);
+        let store = "test_store";
+        let template = RawDocument {
+            name: "test/doc".to_string(),
+            parents: vec![],
+            author: "me".to_string(),
+            timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(5000, 0), Utc),
+            type_: "test_data".to_string(),
+            data: json!({}),
+        };
+
+        let mut base_doc = template.clone();
+        base_doc.data = json!({
+          "value1": "base",
+          "map": {},
+          "conflict": "base value"
+        });
+        let v0 = service.insert_document(store, base_doc).unwrap();
+        // assert document is there:
+        let result = service.get_document(&template.name, store).unwrap();
+        assert_eq!(result.id, v0.id);
+
+        // concurrent edits form "their" and "our"
+
+        let mut their_doc = template.clone();
+        their_doc.parents = vec![v0.id.to_owned()];
+        their_doc.timestamp =
+            DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(5100, 0), Utc);
+        their_doc.data = json!({
+          "value1": "their change",
+          "map": {
+            "entry_their": 1
+          },
+          "conflict": "their change"
+        });
+        let v1 = service.insert_document(store, their_doc).unwrap();
+        let result = service.get_document(&template.name, store).unwrap();
+        assert_eq!(result.id, v1.id);
+
+        let mut our_doc = template.clone();
+        our_doc.parents = vec![v0.id.to_owned()];
+        our_doc.timestamp = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(5200, 0), Utc);
+        our_doc.data = json!({
+          "value1": "base",
+          "map": {
+            "entry_our": 2
+          },
+          "conflict": "our change wins because we are more recent"
+        });
+        let merge_err = service.insert_document(store, our_doc).unwrap_err();
+        let auto_merge = match merge_err {
+            DocumentInsertError::MergeRequired(auto_merge) => auto_merge,
+            err => panic!(
+                "Expected DocumentInsertError::MergeRequired but got: {:?}",
+                err
+            ),
+        };
+        // try to insert the auto merge
+        service.insert_document(store, auto_merge).unwrap();
+        let result = service.get_document(&template.name, store).unwrap();
+        assert_json_eq!(
+            result.data,
+            json!({
+              "value1": "their change",
+              "map": {
+                "entry_their": 1,
+                "entry_our": 2
+              },
+              "conflict": "our change wins because we are more recent"
+            })
+        );
+        assert_eq!(result.parents, vec![v0.id.to_owned(), v1.id.to_owned()]);
+
+        // add new doc with a merge as parent
+        let mut next_doc = template.clone();
+        next_doc.parents = vec![result.id.to_owned()];
+        next_doc.timestamp = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(5500, 0), Utc);
+        next_doc.data = json!({
+          "value1": "next change",
+          "map": {
+            "entry_their": 1,
+            "entry_our": 2
+          },
+          "conflict": "our change wins because we are more recent"
+        });
+        let v4 = service.insert_document(store, next_doc).unwrap();
+        let result = service.get_document(&template.name, store).unwrap();
+        assert_eq!(result.id, v4.id);
+        assert_json_eq!(
+            result.data,
+            json!({
+              "value1": "next change",
+              "map": {
+                "entry_their": 1,
+                "entry_our": 2
+              },
+              "conflict": "our change wins because we are more recent"
+            })
+        );
+    }
+
+    /// Test case where another change is made while handling a merge conflict:
+    /// 1) insert: `base`
+    /// 2) insert: `their` -> parents: [base]
+    /// 3) try insert conflicting `our` -> service returns an `auto_merge`
+    /// 4) insert: `their2` -> parents: [their]
+    /// 5) inserting `auto_merge` will fail
+    /// To solve this conflict:
+    /// 6) retry insert `our`: -> service returns an automerge
+    /// 7) insert: `auto_merge` -> parents: [base, their2]
+    #[actix_rt::test]
+    async fn test_document_multiple_concurrent_edits() {
+        let settings =
+            test_db::get_test_db_settings("omsupply-database-document_multiple_concurrent_edits");
+        test_db::setup(&settings).await;
+        let connection_manager = get_storage_connection_manager(&settings);
+        let connection = connection_manager.connection().unwrap();
+
+        let service = DocumentService::new(&connection);
+        let store = "test_store";
+        let template = RawDocument {
+            name: "test/doc".to_string(),
+            parents: vec![],
+            author: "me".to_string(),
+            timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(5000, 0), Utc),
+            type_: "test_data".to_string(),
+            data: json!({}),
+        };
+
+        let mut base_doc = template.clone();
+        base_doc.data = json!({
+          "value1": "base",
+        });
+        let v0 = service.insert_document(store, base_doc).unwrap();
+        // assert document is there:
+        let result = service.get_document(&template.name, store).unwrap();
+        assert_eq!(result.id, v0.id);
+
+        // concurrent edits form "their" and "our"
+        let mut their_doc = template.clone();
+        their_doc.parents = vec![v0.id.to_owned()];
+        their_doc.timestamp =
+            DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(5100, 0), Utc);
+        their_doc.data = json!({
+          "value1": "their change",
+        });
+        let their_v0 = service.insert_document(store, their_doc).unwrap();
+        let result = service.get_document(&template.name, store).unwrap();
+        assert_eq!(result.id, their_v0.id);
+
+        let mut our_doc = template.clone();
+        our_doc.parents = vec![v0.id.to_owned()];
+        our_doc.timestamp = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(5200, 0), Utc);
+        our_doc.data = json!({
+          "value1": "base",
+          "our": "our",
+        });
+        // Need to have a copy for retry. TODO: but the
+        let our_copy = our_doc.clone();
+        let merge_err = service.insert_document(store, our_doc).unwrap_err();
+        let auto_merge = match merge_err {
+            DocumentInsertError::MergeRequired(auto_merge) => auto_merge,
+            err => panic!(
+                "Expected DocumentInsertError::MergeRequired but got: {:?}",
+                err
+            ),
+        };
+        // another edit from their in the mean time:
+        let mut their_doc = template.clone();
+        their_doc.parents = vec![their_v0.id.to_owned()];
+        their_doc.timestamp =
+            DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(5300, 0), Utc);
+        their_doc.data = json!({
+          "value1": "their change 2",
+        });
+        let their_v1 = service.insert_document(store, their_doc).unwrap();
+        let result = service.get_document(&template.name, store).unwrap();
+        assert_eq!(result.id, their_v1.id);
+
+        // try to insert the auto merge
+        let merge_err = service.insert_document(store, auto_merge).unwrap_err();
+        assert!(matches!(merge_err, DocumentInsertError::MergeRequired(_)));
+
+        // Retry insert the original our
+        let merge_err = service.insert_document(store, our_copy).unwrap_err();
+        let auto_merge = match merge_err {
+            DocumentInsertError::MergeRequired(auto_merge) => auto_merge,
+            err => panic!(
+                "Expected DocumentInsertError::MergeRequired but got: {:?}",
+                err
+            ),
+        };
+        // try to insert the new auto merge
+        service.insert_document(store, auto_merge).unwrap();
+        let result = service.get_document(&template.name, store).unwrap();
+        assert_json_eq!(
+            result.data,
+            json!({
+                "value1": "their change 2",
+                "our": "our"
+            })
+        );
+        assert_eq!(
+            result.parents,
+            vec![v0.id.to_owned(), their_v1.id.to_owned()]
+        );
+    }
+}

--- a/service/src/document/merge.rs
+++ b/service/src/document/merge.rs
@@ -1,0 +1,427 @@
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+type MergeObject = serde_json::Map<String, serde_json::Value>;
+
+pub trait ConflictSolver {
+    fn solve(&self, our: &Value, their: &Value, base: Option<&Value>) -> Value;
+}
+
+pub struct TakeOurConflictSolver {}
+
+impl ConflictSolver for TakeOurConflictSolver {
+    fn solve(&self, our: &Value, _: &Value, _: Option<&Value>) -> Value {
+        our.clone()
+    }
+}
+
+pub struct TakeLatestConflictSolver {
+    our: DateTime<Utc>,
+    their: DateTime<Utc>,
+}
+
+impl TakeLatestConflictSolver {
+    pub fn new(our: DateTime<Utc>, their: DateTime<Utc>) -> Self {
+        TakeLatestConflictSolver { our, their }
+    }
+}
+
+impl ConflictSolver for TakeLatestConflictSolver {
+    fn solve(&self, our: &Value, their: &Value, _: Option<&Value>) -> Value {
+        if self.our > self.their {
+            our.clone()
+        } else {
+            their.clone()
+        }
+    }
+}
+
+pub fn two_way_merge(ours: &Value, theirs: &Value, strategy: &dyn ConflictSolver) -> Value {
+    match (ours, theirs) {
+        (Value::Object(o), Value::Object(t)) => {
+            return two_way_merge_object(o, t, strategy);
+        }
+        (o, t) => {
+            let merge = two_way_merge_value(Some(o), Some(t), strategy);
+            merge.unwrap_or(Value::Null)
+        }
+    }
+}
+
+fn two_way_merge_object(
+    ours: &MergeObject,
+    theirs: &MergeObject,
+    strategy: &dyn ConflictSolver,
+) -> Value {
+    let all_keys: Vec<String> = ours
+        .keys()
+        .into_iter()
+        .chain(theirs.keys().into_iter())
+        .map(|it| it.to_owned())
+        .collect();
+
+    let mut result = MergeObject::new();
+    for key in all_keys {
+        let merged = two_way_merge_value(ours.get(&key), theirs.get(&key), strategy);
+        merged.map(|v| result.insert(key, v));
+    }
+
+    Value::Object(result)
+}
+
+fn two_way_merge_value(
+    ours: Option<&Value>,
+    theirs: Option<&Value>,
+    strategy: &dyn ConflictSolver,
+) -> Option<Value> {
+    match (ours, theirs) {
+        (Some(our), Some(their)) => match (our, their) {
+            (Value::Object(o), Value::Object(t)) => Some(two_way_merge_object(o, t, strategy)),
+            _ => Some(strategy.solve(our, their, None)),
+        },
+        (Some(our), None) => Some(our.clone()),
+        (None, Some(their)) => Some(their.clone()),
+        (None, None) => None,
+    }
+}
+
+/// Merge theirs into ours using `base` as a common ancestor
+pub fn three_way_merge(
+    ours: &Value,
+    theirs: &Value,
+    base: &Value,
+    strategy: &dyn ConflictSolver,
+) -> Value {
+    match (ours, theirs, base) {
+        (Value::Object(o), Value::Object(t), Value::Object(b)) => {
+            return three_way_merge_object(o, t, b, strategy);
+        }
+        (o, t, b) => {
+            let merge = three_way_merge_value(Some(o), Some(t), Some(b), strategy);
+            merge.unwrap_or(Value::Null)
+        }
+    }
+}
+
+fn three_way_merge_object(
+    ours: &MergeObject,
+    theirs: &MergeObject,
+    base: &MergeObject,
+    strategy: &dyn ConflictSolver,
+) -> Value {
+    let all_keys: Vec<String> = ours
+        .keys()
+        .into_iter()
+        .chain(theirs.keys().into_iter())
+        .map(|it| it.to_owned())
+        .collect();
+
+    let mut result = MergeObject::new();
+    for key in all_keys {
+        let merged =
+            three_way_merge_value(ours.get(&key), theirs.get(&key), base.get(&key), strategy);
+        merged.map(|v| result.insert(key, v));
+    }
+
+    Value::Object(result)
+}
+
+fn three_way_merge_value(
+    ours: Option<&Value>,
+    theirs: Option<&Value>,
+    base: Option<&Value>,
+    strategy: &dyn ConflictSolver,
+) -> Option<Value> {
+    match (ours, theirs, base) {
+        (Some(our), Some(their), Some(base)) => match (our, their, base) {
+            (Value::Object(o), Value::Object(t), Value::Object(b)) => {
+                Some(three_way_merge_object(o, t, b, strategy))
+            }
+            _ => {
+                if our == their {
+                    Some(our.clone())
+                } else if our == base {
+                    Some(their.clone())
+                } else if their == base {
+                    Some(our.clone())
+                } else {
+                    Some(strategy.solve(our, their, Some(base)))
+                }
+            }
+        },
+        (Some(our), Some(their), None) => {
+            let merged = two_way_merge(our, their, strategy);
+            Some(merged)
+        }
+        (Some(_), None, Some(_)) => {
+            // removed in theirs
+            None
+        }
+        (None, Some(_), Some(_)) => {
+            // removed in ours
+            None
+        }
+        (Some(our), None, None) => {
+            // added in our's
+            Some(our.clone())
+        }
+        (None, Some(their), None) => {
+            // Added in their's
+            Some(their.clone())
+        }
+        (None, None, Some(_)) => {
+            // nothing to do
+            None
+        }
+        (None, None, None) => {
+            // should not happen
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod two_way_merge_test {
+    use assert_json_diff::assert_json_eq;
+    use serde_json::*;
+
+    use crate::document::merge::{two_way_merge, TakeOurConflictSolver};
+
+    #[test]
+    fn test_simple_merge() {
+        let theirs = json!({
+          "value1": "string2",
+          "value2": true,
+          "value4": 50,
+          "value5": 5
+        });
+        let ours = json!({
+          "value1": "string",
+          "value2": false,
+          "value3": 30,
+          "value4": 50
+        });
+        let result = two_way_merge(&ours, &theirs, &TakeOurConflictSolver {});
+        assert_json_eq!(
+            &result,
+            json!({
+              "value1": "string",
+              "value2": false,
+              "value3": 30,
+              "value4": 50,
+              "value5": 5
+            })
+        );
+    }
+
+    #[test]
+    fn test_simple_nested() {
+        let theirs = json!({
+          "value1": "string",
+          "value2": true,
+          "value3": {
+            "obj": {
+              "value1": 1,
+            },
+            "value1": "v1",
+            "value2": 2
+          }
+        });
+        let ours = json!({
+          "value1": "string",
+          "value2": true,
+          "value3": {
+            "obj": {
+              "value1": 2,
+              "value2": 22,
+            },
+            "value1": "v1"
+          }
+        });
+        let result = two_way_merge(&ours, &theirs, &TakeOurConflictSolver {});
+        assert_json_eq!(
+            &result,
+            json!({
+              "value1": "string",
+              "value2": true,
+              "value3": {
+                "obj": {
+                  "value1": 2,
+                  "value2": 22,
+                },
+                "value1": "v1",
+                "value2": 2
+              }
+            })
+        );
+    }
+}
+
+#[cfg(test)]
+mod three_way_merge_test {
+    use assert_json_diff::assert_json_eq;
+    use serde_json::*;
+
+    use crate::document::merge::{three_way_merge, TakeOurConflictSolver};
+
+    #[test]
+    fn test_simple_merge() {
+        let base = json!({
+          "value1": "string",
+          "value2": true,
+          "value3": 30,
+          "value4": 50
+        });
+        let theirs = json!({
+          "value1": "string2",
+          "value2": true,
+          "value4": 50
+        });
+        let ours = json!({
+          "value1": "string",
+          "value2": false,
+          "value3": 30,
+          "value4": 50
+        });
+        let result = three_way_merge(&ours, &theirs, &base, &TakeOurConflictSolver {});
+        assert_json_eq!(
+            &result,
+            json!({
+              "value1": "string2",
+              "value2": false,
+              "value4": 50
+            })
+        );
+    }
+
+    #[test]
+    fn test_simple_merge_conflict() {
+        // test conflict
+        let base = json!({
+          "value1": "string",
+          "value2": true,
+          "value3": 30,
+          "value4": 50
+        });
+        let theirs = json!({
+          "value1": "string2",
+          "value2": false,
+          "value4": 51
+        });
+        let ours = json!({
+          "value1": "string3",
+          "value2": false,
+          "value3": 30,
+          "value4": 52
+        });
+        let result = three_way_merge(&ours, &theirs, &base, &TakeOurConflictSolver {});
+        assert_json_eq!(
+            &result,
+            json!({
+              "value1": "string3",
+              "value2": false,
+              "value4": 52
+            })
+        );
+    }
+
+    #[test]
+    fn test_simple_merge_nested() {
+        // test conflict
+        let base = json!({
+          "value1": "string",
+          "obj": {
+            "i1": 1,
+            "obj2": {
+              "str": "str",
+            }
+          }
+        });
+        let theirs = json!({
+          "value1": "string",
+          "obj": {
+            "i1": 2,
+            "obj2": {
+              "str": "str",
+            }
+          }
+        });
+        let ours = json!({
+          "value1": "string2",
+          "obj": {
+            "i1": 1,
+            "obj2": {
+              "str": "str2",
+            }
+          }
+        });
+        let result = three_way_merge(&ours, &theirs, &base, &TakeOurConflictSolver {});
+        assert_json_eq!(
+            &result,
+            json!({
+              "value1": "string2",
+              "obj": {
+                "i1": 2,
+                "obj2": {
+                  "str": "str2",
+                }
+              }
+            })
+        );
+
+        // remove whole nested obj
+        let ours = json!({
+          "value1": "string2",
+          "obj": {
+            "i1": 1,
+          }
+        });
+        let result = three_way_merge(&ours, &theirs, &base, &TakeOurConflictSolver {});
+        assert_json_eq!(
+            &result,
+            json!({
+              "value1": "string2",
+              "obj": {
+                "i1": 2,
+              }
+            })
+        );
+    }
+
+    #[test]
+    fn test_simple_merge_different_shapes() {
+        // test conflict
+        let base = json!({
+          "value1": "string",
+          "value2": true,
+          "value3": 30,
+          "obj": {
+            "v": 1,
+          }
+        });
+        let theirs = json!({
+          "value1": 1,
+          "value2": "str",
+          "value3": 30,
+          "obj": {
+            "v": 2
+          }
+        });
+        let ours = json!({
+          "value1": "string",
+          "value2": true,
+          "value3": false,
+          "obj": 10,
+        });
+        let result = three_way_merge(&ours, &theirs, &base, &TakeOurConflictSolver {});
+        assert_json_eq!(
+            &result,
+            json!({
+              "value1": 1,
+              "value2": "str",
+              "value3": false,
+              "obj": 10,
+            })
+        );
+    }
+}

--- a/service/src/document/mod.rs
+++ b/service/src/document/mod.rs
@@ -1,0 +1,3 @@
+pub mod common_ancestor;
+pub mod document_service;
+pub mod merge;

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -3,6 +3,7 @@ use repository::RepositoryError;
 use std::convert::TryInto;
 
 pub mod auth_data;
+pub mod document;
 pub mod invoice;
 pub mod invoice_line;
 pub mod item;

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -9,3 +9,5 @@ path = "src/lib.rs"
 [dependencies]
 sha2 = "0.9.5"
 uuid = { version = "0.8", features = ["v4"] }
+serde = "1.0.126"
+serde_json = "1.0.66"

--- a/util/src/canonical_json.rs
+++ b/util/src/canonical_json.rs
@@ -1,0 +1,78 @@
+use std::{collections::BTreeMap, fmt};
+
+use serde::{Serialize, Serializer};
+use serde_json::to_string as to_json_string;
+
+pub type Object = BTreeMap<String, CanonicalJsonValue>;
+
+// This code is mostly copied from
+// https://github.com/ruma/ruma/blob/main/crates/ruma-serde/src/canonical_json/value.rs
+// Only difference is that it also works with floats
+
+/// Serialize a Json value in a deterministic way, i.e. object keys are sorted.
+#[derive(Clone, Eq, PartialEq)]
+pub enum CanonicalJsonValue {
+    Null,
+    Bool(bool),
+    Number(serde_json::Number),
+    String(String),
+    Array(Vec<CanonicalJsonValue>),
+    Object(Object),
+}
+
+impl From<serde_json::Value> for CanonicalJsonValue {
+    fn from(val: serde_json::Value) -> Self {
+        match val {
+            serde_json::Value::Bool(b) => Self::Bool(b),
+            serde_json::Value::Number(num) => Self::Number(num),
+            serde_json::Value::Array(vec) => {
+                Self::Array(vec.into_iter().map(Into::into).collect::<Vec<_>>())
+            }
+            serde_json::Value::String(string) => Self::String(string),
+            serde_json::Value::Object(obj) => Self::Object(
+                obj.into_iter()
+                    .map(|(k, v)| (k, v.into()))
+                    .collect::<Object>(),
+            ),
+            serde_json::Value::Null => Self::Null,
+        }
+    }
+}
+
+impl Serialize for CanonicalJsonValue {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Null => serializer.serialize_unit(),
+            Self::Bool(b) => serializer.serialize_bool(*b),
+            Self::Number(n) => n.serialize(serializer),
+            Self::String(s) => serializer.serialize_str(s),
+            Self::Array(v) => v.serialize(serializer),
+            Self::Object(m) => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(m.len()))?;
+                for (k, v) in m {
+                    map.serialize_entry(k, v)?;
+                }
+                map.end()
+            }
+        }
+    }
+}
+
+impl fmt::Display for CanonicalJsonValue {
+    /// Display this value as a string.
+    ///
+    /// This `Display` implementation is intentionally unaffected by any formatting parameters,
+    /// because adding extra whitespace or otherwise pretty-printing it would make it not the
+    /// canonical form anymore.
+    ///
+    /// If you want to pretty-print a `CanonicalJsonValue` for debugging purposes, use
+    /// one of `serde_json::{to_string_pretty, to_vec_pretty, to_writer_pretty}`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", to_json_string(&self).map_err(|_| fmt::Error)?)
+    }
+}

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod canonical_json;
 pub mod hash;
 pub mod uuid;


### PR DESCRIPTION
Includes:
- Document repository
- CanonicalJsonValue to serialize a json object in a deterministic way, i.e. to get the same object hash even if input object keys are sorted differently => `hash(obj) == hash(obj')` if `obj` and `obj'` are the same but have differently sorted keys.
- Common ancestor finder: finds the latest common ancestor of two document versions (needed for a three way merge)
- Two and three way merges
- Document Service to add new document versions and proposes a merged document version if there was a concurrent edit