### PR TITLE
Add basic plugin implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,6 +2149,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
+name = "libloading"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afe203d669ec979b7128619bae5a63b7b42e9203c1b29146079ee05e2f604b52"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "libnghttp2-sys"
 version = "0.1.7+1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,6 +2738,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
+name = "plugin_api"
+version = "0.1.0"
+
+[[package]]
+name = "plugin_example"
+version = "0.1.0"
+dependencies = [
+ "plugin_api",
+]
+
+[[package]]
 name = "polling"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3242,7 +3263,9 @@ dependencies = [
  "graphql",
  "graphql_client",
  "httpmock",
+ "libloading",
  "log",
+ "plugin_api",
  "repository",
  "reqwest",
  "serde 1.0.130",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,7 @@ members = [
     "server",
     "service",
     "util",
+
+    "plugin_api",
+    "plugin_example",
 ]

--- a/plugin_api/Cargo.toml
+++ b/plugin_api/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "plugin_api"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+path = "src/lib.rs"

--- a/plugin_api/src/lib.rs
+++ b/plugin_api/src/lib.rs
@@ -1,0 +1,75 @@
+use std::{ffi::*, os::raw::c_char};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct TestParameter {
+    pub value: i32,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct TestResponse {
+    pub result: i32,
+    pub result_struct: TestParameter,
+}
+
+pub trait MSupplyPlugin {
+    fn on_load(&self) -> ();
+    fn on_unload(&self) -> ();
+    fn test(&self, value: i32, str: String, complex_params: &TestParameter) -> TestResponse;
+}
+
+pub type CreatePluginFunc = unsafe extern "C" fn() -> *mut dyn MSupplyPlugin;
+pub type DestroyPluginFunc = unsafe extern "C" fn(plugin: *mut c_void) -> ();
+pub type OnLoadFunc = unsafe extern "C" fn(plugin: *mut c_void) -> ();
+pub type OnUnloadFunc = unsafe extern "C" fn(plugin: *mut c_void) -> ();
+pub type TestFunc = unsafe extern "C" fn(
+    plugin: *mut c_void,
+    value: i32,
+    str: *const c_char,
+    complex_params: *const TestParameter,
+) -> TestResponse;
+
+#[macro_export]
+macro_rules! export_plugin {
+    ($PluginType:ty) => {
+        #[no_mangle]
+        pub extern "C" fn create_plugin() -> *mut $PluginType {
+            Box::into_raw(<$PluginType>::new())
+        }
+
+        #[no_mangle]
+        pub extern "C" fn destroy_plugin(plugin: *mut $PluginType) -> () {
+            unsafe {
+                // take ownership and drop it
+                Box::from_raw(plugin);
+            }
+        }
+
+        #[no_mangle]
+        pub extern "C" fn on_load(plugin: *mut $PluginType) -> () {
+            unsafe { plugin.as_ref().unwrap().on_load() }
+        }
+
+        #[no_mangle]
+        pub extern "C" fn on_unload(plugin: *mut $PluginType) -> () {
+            unsafe { plugin.as_ref().unwrap().on_unload() }
+        }
+
+        #[no_mangle]
+        pub extern "C" fn test(
+            plugin: *mut $PluginType,
+            value: i32,
+            string: *const std::os::raw::c_char,
+            complex_params: *const plugin_api::TestParameter,
+        ) -> plugin_api::TestResponse {
+            unsafe {
+                let string = CStr::from_ptr(string).to_str().unwrap().to_owned();
+                plugin
+                    .as_ref()
+                    .unwrap()
+                    .test(value, string, complex_params.as_ref().unwrap())
+            }
+        }
+    };
+}

--- a/plugin_example/Cargo.toml
+++ b/plugin_example/Cargo.toml
@@ -1,0 +1,12 @@
+ 
+[package]
+name = "plugin_example"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+path = "src/lib.rs"
+
+[dependencies]
+plugin_api = { path = "../plugin_api" }

--- a/plugin_example/src/lib.rs
+++ b/plugin_example/src/lib.rs
@@ -1,0 +1,40 @@
+use std::ffi::CStr;
+
+use plugin_api::{export_plugin, MSupplyPlugin};
+
+#[repr(C)]
+pub struct ExamplePlugin {}
+
+impl ExamplePlugin {
+    pub fn new() -> Box<Self> {
+        println!("ExamplePlugin created");
+        Box::new(ExamplePlugin {})
+    }
+}
+
+impl MSupplyPlugin for ExamplePlugin {
+    fn on_load(&self) -> () {
+        println!("ExamplePlugin loaded");
+    }
+
+    fn on_unload(&self) -> () {
+        println!("ExamplePlugin unloaded");
+    }
+
+    fn test(
+        &self,
+        value: i32,
+        string: String,
+        complex_params: &plugin_api::TestParameter,
+    ) -> plugin_api::TestResponse {
+        println!("ExamplePlugin test, message from host: {}", string);
+        return plugin_api::TestResponse {
+            result: value + 5,
+            result_struct: plugin_api::TestParameter {
+                value: complex_params.value + 5,
+            },
+        };
+    }
+}
+
+export_plugin!(ExamplePlugin);

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -19,11 +19,14 @@ repository = { path = "../repository" }
 service = { path = "../service" }
 util = { path = "../util" }
 
+plugin_api = { path = "../plugin_api" }
+
 actix-cors = "0.5.4"
 actix-web = "3.3.2" # Versions >=v4 depend on Tokio v1.
 anyhow = "1.0.44"
 config = "0.11.0"
 env_logger = "0.8.3"
+libloading = "0.7.1"
 log = "0.4.14"
 reqwest = { version = "0.10", features = ["json"] } # Versions >=0.11 depend on Tokio v1.
 serde = "1.0.126"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -2,6 +2,7 @@ pub mod actor_registry;
 pub mod configuration;
 pub mod environment;
 pub mod middleware;
+pub mod plugin_host;
 pub mod settings;
 pub mod sync;
 pub mod test_utils;

--- a/server/src/plugin_host.rs
+++ b/server/src/plugin_host.rs
@@ -1,0 +1,129 @@
+extern crate libloading;
+
+#[cfg(unix)]
+use libloading::os::unix::Symbol as RawSymbol;
+#[cfg(windows)]
+use libloading::os::windows::Symbol as RawSymbol;
+use libloading::Library;
+use log::{error, info};
+use plugin_api::DestroyPluginFunc;
+use plugin_api::{
+    CreatePluginFunc, MSupplyPlugin, OnLoadFunc, OnUnloadFunc, TestFunc, TestParameter,
+    TestResponse,
+};
+use std::ffi::*;
+use std::fs;
+
+pub fn load_plugins() -> anyhow::Result<Vec<PluginHostProxy>> {
+    let mut plugins = Vec::<PluginHostProxy>::new();
+    for item in fs::read_dir("./plugins")? {
+        let entry = match item {
+            Err(_) => continue,
+            Ok(entry) => entry,
+        };
+
+        let plugin = match entry.file_name().to_str() {
+            None => continue,
+            Some(name) => {
+                if !name.ends_with(".so") && !name.ends_with(".dll") {
+                    continue;
+                }
+                info!("Plugin found: {}", name);
+                match load_plugin(name.to_string()) {
+                    Err(e) => {
+                        error!("Failed to load plugin: {}", e);
+                        continue;
+                    }
+                    Ok(plugin) => plugin,
+                }
+            }
+        };
+        plugin.on_load();
+        plugins.push(plugin);
+    }
+    Ok(plugins)
+}
+
+pub struct PluginMethods {
+    pub create: RawSymbol<CreatePluginFunc>,
+    pub destroy: RawSymbol<DestroyPluginFunc>,
+    pub on_load: RawSymbol<OnLoadFunc>,
+    pub on_unload: RawSymbol<OnUnloadFunc>,
+    pub test: RawSymbol<TestFunc>,
+}
+
+impl PluginMethods {
+    unsafe fn load(lib: &Library) -> Result<PluginMethods, libloading::Error> {
+        Ok(PluginMethods {
+            create: lib.get::<CreatePluginFunc>(b"create_plugin")?.into_raw(),
+            destroy: lib.get::<DestroyPluginFunc>(b"destroy_plugin")?.into_raw(),
+            on_load: lib.get::<OnLoadFunc>(b"on_load")?.into_raw(),
+            on_unload: lib.get::<OnUnloadFunc>(b"on_unload")?.into_raw(),
+            test: lib.get::<TestFunc>(b"test")?.into_raw(),
+        })
+    }
+}
+
+/// Delegates calls from the host to the actual implementation
+pub struct PluginHostProxy {
+    _filename: String,
+    _lib: Library,
+    methods: PluginMethods,
+    plugin: *mut dyn MSupplyPlugin,
+}
+
+impl MSupplyPlugin for PluginHostProxy {
+    fn on_load(&self) -> () {
+        unsafe {
+            let func = &self.methods.on_load;
+            func(self.plugin as *mut c_void)
+        }
+    }
+
+    fn on_unload(&self) -> () {
+        unsafe {
+            let func = &self.methods.on_unload;
+            func(self.plugin as *mut c_void);
+        }
+    }
+
+    fn test(&self, value: i32, str: String, complex_params: &TestParameter) -> TestResponse {
+        let str = CString::new(str).unwrap();
+        unsafe {
+            let func = &self.methods.test;
+            func(
+                self.plugin as *mut c_void,
+                value,
+                str.as_ptr(),
+                complex_params,
+            )
+        }
+    }
+}
+
+impl Drop for PluginHostProxy {
+    fn drop(&mut self) {
+        unsafe {
+            self.on_unload();
+
+            let func = &self.methods.destroy;
+            func(self.plugin as *mut c_void);
+        }
+    }
+}
+
+fn load_plugin(filename: String) -> anyhow::Result<PluginHostProxy> {
+    unsafe {
+        let lib = Library::new(&filename)?;
+        let methods = PluginMethods::load(&lib)?;
+        let create_func = &methods.create;
+        let plugin = create_func();
+
+        Ok(PluginHostProxy {
+            _filename: filename,
+            _lib: lib,
+            methods,
+            plugin: plugin,
+        })
+    }
+}


### PR DESCRIPTION
Proof of concept implementation of a very basic plugin.

- the plugin_api crate contains common types and a helper macro to export a new plugin
- the plugin_example crate contains a dummy plugin implementation
- the plugin host (in main for now) loads all .so / .dll files in the `plugins` directory (sym links work as well)

A new plugin can be created by implementing the MSupplyPlugin trait. A plugin instance is create by the host by calling create_plugin (from the plugin .so). A pointer to this plugin instance is cached on the host. When the host makes a plugin call the plugin pointer is passed as a "cookie" to the c api along with other parameters for the call. The macro on the plugin side de-serializes the parameters if needed, e.g. strings, and calls the actual method on the plugin cookie.