### PR TITLE
Reuse existing tx on default when doing nested con.transaction() calls

### DIFF
--- a/repository/src/db_diesel/central_sync_cursor.rs
+++ b/repository/src/db_diesel/central_sync_cursor.rs
@@ -24,7 +24,6 @@ impl<'a> CentralSyncCursorRepository<'a> {
     pub async fn update_cursor(&self, cursor: u32) -> Result<(), RepositoryError> {
         use crate::schema::diesel_schema::central_sync_cursor::dsl::*;
         let row = CentralSyncCursorRow { id: cursor as i32 };
-        // note: if already in a transaction this creates a safepoint:
         self.connection.connection.transaction(|| {
             diesel::delete(central_sync_cursor).execute(&self.connection.connection)?;
             diesel::insert_into(central_sync_cursor)

--- a/repository/src/db_diesel/storage_connection.rs
+++ b/repository/src/db_diesel/storage_connection.rs
@@ -65,10 +65,8 @@ impl StorageConnection {
     {
         let current_level = self.transaction_level.get();
         if current_level > 0 && reuse_tx {
-            return match f(self).await {
-                Ok(ok) => Ok(ok),
-                Err(err) => Err(TransactionError::Inner(err)),
-            };
+            let result = f(self).await.map_err(|err| TransactionError::Inner(err))?;
+            return Ok(result);
         }
 
         let con = &self.connection;

--- a/repository/src/db_diesel/storage_connection.rs
+++ b/repository/src/db_diesel/storage_connection.rs
@@ -1,3 +1,5 @@
+use std::cell::Cell;
+
 use super::{get_connection, DBBackendConnection, DBConnection};
 
 use crate::repository_error::RepositoryError;
@@ -11,8 +13,16 @@ use futures_util::Future;
 
 pub struct StorageConnection {
     pub connection: DBConnection,
+    /// Current level of nested transaction.
+    /// For example:
+    /// 0 => no transaction
+    /// 1 => in transaction
+    /// 2 => 1st nested transaction
+    /// 3 => 2nd nested transaction
+    pub transaction_level: Cell<i32>,
 }
 
+#[derive(Debug)]
 pub enum TransactionError<E> {
     Transaction {
         msg: String,
@@ -34,11 +44,33 @@ impl From<TransactionError<RepositoryError>> for RepositoryError {
 }
 
 impl StorageConnection {
+    /// Executes operations in transaction. A new transaction is only started if not already in a
+    /// transaction.
     pub async fn transaction<'a, T, E, F, Fut>(&'a self, f: F) -> Result<T, TransactionError<E>>
     where
         F: FnOnce(&'a StorageConnection) -> Fut,
         Fut: Future<Output = Result<T, E>>,
     {
+        self.transaction_etc(f, true).await
+    }
+
+    pub async fn transaction_etc<'a, T, E, F, Fut>(
+        &'a self,
+        f: F,
+        reuse_tx: bool,
+    ) -> Result<T, TransactionError<E>>
+    where
+        F: FnOnce(&'a StorageConnection) -> Fut,
+        Fut: Future<Output = Result<T, E>>,
+    {
+        let current_level = self.transaction_level.get();
+        if current_level > 0 && reuse_tx {
+            return match f(self).await {
+                Ok(ok) => Ok(ok),
+                Err(err) => Err(TransactionError::Inner(err)),
+            };
+        }
+
         let con = &self.connection;
         let transaction_manager = con.transaction_manager();
         transaction_manager
@@ -47,7 +79,11 @@ impl StorageConnection {
                 msg: "Failed to start tx".to_string(),
             })?;
 
-        match f(&self).await {
+        self.transaction_level.set(current_level + 1);
+        let result = f(self).await;
+        self.transaction_level.set(current_level);
+
+        match result {
             Ok(value) => {
                 transaction_manager.commit_transaction(con).map_err(|_| {
                     TransactionError::Transaction {
@@ -67,10 +103,33 @@ impl StorageConnection {
         }
     }
 
+    /// Executes operations in transaction. A new transaction is only started if not already in a
+    /// transaction.
     pub fn transaction_sync<'a, T, E, F>(&'a self, f: F) -> Result<T, TransactionError<E>>
     where
         F: FnOnce(&'a StorageConnection) -> Result<T, E>,
     {
+        self.transaction_sync_etc(f, true)
+    }
+
+    /// # Arguments
+    /// * `reuse_tx` - if true and the connection is currently in a transaction no new nested
+    /// transaction is started.
+    pub fn transaction_sync_etc<'a, T, E, F>(
+        &'a self,
+        f: F,
+        reuse_tx: bool,
+    ) -> Result<T, TransactionError<E>>
+    where
+        F: FnOnce(&'a StorageConnection) -> Result<T, E>,
+    {
+        let current_level = self.transaction_level.get();
+        if current_level > 0 && reuse_tx {
+            return match f(self) {
+                Ok(ok) => Ok(ok),
+                Err(err) => Err(TransactionError::Inner(err)),
+            };
+        }
         let con = &self.connection;
         let transaction_manager = con.transaction_manager();
 
@@ -80,7 +139,11 @@ impl StorageConnection {
                 msg: "Failed to start tx".to_string(),
             })?;
 
-        match f(&self) {
+        self.transaction_level.set(current_level + 1);
+        let result = f(self);
+        self.transaction_level.set(current_level);
+
+        match result {
             Ok(value) => {
                 transaction_manager.commit_transaction(con).map_err(|_| {
                     TransactionError::Transaction {
@@ -114,6 +177,53 @@ impl StorageConnectionManager {
     pub fn connection(&self) -> Result<StorageConnection, RepositoryError> {
         Ok(StorageConnection {
             connection: get_connection(&self.pool)?,
+            transaction_level: Cell::new(0),
         })
+    }
+}
+
+#[cfg(test)]
+mod connection_manager_tests {
+    use crate::{get_storage_connection_manager, test_db, RepositoryError, TransactionError};
+
+    #[actix_rt::test]
+    async fn test_nested_tx() {
+        let settings = test_db::get_test_db_settings("omsupply-nested-tx");
+        let connection_manager = get_storage_connection_manager(&settings);
+        let connection = connection_manager.connection().unwrap();
+
+        assert_eq!(connection.transaction_level.get(), 0);
+        let _result: Result<(), TransactionError<RepositoryError>> = connection
+            .transaction_sync_etc(
+                |con| {
+                    assert_eq!(con.transaction_level.get(), 1);
+                    connection.transaction_sync_etc(
+                        |con| {
+                            assert_eq!(con.transaction_level.get(), 2);
+                            // reuse previous tx
+                            connection.transaction_sync(|con| {
+                                assert_eq!(con.transaction_level.get(), 2);
+                                Ok(())
+                            })?;
+                            Ok(())
+                        },
+                        false,
+                    )?;
+                    Ok(())
+                },
+                false,
+            );
+        assert_eq!(connection.transaction_level.get(), 0);
+
+        // test that new tx is started if there is none but reuse_tx was request
+        let _result: Result<(), TransactionError<RepositoryError>> = connection
+            .transaction_sync_etc(
+                |con| {
+                    assert_eq!(con.transaction_level.get(), 1);
+                    Ok(())
+                },
+                true,
+            );
+        assert_eq!(connection.transaction_level.get(), 0);
     }
 }

--- a/server/src/sync/translation/mod.rs
+++ b/server/src/sync/translation/mod.rs
@@ -202,7 +202,8 @@ async fn store_integration_records(
         for record in &integration_records.upserts {
             // Integrate every record in a sub transaction. This is mainly for Postgres where the
             // whole transaction fails when there is a DB error (not a problem in sqlite).
-            let sub_result = con.transaction_sync(|sub_tx| integrate_record(record, sub_tx));
+            let sub_result =
+                con.transaction_sync_etc(|sub_tx| integrate_record(record, sub_tx), false);
             match sub_result {
                 Ok(_) => Ok(()),
                 Err(TransactionError::Inner(err @ RepositoryError::ForeignKeyViolation(_))) => {


### PR DESCRIPTION
Add transaction_etc method which has the option to enforce a nested
transaction.

This avoids creating unnecessary nested transaction while ensuring that operations are performed in a transaction.