### PR TITLE
506 auth/permission validation helper and me endpoint

### DIFF
--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -21,6 +21,7 @@ pub trait ContextExt {
     fn get_connection_manager(&self) -> &StorageConnectionManager;
     fn get_loader<T: anymap::any::Any + Send + Sync>(&self) -> &T;
     fn get_auth_data(&self) -> &AuthData;
+    fn get_auth_token(&self) -> Option<String>;
 }
 
 impl<'a> ContextExt for Context<'a> {
@@ -34,6 +35,11 @@ impl<'a> ContextExt for Context<'a> {
 
     fn get_auth_data(&self) -> &AuthData {
         self.data_unchecked::<Data<AuthData>>()
+    }
+
+    fn get_auth_token(&self) -> Option<String> {
+        self.data_opt::<RequestUserData>()
+            .and_then(|d| d.auth_token.to_owned())
     }
 }
 

--- a/graphql/src/schema/mod.rs
+++ b/graphql/src/schema/mod.rs
@@ -5,6 +5,16 @@ pub mod types;
 
 pub use mutations::Mutations;
 pub use queries::Queries;
+use service::permission_validation::ValidationDeniedKind;
 pub use subscriptions::Subscriptions;
 
 pub type Schema = async_graphql::Schema<Queries, Mutations, Subscriptions>;
+
+pub fn validation_denied_kind_to_string(kind: ValidationDeniedKind) -> String {
+    match kind {
+        ValidationDeniedKind::NotAuthenticated(msg) => format!("Not authenticated: {}", msg),
+        ValidationDeniedKind::InsufficientPermission((msg, _)) => {
+            format!("Insufficient permission: {}", msg)
+        }
+    }
+}

--- a/graphql/src/schema/queries/logout.rs
+++ b/graphql/src/schema/queries/logout.rs
@@ -1,9 +1,8 @@
 use async_graphql::*;
-use service::permission_validation::{
-    validate_auth, validation_denied_kind_to_string, ValidationError,
-};
+use service::permission_validation::{validate_auth, ValidationError};
 
 use crate::schema::types::{AccessDenied, InternalError};
+use crate::schema::validation_denied_kind_to_string;
 use crate::ContextExt;
 use service::token::TokenService;
 

--- a/graphql/src/schema/queries/logout.rs
+++ b/graphql/src/schema/queries/logout.rs
@@ -1,7 +1,10 @@
 use async_graphql::*;
+use service::permission_validation::{
+    validate_auth, validation_denied_kind_to_string, ValidationError,
+};
 
-use crate::schema::types::InternalError;
-use crate::{ContextExt, RequestUserData};
+use crate::schema::types::{AccessDenied, InternalError};
+use crate::ContextExt;
 use service::token::TokenService;
 
 use super::{set_refresh_token_cookie, ErrorWrapper};
@@ -61,11 +64,7 @@ impl NotAnApiToken {
 #[derive(Interface)]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum LogoutErrorInterface {
-    MissingAuthToken(MissingAuthToken),
-    ExpiredSignature(ExpiredSignature),
-    InvalidToken(InvalidToken),
-    TokenInvalided(TokenInvalided),
-    NotAnApiToken(NotAnApiToken),
+    AccessDenied(AccessDenied),
     InternalError(InternalError),
 }
 
@@ -79,51 +78,30 @@ pub enum LogoutResponse {
 
 pub fn logout(ctx: &Context<'_>) -> LogoutResponse {
     let auth_data = ctx.get_auth_data();
-    let mut service = TokenService::new(
-        &auth_data.token_bucket,
-        auth_data.auth_token_secret.as_bytes(),
-    );
-
     // invalid the refresh token cookie first (just in case an error happens before we do so)
     set_refresh_token_cookie(ctx, "logged out", 0, auth_data.debug_no_ssl);
 
-    let auth_token = match ctx
-        .data_opt::<RequestUserData>()
-        .and_then(|d| d.auth_token.to_owned())
-    {
-        Some(data) => data,
-        None => {
-            return LogoutResponse::Error(ErrorWrapper {
-                error: LogoutErrorInterface::MissingAuthToken(MissingAuthToken),
-            })
-        }
-    };
-
-    // verify that the provided token is valid
-    let claims = match service.verify_token(&auth_token) {
-        Ok(claims) => claims,
+    let user_auth = match validate_auth(auth_data, &ctx.get_auth_token()) {
+        Ok(value) => value,
         Err(err) => {
-            let e = match err {
-                service::token::JWTValidationError::ExpiredSignature => todo!(),
-                service::token::JWTValidationError::NotAnApiToken => {
-                    LogoutErrorInterface::NotAnApiToken(NotAnApiToken)
-                }
-                service::token::JWTValidationError::InvalidToken(_) => {
-                    LogoutErrorInterface::InvalidToken(InvalidToken)
-                }
-                service::token::JWTValidationError::TokenInvalided => {
-                    LogoutErrorInterface::TokenInvalided(TokenInvalided)
-                }
-                service::token::JWTValidationError::ConcurrencyLockError(_) => {
-                    LogoutErrorInterface::InternalError(InternalError("Lock error".to_string()))
+            let error = match err {
+                ValidationError::Denied(denied) => LogoutErrorInterface::AccessDenied(
+                    AccessDenied(validation_denied_kind_to_string(denied)),
+                ),
+                ValidationError::InternalError(err) => {
+                    LogoutErrorInterface::InternalError(InternalError(err))
                 }
             };
-            return LogoutResponse::Error(ErrorWrapper { error: e });
+            return LogoutResponse::Error(ErrorWrapper { error });
         }
     };
 
     // invalided all tokens of the user on the server
-    let user_id = claims.sub;
+    let user_id = user_auth.claims.sub;
+    let mut service = TokenService::new(
+        &auth_data.token_bucket,
+        auth_data.auth_token_secret.as_bytes(),
+    );
     match service.logout(&user_id) {
         Ok(_) => {}
         Err(e) => match e {

--- a/graphql/src/schema/queries/me.rs
+++ b/graphql/src/schema/queries/me.rs
@@ -1,10 +1,9 @@
 use async_graphql::*;
-use service::permission_validation::{
-    has_api_role, validate, validation_denied_kind_to_string, ValidationError,
-};
+use service::permission_validation::{has_api_role, validate, ValidationError};
 use service::user_account::{UserAccount, UserAccountService};
 
 use crate::schema::types::{AccessDenied, DatabaseError, InternalError};
+use crate::schema::validation_denied_kind_to_string;
 use crate::ContextExt;
 
 use super::ErrorWrapper;

--- a/graphql/src/schema/queries/me.rs
+++ b/graphql/src/schema/queries/me.rs
@@ -15,11 +15,12 @@ pub struct Me {
 
 #[Object]
 impl Me {
-    /// User id of the logged out user
+    /// Internal user id
     pub async fn user_id(&self) -> &str {
         &self.user.id
     }
 
+    /// The user's email address
     pub async fn email(&self) -> &Option<String> {
         &self.user.email
     }

--- a/graphql/src/schema/queries/me.rs
+++ b/graphql/src/schema/queries/me.rs
@@ -1,0 +1,83 @@
+use async_graphql::*;
+use service::permission_validation::{
+    has_api_role, validate, validation_denied_kind_to_string, ValidationError,
+};
+use service::user_account::{UserAccount, UserAccountService};
+
+use crate::schema::types::{AccessDenied, DatabaseError, InternalError};
+use crate::ContextExt;
+
+use super::ErrorWrapper;
+
+pub struct Me {
+    pub user: UserAccount,
+}
+
+#[Object]
+impl Me {
+    /// User id of the logged out user
+    pub async fn user_id(&self) -> &str {
+        &self.user.id
+    }
+
+    pub async fn email(&self) -> &Option<String> {
+        &self.user.email
+    }
+}
+
+#[derive(Interface)]
+#[graphql(field(name = "description", type = "&str"))]
+pub enum MeErrorInterface {
+    AccessDenied(AccessDenied),
+    DatabaseError(DatabaseError),
+    InternalError(InternalError),
+}
+
+pub type MeError = ErrorWrapper<MeErrorInterface>;
+
+#[derive(Union)]
+pub enum MeResponse {
+    Error(MeError),
+    Response(Me),
+}
+
+pub fn me(ctx: &Context<'_>) -> MeResponse {
+    let user = match validate(
+        ctx.get_connection_manager(),
+        ctx.get_auth_data(),
+        &ctx.get_auth_token(),
+        vec![has_api_role(service::permissions::ApiRole::User)],
+    ) {
+        Ok(value) => value,
+        Err(err) => {
+            let error = match err {
+                ValidationError::Denied(denied) => MeErrorInterface::AccessDenied(AccessDenied(
+                    validation_denied_kind_to_string(denied),
+                )),
+                ValidationError::InternalError(err) => {
+                    MeErrorInterface::InternalError(InternalError(err))
+                }
+            };
+            return MeResponse::Error(ErrorWrapper { error });
+        }
+    };
+
+    let user_service = UserAccountService::new(&user.connection);
+    let user = match user_service.find_user(&user.user_id) {
+        Ok(Some(user)) => user,
+        Ok(None) => {
+            return MeResponse::Error(ErrorWrapper {
+                error: MeErrorInterface::InternalError(InternalError(
+                    "Can't find user account data".to_string(),
+                )),
+            })
+        }
+        Err(err) => {
+            return MeResponse::Error(ErrorWrapper {
+                error: MeErrorInterface::DatabaseError(DatabaseError(err)),
+            })
+        }
+    };
+
+    MeResponse::Response(Me { user })
+}

--- a/graphql/src/schema/queries/mod.rs
+++ b/graphql/src/schema/queries/mod.rs
@@ -11,6 +11,8 @@ pub mod login;
 pub use self::login::*;
 pub mod logout;
 pub use self::logout::*;
+pub mod me;
+pub use self::me::*;
 pub mod refresh_token;
 pub use self::refresh_token::*;
 
@@ -40,6 +42,10 @@ impl Queries {
     /// The refresh token is returned as a cookie
     pub async fn refresh_token(&self, ctx: &Context<'_>) -> RefreshTokenResponse {
         refresh_token(ctx)
+    }
+
+    pub async fn me(&self, ctx: &Context<'_>) -> MeResponse {
+        me(ctx)
     }
 
     /// Query omSupply "name" entries

--- a/graphql/src/schema/queries/mod.rs
+++ b/graphql/src/schema/queries/mod.rs
@@ -44,7 +44,7 @@ impl Queries {
         refresh_token(ctx)
     }
 
-    pub async fn me(&self, ctx: &Context<'_>) -> MeResponse {
+    pub async fn me(&self, ctx: &Context<'_>) -> UserResponse {
         me(ctx)
     }
 

--- a/graphql/src/schema/types/mod.rs
+++ b/graphql/src/schema/types/mod.rs
@@ -246,8 +246,8 @@ impl AccessDenied {
         "Access Denied"
     }
 
-    pub async fn full_error(&self) -> String {
-        format!("{:#}", self.0)
+    pub async fn full_error(&self) -> &str {
+        &self.0
     }
 }
 

--- a/graphql/src/schema/types/mod.rs
+++ b/graphql/src/schema/types/mod.rs
@@ -1,7 +1,8 @@
 use crate::schema::{
     mutations::UserRegisterErrorInterface,
     queries::{
-        AuthTokenErrorInterface, LogoutErrorInterface, MeErrorInterface, RefreshTokenErrorInterface,
+        AuthTokenErrorInterface, LogoutErrorInterface, RefreshTokenErrorInterface,
+        UserErrorInterface,
     },
 };
 use domain::PaginationOption;
@@ -148,7 +149,7 @@ impl From<PaginationInput> for PaginationOption {
 #[graphql(concrete(name = "AuthTokenError", params(AuthTokenErrorInterface)))]
 #[graphql(concrete(name = "RefreshTokenError", params(RefreshTokenErrorInterface)))]
 #[graphql(concrete(name = "LogoutError", params(LogoutErrorInterface)))]
-#[graphql(concrete(name = "MeError", params(MeErrorInterface)))]
+#[graphql(concrete(name = "UserError", params(UserErrorInterface)))]
 pub struct ErrorWrapper<T: OutputType> {
     pub error: T,
 }

--- a/graphql/src/schema/types/mod.rs
+++ b/graphql/src/schema/types/mod.rs
@@ -1,6 +1,8 @@
 use crate::schema::{
     mutations::UserRegisterErrorInterface,
-    queries::{AuthTokenErrorInterface, LogoutErrorInterface, RefreshTokenErrorInterface},
+    queries::{
+        AuthTokenErrorInterface, LogoutErrorInterface, MeErrorInterface, RefreshTokenErrorInterface,
+    },
 };
 use domain::PaginationOption;
 use repository::RepositoryError;
@@ -146,6 +148,7 @@ impl From<PaginationInput> for PaginationOption {
 #[graphql(concrete(name = "AuthTokenError", params(AuthTokenErrorInterface)))]
 #[graphql(concrete(name = "RefreshTokenError", params(RefreshTokenErrorInterface)))]
 #[graphql(concrete(name = "LogoutError", params(LogoutErrorInterface)))]
+#[graphql(concrete(name = "MeError", params(MeErrorInterface)))]
 pub struct ErrorWrapper<T: OutputType> {
     pub error: T,
 }
@@ -233,6 +236,20 @@ impl From<RepositoryError> for NodeError {
 }
 
 // Generic Errors
+
+pub struct AccessDenied(pub String);
+
+#[Object]
+impl AccessDenied {
+    pub async fn description(&self) -> &'static str {
+        "Access Denied"
+    }
+
+    pub async fn full_error(&self) -> String {
+        format!("{:#}", self.0)
+    }
+}
+
 pub struct DatabaseError(pub RepositoryError);
 
 #[Object]

--- a/repository/src/db_diesel/user_account.rs
+++ b/repository/src/db_diesel/user_account.rs
@@ -23,11 +23,20 @@ impl<'a> UserAccountRepository<'a> {
         Ok(())
     }
 
-    pub fn find_one_by_id(&self, account_id: &str) -> Result<UserAccountRow, RepositoryError> {
-        let result = user_account_dsl::user_account
+    pub fn find_one_by_id(
+        &self,
+        account_id: &str,
+    ) -> Result<Option<UserAccountRow>, RepositoryError> {
+        let result: Result<UserAccountRow, diesel::result::Error> = user_account_dsl::user_account
             .filter(user_account_dsl::id.eq(account_id))
-            .first(&self.connection.connection)?;
-        Ok(result)
+            .first(&self.connection.connection);
+        match result {
+            Ok(row) => Ok(Some(row)),
+            Err(err) => match err {
+                diesel::result::Error::NotFound => Ok(None),
+                _ => Err(RepositoryError::from(err)),
+            },
+        }
     }
 
     pub fn find_one_by_user_name(

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -37,6 +37,7 @@ async fn main() -> std::io::Result<()> {
         token_bucket: RwLock::new(TokenBucket::new()),
         // TODO: configure ssl
         debug_no_ssl: true,
+        debug_no_access_control: false,
     });
     let connection_manager = get_storage_connection_manager(&settings.database);
     let loaders: LoaderMap = get_loaders(&connection_manager).await;

--- a/server/tests/graphql/mod.rs
+++ b/server/tests/graphql/mod.rs
@@ -49,6 +49,7 @@ where
         token_bucket: RwLock::new(TokenBucket::new()),
         // TODO: configure ssl
         debug_no_ssl: true,
+        debug_no_access_control: true,
     });
 
     let mut app = actix_web::test::init_service(
@@ -96,6 +97,7 @@ async fn run_gql_query(
         token_bucket: RwLock::new(TokenBucket::new()),
         // TODO: configure ssl
         debug_no_ssl: true,
+        debug_no_access_control: true,
     });
 
     let mut app = actix_web::test::init_service(

--- a/service/src/auth_data.rs
+++ b/service/src/auth_data.rs
@@ -5,6 +5,8 @@ pub struct AuthData {
     /// Secret to sign and verify auth (JWT) tokens.
     pub auth_token_secret: String,
     pub token_bucket: RwLock<TokenBucket>,
-    /// Indicates if we ran in debug mode without ssl certificate
+    /// Indicates if we run in debug mode without ssl certificate
     pub debug_no_ssl: bool,
+    /// Disable access control (e.g. for testing)
+    pub debug_no_access_control: bool,
 }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -7,6 +7,8 @@ pub mod invoice;
 pub mod invoice_line;
 pub mod item;
 pub mod name;
+pub mod permission_validation;
+pub mod permissions;
 pub mod stock_line;
 pub mod token;
 pub mod token_bucket;

--- a/service/src/permission_validation.rs
+++ b/service/src/permission_validation.rs
@@ -49,15 +49,6 @@ pub enum ValidationDeniedKind {
     InsufficientPermission((String, UserPermissions)),
 }
 
-pub fn validation_denied_kind_to_string(kind: ValidationDeniedKind) -> String {
-    match kind {
-        ValidationDeniedKind::NotAuthenticated(msg) => format!("Not authenticated: {}", msg),
-        ValidationDeniedKind::InsufficientPermission((msg, _)) => {
-            format!("Insufficient permission: {}", msg)
-        }
-    }
-}
-
 #[derive(Debug)]
 pub enum ValidationError {
     Denied(ValidationDeniedKind),

--- a/service/src/permission_validation.rs
+++ b/service/src/permission_validation.rs
@@ -1,0 +1,212 @@
+use log::error;
+use repository::{StorageConnection, StorageConnectionManager};
+
+use crate::{
+    auth_data::AuthData,
+    permissions::{ApiRole, PermissionService, UserPermissions},
+    token::{JWTValidationError, OmSupplyClaim, TokenService},
+};
+
+pub struct ValidationUserData {
+    pub user_id: String,
+    pub permissions: UserPermissions,
+}
+
+/// Returns the permission name and an error if validation failed
+pub type PermissionChecker = Box<dyn FnOnce(&ValidationUserData) -> (String, Option<String>)>;
+
+pub fn any(checkers: Vec<PermissionChecker>) -> PermissionChecker {
+    let checker: PermissionChecker = Box::new(|data: &ValidationUserData| {
+        let mut checked_msg = "any of:".to_string();
+        for c in checkers {
+            let (name, error) = c(data);
+            if let None = error {
+                return (name, None);
+            }
+            checked_msg.push_str(&name);
+        }
+        (checked_msg.to_owned(), Some(format!("Not {}", checked_msg)))
+    });
+    checker
+}
+
+pub fn has_api_role(role: ApiRole) -> PermissionChecker {
+    Box::new(move |data: &ValidationUserData| {
+        let name = "api role".to_string();
+        if let Some(_) = data.permissions.api.iter().find(|r| r == &&ApiRole::Admin) {
+            return (name, None);
+        }
+        if let Some(_) = data.permissions.api.iter().find(|r| r == &&role) {
+            return (name, None);
+        }
+        (name, Some("Missing api role".to_string()))
+    })
+}
+
+#[derive(Debug)]
+pub enum ValidationDeniedKind {
+    NotAuthenticated(String),
+    InsufficientPermission((String, UserPermissions)),
+}
+
+pub fn validation_denied_kind_to_string(kind: ValidationDeniedKind) -> String {
+    match kind {
+        ValidationDeniedKind::NotAuthenticated(msg) => format!("Not authenticated: {}", msg),
+        ValidationDeniedKind::InsufficientPermission((msg, _)) => {
+            format!("Insufficient permission: {}", msg)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ValidationError {
+    Denied(ValidationDeniedKind),
+    InternalError(String),
+}
+
+pub struct ValidatedUserAuth {
+    pub user_id: String,
+    pub claims: OmSupplyClaim,
+}
+
+/// Validates user is auth (no permissions checked)
+pub fn validate_auth(
+    auth_data: &AuthData,
+    auth_token: &Option<String>,
+) -> Result<ValidatedUserAuth, ValidationError> {
+    let auth_token = match auth_token {
+        Some(token) => token,
+        None => {
+            return Err(ValidationError::Denied(
+                ValidationDeniedKind::NotAuthenticated("Missing auth token".to_string()),
+            ))
+        }
+    };
+    let service = TokenService::new(
+        &auth_data.token_bucket,
+        auth_data.auth_token_secret.as_bytes(),
+    );
+    let claims = match service.verify_token(auth_token) {
+        Ok(claims) => claims,
+        Err(err) => {
+            let e = match err {
+                JWTValidationError::ExpiredSignature => todo!(),
+                JWTValidationError::NotAnApiToken => ValidationError::Denied(
+                    ValidationDeniedKind::NotAuthenticated("Not an api token".to_string()),
+                ),
+                JWTValidationError::InvalidToken(_) => ValidationError::Denied(
+                    ValidationDeniedKind::NotAuthenticated("Invalid token".to_string()),
+                ),
+                JWTValidationError::TokenInvalided => {
+                    ValidationError::Denied(ValidationDeniedKind::NotAuthenticated(
+                        "Token has been invalided on the server".to_string(),
+                    ))
+                }
+                JWTValidationError::ConcurrencyLockError(_) => {
+                    ValidationError::InternalError("Lock error".to_string())
+                }
+            };
+            return Err(e);
+        }
+    };
+    let user_id = claims.sub.to_owned();
+    return Ok(ValidatedUserAuth { user_id, claims });
+}
+
+pub struct ValidatedUser {
+    pub user_id: String,
+    pub claims: OmSupplyClaim,
+    pub permissions: UserPermissions,
+    /// For convenience the connection that is used to validate the user is passed on for further
+    /// use.
+    pub connection: StorageConnection,
+}
+
+/// Validates user is authenticated and authorized
+pub fn validate(
+    connection_manager: &StorageConnectionManager,
+    auth_data: &AuthData,
+    auth_token: &Option<String>,
+    checkers: Vec<PermissionChecker>,
+) -> Result<ValidatedUser, ValidationError> {
+    let validated_auth = validate_auth(auth_data, auth_token)?;
+
+    // TODO not used yet here but will be needed later for the PermissionService
+    let connection = match connection_manager.connection() {
+        Ok(con) => con,
+        Err(err) => {
+            error!("validate: Failed to get connection: {}", err);
+            return Err(ValidationError::InternalError(
+                "Failed to connect to database".to_string(),
+            ));
+        }
+    };
+    let permission_service = PermissionService::new();
+    let permissions = permission_service.permissions(&validated_auth.user_id);
+    let validation_data = ValidationUserData {
+        user_id: validated_auth.user_id,
+        permissions,
+    };
+    for c in checkers {
+        let (_, error) = c(&validation_data);
+        if let Some(msg) = error {
+            return Err(ValidationError::Denied(
+                ValidationDeniedKind::InsufficientPermission((msg, validation_data.permissions)),
+            ));
+        }
+    }
+
+    Ok(ValidatedUser {
+        user_id: validation_data.user_id,
+        claims: validated_auth.claims,
+        permissions: validation_data.permissions,
+        connection,
+    })
+}
+
+#[cfg(test)]
+mod permission_validation_test {
+    use std::sync::RwLock;
+
+    use super::*;
+    use crate::{auth_data::AuthData, token_bucket::TokenBucket};
+    use repository::{get_storage_connection_manager, test_db};
+
+    #[actix_rt::test]
+    async fn test_basic_permission_validation() {
+        let auth_data = AuthData {
+            auth_token_secret: "some secret".to_string(),
+            token_bucket: RwLock::new(TokenBucket::new()),
+            debug_no_ssl: true,
+        };
+        let user_id = "test_user_id";
+        let mut service = TokenService::new(
+            &auth_data.token_bucket,
+            auth_data.auth_token_secret.as_bytes(),
+        );
+        let token_pair = service.jwt_token(user_id, 60, 120).unwrap();
+
+        let settings =
+            test_db::get_test_db_settings("omsupply-database-basic_permission_validation");
+        test_db::setup(&settings).await;
+        let connection_manager = get_storage_connection_manager(&settings);
+
+        // validate user doesn't has Admin access
+        assert!(validate(
+            &connection_manager,
+            &auth_data,
+            &Some(token_pair.token.to_owned()),
+            vec![has_api_role(ApiRole::Admin)],
+        )
+        .is_err());
+
+        // validate user has User access
+        validate(
+            &connection_manager,
+            &auth_data,
+            &Some(token_pair.token.to_owned()),
+            vec![has_api_role(ApiRole::User)],
+        )
+        .unwrap();
+    }
+}

--- a/service/src/permission_validation.rs
+++ b/service/src/permission_validation.rs
@@ -69,11 +69,29 @@ pub struct ValidatedUserAuth {
     pub claims: OmSupplyClaim,
 }
 
+fn dummy_user_auth() -> ValidatedUserAuth {
+    let user_id = "dummy_user";
+    ValidatedUserAuth {
+        user_id: user_id.to_string(),
+        claims: OmSupplyClaim {
+            exp: 0,
+            aud: crate::token::Audience::Api,
+            iat: 0,
+            iss: "omSupply-debug".to_string(),
+            sub: user_id.to_string(),
+        },
+    }
+}
+
 /// Validates user is auth (no permissions checked)
 pub fn validate_auth(
     auth_data: &AuthData,
     auth_token: &Option<String>,
 ) -> Result<ValidatedUserAuth, ValidationError> {
+    if auth_data.debug_no_access_control {
+        return Ok(dummy_user_auth());
+    }
+
     let auth_token = match auth_token {
         Some(token) => token,
         None => {
@@ -180,6 +198,7 @@ mod permission_validation_test {
             auth_token_secret: "some secret".to_string(),
             token_bucket: RwLock::new(TokenBucket::new()),
             debug_no_ssl: true,
+            debug_no_access_control: false,
         };
         let user_id = "test_user_id";
         let mut service = TokenService::new(

--- a/service/src/permission_validation.rs
+++ b/service/src/permission_validation.rs
@@ -90,7 +90,9 @@ pub fn validate_auth(
         Ok(claims) => claims,
         Err(err) => {
             let e = match err {
-                JWTValidationError::ExpiredSignature => todo!(),
+                JWTValidationError::ExpiredSignature => ValidationError::Denied(
+                    ValidationDeniedKind::NotAuthenticated("Expired signature".to_string()),
+                ),
                 JWTValidationError::NotAnApiToken => ValidationError::Denied(
                     ValidationDeniedKind::NotAuthenticated("Not an api token".to_string()),
                 ),

--- a/service/src/permissions.rs
+++ b/service/src/permissions.rs
@@ -1,0 +1,38 @@
+use std::collections::HashMap;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ApiRole {
+    /// Admin user can use all API endpoints
+    Admin,
+    /// Normal API user
+    User,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum StoreRole {
+    User,
+}
+
+#[derive(Debug)]
+pub struct UserPermissions {
+    pub api: Vec<ApiRole>,
+    /// Store id -> list of roles for this store
+    pub stores: HashMap<String, Vec<StoreRole>>,
+}
+
+pub struct PermissionService {}
+
+impl PermissionService {
+    pub fn new() -> Self {
+        PermissionService {}
+    }
+
+    pub fn permissions(&self, _user_id: &str) -> UserPermissions {
+        // returns some dummy default permissions
+        // TODO read permissions from the DB
+        UserPermissions {
+            api: vec![ApiRole::User],
+            stores: HashMap::new(),
+        }
+    }
+}

--- a/service/src/user_account.rs
+++ b/service/src/user_account.rs
@@ -85,6 +85,11 @@ impl<'a> UserAccountService<'a> {
             )
     }
 
+    pub fn find_user(&self, user_id: &str) -> Result<Option<UserAccount>, RepositoryError> {
+        let repo = UserAccountRepository::new(self.connection);
+        repo.find_one_by_id(user_id)
+    }
+
     /// Finds a user account and verifies that the password is ok
     pub fn verify_password(
         &self,


### PR DESCRIPTION
- Add helper method to validate that a user is authenticated and has the correct permissions.
- Add `me` endpoint that uses the helper method
- Refactor the `logout` endpoint to use the helper
- Add debug flag to disable the authentication check and make the user an Admin user

The permission system is work in progress, happy to discuss. For the validation I use some higher order functions to have something like a permission DSL. For example, a complex permission check could look like:
``` rust
validate(..., vec![
   // ANY required roles to access this endpoint
   any(vec![ 
        has_api_role(ApiRole::Support),
        has_api_role(ApiRole::Plugin)
   ]),
   // AND:
   has_store_access((store_id, StoreRole::StoreWorker)),
   // AND all of the following:
   all(vec![
       some(),
       other(),
       role(),
       checker()
   ])
])
```