### PR TITLE
update M1 doc with multi-platform quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,14 @@ cargo install diesel_cli --no-default-features --features "sqlite-bundled postgr
 
 ```bash
 # postgres
-diesel migration run --database-url="postgres://postgres:password@localhost:5432/omsupply-database" --migration-dir ./repository/migrations/postgres
+diesel migration run --database-url="postgres://[user]:[password]@[localhost]:[port]/[database]" --migration-dir ./repository/migrations/postgres
 
 # sqlite
+diesel migration run --database-url [database file] --migration-dir ./repository/migrations/sqlite
+
+# examples
+diesel migration run --database-url="postgres://postgres:password@localhost:5432/omsupply-database" --migration-dir ./repository/migrations/postgres
+
 diesel migration run --database-url ./omsupply-database.sqlite --migration-dir ./repository/migrations/sqlite
 ```
 

--- a/docs/content/docs/M1/how_to_m1.md
+++ b/docs/content/docs/M1/how_to_m1.md
@@ -33,10 +33,15 @@ Don't need to start sqlite, migration scripts should do that for you, but if you
 
 ```bash
 # postgres
-diesel migration run --database-url='postgres://postgres:password@localhost:5432/omsupply-database' --migration-dir ./migrations/postgres
+diesel migration run --database-url="postgres://[user]:[password]@[localhost]:[port]/[database]" --migration-dir ./repository/migrations/postgres
 
 # sqlite
-diesel migration run --database-url ./omsupply-database.sqlite --migration-dir ./migrations/sqlite/
+diesel migration run --database-url [database file] --migration-dir ./repository/migrations/sqlite
+
+# examples
+diesel migration run --database-url="postgres://postgres:password@localhost:5432/omsupply-database" --migration-dir ./repository/migrations/postgres
+
+diesel migration run --database-url ./omsupply-database.sqlite --migration-dir ./repository/migrations/sqlite
 ```
 
 ##### Configure


### PR DESCRIPTION
Fixes #561 

Scratches an itch.. I've referred to the M1 docs a few times when working on windows and it would be useful to copy and paste. Have taken the change from the main readme across.

Also detailed the parts of the command a little, as it took me a moment to realise what was going on when I first used it, thought that it would be clearer for new users if I broke the command down.