### PR TITLE
619 insert location mutation

### DIFF
--- a/domain/src/location.rs
+++ b/domain/src/location.rs
@@ -12,6 +12,7 @@ pub struct LocationFilter {
     pub id: Option<EqualFilter<String>>,
     pub name: Option<EqualFilter<String>>,
     pub code: Option<EqualFilter<String>>,
+    pub store_id: Option<EqualFilter<String>>,
 }
 
 impl LocationFilter {
@@ -20,6 +21,7 @@ impl LocationFilter {
             id: None,
             name: None,
             code: None,
+            store_id: None,
         }
     }
 
@@ -49,6 +51,24 @@ impl LocationFilter {
 
         self
     }
+
+    pub fn match_code(mut self, code: &str) -> Self {
+        self.code = Some(EqualFilter {
+            equal_to: Some(code.to_owned()),
+            equal_any: None,
+        });
+
+        self
+    }
+
+    pub fn match_store_id(mut self, store_id: &str) -> Self {
+        self.store_id = Some(EqualFilter {
+            equal_to: Some(store_id.to_owned()),
+            equal_any: None,
+        });
+
+        self
+    }
 }
 #[derive(PartialEq, Debug)]
 pub enum LocationSortField {
@@ -57,3 +77,10 @@ pub enum LocationSortField {
 }
 
 pub type LocationSort = Sort<LocationSortField>;
+
+pub struct InsertLocation {
+    pub id: String,
+    pub code: String,
+    pub name: Option<String>,
+    pub on_hold: Option<bool>,
+}

--- a/graphql/src/loader/location.rs
+++ b/graphql/src/loader/location.rs
@@ -18,7 +18,7 @@ impl Loader<String> for LocationByIdLoader {
         let connection = self.connection_manager.connection()?;
         let repo = LocationRepository::new(&connection);
 
-        let result = repo.query_filter_only(LocationFilter::new().match_ids(ids.to_owned()))?;
+        let result = repo.query_by_filter(LocationFilter::new().match_ids(ids.to_owned()))?;
 
         Ok(result
             .into_iter()

--- a/graphql/src/schema/mutations/location/insert.rs
+++ b/graphql/src/schema/mutations/location/insert.rs
@@ -1,0 +1,78 @@
+use async_graphql::*;
+use domain::location::InsertLocation;
+use repository::RepositoryError;
+use service::location::insert::InsertLocationError;
+
+use crate::schema::{
+    mutations::{error::DatabaseError, RecordAlreadyExist, UniqueValueKey, UniqueValueViolation},
+    types::{ErrorWrapper, InternalError, LocationNode},
+};
+
+#[derive(InputObject)]
+pub struct InsertLocationInput {
+    pub id: String,
+    pub code: String,
+    pub name: Option<String>,
+    pub on_hold: Option<bool>,
+}
+
+impl From<InsertLocationInput> for InsertLocation {
+    fn from(
+        InsertLocationInput {
+            id,
+            code,
+            name,
+            on_hold,
+        }: InsertLocationInput,
+    ) -> Self {
+        InsertLocation {
+            id,
+            code,
+            name,
+            on_hold,
+        }
+    }
+}
+
+#[derive(Union)]
+pub enum InsertLocationResponse {
+    Error(ErrorWrapper<InsertLocationErrorInterface>),
+    Response(LocationNode),
+}
+
+#[derive(Interface)]
+#[graphql(field(name = "description", type = "String"))]
+pub enum InsertLocationErrorInterface {
+    LocationAlreadyExists(RecordAlreadyExist),
+    UniqueValueViolation(UniqueValueViolation),
+    InternalError(InternalError),
+    DatabaseError(DatabaseError),
+}
+
+impl From<RepositoryError> for ErrorWrapper<InsertLocationErrorInterface> {
+    fn from(error: RepositoryError) -> Self {
+        let error = InsertLocationErrorInterface::DatabaseError(DatabaseError(error));
+        ErrorWrapper { error }
+    }
+}
+
+impl From<InsertLocationError> for ErrorWrapper<InsertLocationErrorInterface> {
+    fn from(error: InsertLocationError) -> Self {
+        use InsertLocationErrorInterface as OutError;
+        let error = match error {
+            InsertLocationError::LocationAlreadyExists => {
+                OutError::LocationAlreadyExists(RecordAlreadyExist {})
+            }
+            InsertLocationError::LocationWithCodeAlreadyExists => {
+                OutError::UniqueValueViolation(UniqueValueViolation(UniqueValueKey::Code))
+            }
+            InsertLocationError::CreatedRecordDoesNotExist => OutError::InternalError(
+                InternalError("Could not find record after creation".to_owned()),
+            ),
+            InsertLocationError::DatabaseError(error) => {
+                OutError::DatabaseError(DatabaseError(error))
+            }
+        };
+        ErrorWrapper { error }
+    }
+}

--- a/graphql/src/schema/mutations/location/mod.rs
+++ b/graphql/src/schema/mutations/location/mod.rs
@@ -1,0 +1,3 @@
+mod insert;
+
+pub use insert::*;

--- a/graphql/src/schema/mutations/mod.rs
+++ b/graphql/src/schema/mutations/mod.rs
@@ -32,12 +32,15 @@ impl Mutations {
         input: InsertLocationInput,
     ) -> InsertLocationResponse {
         let service_provider = ctx.service_provider();
-        let insert_location_service = match service_provider.insert_location() {
+        let service_context = match service_provider.context() {
             Ok(service) => service,
             Err(error) => return InsertLocationResponse::Error(error.into()),
         };
 
-        match insert_location_service.insert_location(input.into()) {
+        match service_provider
+            .insert_location_service
+            .insert_location(input.into(), &service_context)
+        {
             Ok(location) => InsertLocationResponse::Response(location.into()),
             Err(error) => InsertLocationResponse::Error(error.into()),
         }

--- a/graphql/src/schema/mutations/mod.rs
+++ b/graphql/src/schema/mutations/mod.rs
@@ -1,8 +1,11 @@
 mod error;
 
 pub mod inbound_shipment;
+pub mod location;
 pub mod outbound_shipment;
 pub mod user_register;
+
+use self::location::{InsertLocationInput, InsertLocationResponse};
 
 use super::types::{get_invoice_response, Connector, InvoiceLineNode, InvoiceResponse};
 use crate::ContextExt;
@@ -21,6 +24,23 @@ impl Mutations {
         input: UserRegisterInput,
     ) -> UserRegisterResponse {
         user_register(ctx, input)
+    }
+
+    async fn insert_location(
+        &self,
+        ctx: &Context<'_>,
+        input: InsertLocationInput,
+    ) -> InsertLocationResponse {
+        let service_provider = ctx.service_provider();
+        let insert_location_service = match service_provider.insert_location() {
+            Ok(service) => service,
+            Err(error) => return InsertLocationResponse::Error(error.into()),
+        };
+
+        match insert_location_service.insert_location(input.into()) {
+            Ok(location) => InsertLocationResponse::Response(location.into()),
+            Err(error) => InsertLocationResponse::Error(error.into()),
+        }
     }
 
     async fn insert_outbound_shipment(
@@ -197,6 +217,24 @@ impl ForeignKeyError {
     }
 
     pub async fn key(&self) -> ForeignKey {
+        self.0
+    }
+}
+
+#[derive(Enum, Copy, Clone, PartialEq, Eq)]
+#[graphql(rename_items = "camelCase")]
+pub enum UniqueValueKey {
+    Code,
+}
+
+pub struct UniqueValueViolation(UniqueValueKey);
+#[Object]
+impl UniqueValueViolation {
+    pub async fn description(&self) -> &'static str {
+        "Field needs to be unique"
+    }
+
+    pub async fn field(&self) -> UniqueValueKey {
         self.0
     }
 }

--- a/graphql/src/schema/types/location.rs
+++ b/graphql/src/schema/types/location.rs
@@ -33,6 +33,7 @@ impl From<LocationFilterInput> for LocationFilter {
             name: f.name.map(EqualFilter::from),
             code: f.code.map(EqualFilter::from),
             id: f.id.map(EqualFilter::from),
+            store_id: None,
         }
     }
 }

--- a/graphql/src/schema/types/mod.rs
+++ b/graphql/src/schema/types/mod.rs
@@ -34,7 +34,7 @@ pub use self::invoice_line::*;
 pub mod sort_filter_types;
 pub use self::sort_filter_types::*;
 
-use super::mutations::{inbound_shipment::*, outbound_shipment::*};
+use super::mutations::{inbound_shipment::*, location::*, outbound_shipment::*};
 
 /// Generic Connector
 #[derive(SimpleObject)]
@@ -149,6 +149,7 @@ impl From<PaginationInput> for PaginationOption {
     name = "DeleteOutboundShipmentLineError",
     params(DeleteOutboundShipmentLineErrorInterface)
 ))]
+#[graphql(concrete(name = "InsertLocationError", params(InsertLocationErrorInterface)))]
 #[graphql(concrete(name = "UserRegisterError", params(UserRegisterErrorInterface)))]
 #[graphql(concrete(name = "AuthTokenError", params(AuthTokenErrorInterface)))]
 #[graphql(concrete(name = "RefreshTokenError", params(RefreshTokenErrorInterface)))]

--- a/repository/src/db_diesel/location.rs
+++ b/repository/src/db_diesel/location.rs
@@ -80,7 +80,7 @@ impl<'a> LocationRepository<'a> {
         Ok(query.count().get_result(&self.connection.connection)?)
     }
 
-    pub fn query_filter_only(
+    pub fn query_by_filter(
         &self,
         filter: LocationFilter,
     ) -> Result<Vec<Location>, RepositoryError> {
@@ -127,6 +127,7 @@ fn create_filtered_query(filter: Option<LocationFilter>) -> BoxedLocationQuery {
         apply_equal_filter!(query, filter.id, location_dsl::id);
         apply_equal_filter!(query, filter.name, location_dsl::name);
         apply_equal_filter!(query, filter.code, location_dsl::code);
+        apply_equal_filter!(query, filter.store_id, location_dsl::store_id);
     }
 
     query

--- a/repository/src/db_diesel/storage_connection.rs
+++ b/repository/src/db_diesel/storage_connection.rs
@@ -21,6 +21,22 @@ pub enum TransactionError<E> {
     Inner(E),
 }
 
+impl<E> TransactionError<E> {
+    pub fn convert(self) -> E
+    where
+        E: From<RepositoryError>,
+    {
+        match self {
+            TransactionError::Transaction { msg } => RepositoryError::DBError {
+                msg,
+                extra: "".to_string(),
+            }
+            .into(),
+            TransactionError::Inner(e) => e,
+        }
+    }
+}
+
 impl From<TransactionError<RepositoryError>> for RepositoryError {
     fn from(error: TransactionError<RepositoryError>) -> Self {
         match error {

--- a/repository/src/mock/location.rs
+++ b/repository/src/mock/location.rs
@@ -24,5 +24,13 @@ pub fn mock_locations() -> Vec<LocationRow> {
             on_hold: false,
             store_id: "store_a".to_string(),
         },
+        // Location in another store, for unique code check
+        LocationRow {
+            id: "location_in_another_store".to_owned(),
+            code: "store_b_location".to_owned(),
+            name: "store_b_location_name".to_owned(),
+            on_hold: false,
+            store_id: "store_b".to_string(),
+        },
     ]
 }

--- a/server/tests/graphql/location_insert.rs
+++ b/server/tests/graphql/location_insert.rs
@@ -1,0 +1,213 @@
+mod graphql {
+    use crate::graphql::{assert_gql_query, ServiceOverride};
+    use domain::location::{InsertLocation, Location};
+    use repository::mock::MockDataInserts;
+    use serde_json::json;
+    use server::test_utils::setup_all;
+    use service::location::insert::{InsertLocationError, InsertLocationServiceTrait};
+
+    type InsertLocationMethod =
+        dyn Fn(InsertLocation) -> Result<Location, InsertLocationError> + Sync + Send;
+
+    struct TestService(pub Box<InsertLocationMethod>);
+
+    impl InsertLocationServiceTrait for TestService {
+        fn insert_location(&self, input: InsertLocation) -> Result<Location, InsertLocationError> {
+            (self.0)(input)
+        }
+    }
+
+    macro_rules! service_override {
+        ($closure:expr) => {{
+            ServiceOverride::new()
+                .set_insert_location_service(Box::new(|| Box::new(TestService(Box::new($closure)))))
+        }};
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_insert_location_errors() {
+        let (_, _, settings) = setup_all(
+            "test_graphql_insert_location_errors",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($input: InsertLocationInput!) {
+            insertLocation(input: $input) {
+              ... on InsertLocationError {
+                error {
+                  __typename
+                }
+              }
+            }
+          }
+        "#;
+
+        let variables = Some(json!({
+          "input": {
+            "id": "n/a",
+            "code": "n/a",
+            "name": "n/a",
+          }
+        }));
+
+        // Record Already Exists
+        let service_override =
+            service_override!(|_| Err(InsertLocationError::LocationAlreadyExists));
+
+        let expected = json!({
+            "insertLocation": {
+              "error": {
+                "__typename": "RecordAlreadyExist"
+              }
+            }
+          }
+        );
+
+        assert_gql_query(
+            &settings,
+            mutation,
+            &variables,
+            &expected,
+            Some(service_override),
+        )
+        .await;
+
+        // Unique code violation
+        let mutation = r#"
+              mutation ($input: InsertLocationInput!) {
+                  insertLocation(input: $input) {
+                    ... on InsertLocationError {
+                      error {
+                        ... on UniqueValueViolation {
+                            __typename
+                            field
+                        }
+                      }
+                    }
+                  }
+                }
+              "#;
+
+        let service_override =
+            service_override!(|_| Err(InsertLocationError::LocationWithCodeAlreadyExists));
+
+        let expected = json!({
+            "insertLocation": {
+              "error": {
+                "__typename": "UniqueValueViolation",
+                "field": "code"
+              }
+            }
+          }
+        );
+
+        assert_gql_query(
+            &settings,
+            mutation,
+            &variables,
+            &expected,
+            Some(service_override),
+        )
+        .await;
+
+        // Created record does not exists (this shouldn't happen, but want to test internal error)
+        let mutation = r#"
+         mutation ($input: InsertLocationInput!) {
+             insertLocation(input: $input) {
+               ... on InsertLocationError {
+                 error {
+                   ... on InternalError {
+                       __typename
+                       description
+                       fullError
+                   }
+                 }
+               }
+             }
+           }
+         "#;
+
+        let service_override =
+            service_override!(|_| Err(InsertLocationError::CreatedRecordDoesNotExist));
+
+        let expected = json!({
+            "insertLocation": {
+              "error": {
+                "__typename": "InternalError",
+                "description": "Internal Error",
+                "fullError": "Internal Error: Could not find record after creation"
+              }
+            }
+          }
+        );
+
+        assert_gql_query(
+            &settings,
+            mutation,
+            &variables,
+            &expected,
+            Some(service_override),
+        )
+        .await;
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_insert_location_success() {
+        let (_, _, settings) = setup_all(
+            "test_graphql_insert_location_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($input: InsertLocationInput!) {
+            insertLocation(input: $input) {
+              ... on LocationNode {
+                id
+                code
+                name
+                onHold
+              }
+            }
+          }
+        "#;
+
+        let variables = Some(json!({
+          "input": {
+            "id": "n/a",
+            "code": "n/a",
+            "name": "n/a",
+          }
+        }));
+
+        // Record Already Exists
+        let service_override = service_override!(|_| Ok(Location {
+            id: "id".to_owned(),
+            name: "name".to_owned(),
+            code: "code".to_owned(),
+            on_hold: true
+        }));
+
+        let expected = json!({
+            "insertLocation": {
+                "id": "id",
+                "name": "name",
+                "code": "code",
+                "onHold": true
+
+            }
+          }
+        );
+
+        assert_gql_query(
+            &settings,
+            mutation,
+            &variables,
+            &expected,
+            Some(service_override),
+        )
+        .await;
+    }
+}

--- a/server/tests/graphql/mod.rs
+++ b/server/tests/graphql/mod.rs
@@ -24,6 +24,7 @@ mod inbound_shipment_update;
 mod invoice_query;
 mod invoices;
 mod items;
+mod location_insert;
 mod locations;
 mod names;
 mod outbound_shipment_delete;

--- a/service/src/invoice/inbound_shipment/insert/mod.rs
+++ b/service/src/invoice/inbound_shipment/insert/mod.rs
@@ -18,7 +18,7 @@ pub fn insert_inbound_shipment(
     let new_invoice = connection
         .transaction_sync(|connection| {
             validate(&input, &connection)?;
-            let new_invoice = generate(input, &connection)?;
+            let new_invoice = generate(input);
             InvoiceRepository::new(&connection).upsert_one(&new_invoice)?;
             Ok(new_invoice)
         })

--- a/service/src/invoice/inbound_shipment/mod.rs
+++ b/service/src/invoice/inbound_shipment/mod.rs
@@ -2,9 +2,7 @@ use domain::{
     name::{Name, NameFilter},
     Pagination,
 };
-use repository::{
-    NameQueryRepository, RepositoryError, StorageConnection, StoreRepository,
-};
+use repository::{NameQueryRepository, RepositoryError, StorageConnection};
 
 pub mod insert;
 pub use self::insert::*;
@@ -14,11 +12,6 @@ pub use self::update::*;
 
 pub mod delete;
 pub use self::delete::*;
-
-pub fn current_store_id(connection: &StorageConnection) -> Result<String, RepositoryError> {
-    // Need to check session for store
-    Ok(StoreRepository::new(connection).all()?[0].id.clone())
-}
 
 pub enum OtherPartyError {
     NotASupplier(Name),

--- a/service/src/invoice/inbound_shipment/update/generate.rs
+++ b/service/src/invoice/inbound_shipment/update/generate.rs
@@ -1,12 +1,13 @@
 use chrono::Utc;
 
-use crate::invoice::current_store_id;
 use domain::{inbound_shipment::UpdateInboundShipment, invoice::InvoiceStatus};
 use repository::{
     schema::{InvoiceLineRow, InvoiceRow, InvoiceRowStatus, StockLineRow},
     InvoiceLineRowRepository, StorageConnection,
 };
 use util::uuid::uuid;
+
+use crate::current_store_id;
 
 use super::UpdateInboundShipmentError;
 
@@ -109,7 +110,7 @@ pub fn generate_lines_and_stock_lines(
         let stock_line = StockLineRow {
             id: stock_line_id,
             item_id,
-            store_id: current_store_id(connection)?,
+            store_id: current_store_id(),
             location_id,
             batch,
             pack_size,

--- a/service/src/invoice/outbound_shipment/insert/generate.rs
+++ b/service/src/invoice/outbound_shipment/insert/generate.rs
@@ -4,33 +4,28 @@ use domain::{
     invoice::{InvoiceStatus, InvoiceType},
     outbound_shipment::InsertOutboundShipment,
 };
-use repository::{schema::InvoiceRow, RepositoryError, StorageConnection, StoreRepository};
+use repository::schema::InvoiceRow;
 
-use super::InsertOutboundShipmentError;
+use crate::current_store_id;
 
-pub fn generate(
-    input: InsertOutboundShipment,
-    connection: &StorageConnection,
-) -> Result<InvoiceRow, InsertOutboundShipmentError> {
+pub fn generate(input: InsertOutboundShipment) -> InvoiceRow {
     let current_datetime = Utc::now().naive_utc();
 
-    let result = InvoiceRow {
+    InvoiceRow {
         id: input.id,
         name_id: input.other_party_id,
         r#type: InvoiceType::OutboundShipment.into(),
         comment: input.comment,
         their_reference: input.their_reference,
         invoice_number: new_invoice_number(),
-        store_id: current_store_id(connection)?,
+        store_id: current_store_id(),
         confirm_datetime: confirm_datetime(&input.status, &current_datetime),
         finalised_datetime: finalised_datetime(&input.status, &current_datetime),
         status: input.status.into(),
         on_hold: input.on_hold.unwrap_or(false),
         entry_datetime: current_datetime,
         color: input.color,
-    };
-
-    Ok(result)
+    }
 }
 
 fn new_invoice_number() -> i32 {
@@ -53,9 +48,4 @@ fn finalised_datetime(
         InvoiceStatus::Finalised => None,
         _ => Some(current_time.clone()),
     }
-}
-
-pub fn current_store_id(connection: &StorageConnection) -> Result<String, RepositoryError> {
-    // Need to check session for store
-    Ok(StoreRepository::new(connection).all()?[0].id.clone())
 }

--- a/service/src/invoice/outbound_shipment/insert/mod.rs
+++ b/service/src/invoice/outbound_shipment/insert/mod.rs
@@ -1,7 +1,5 @@
 use domain::{name::Name, outbound_shipment::InsertOutboundShipment};
-use repository::{
-    InvoiceRepository, RepositoryError, StorageConnectionManager, TransactionError,
-};
+use repository::{InvoiceRepository, RepositoryError, StorageConnectionManager, TransactionError};
 
 pub mod generate;
 pub mod validate;
@@ -46,7 +44,7 @@ pub fn insert_outbound_shipment(
 
     let new_invoice_id = connection.transaction_sync(|connection| {
         validate(&input, &connection)?;
-        let new_invoice = generate(input, &connection)?;
+        let new_invoice = generate(input);
         InvoiceRepository::new(&connection).upsert_one(&new_invoice)?;
 
         Ok(new_invoice.id)

--- a/service/src/invoice_line/inbound_shipment_line/generate.rs
+++ b/service/src/invoice_line/inbound_shipment_line/generate.rs
@@ -1,10 +1,7 @@
-use repository::{
-    schema::{InvoiceLineRow, StockLineRow},
-    RepositoryError, StorageConnection,
-};
+use repository::schema::{InvoiceLineRow, StockLineRow};
 use util::uuid::uuid;
 
-use crate::invoice::current_store_id;
+use crate::current_store_id;
 
 pub fn generate_batch(
     InvoiceLineRow {
@@ -21,18 +18,17 @@ pub fn generate_batch(
         ..
     }: InvoiceLineRow,
     keep_existing_batch: bool,
-    connection: &StorageConnection,
-) -> Result<StockLineRow, RepositoryError> {
+) -> StockLineRow {
     // Generate new id if requested via parameter or if stock_line_id is not already set on line
     let stock_line_id = match (stock_line_id, keep_existing_batch) {
         (Some(stock_line_id), true) => stock_line_id,
         _ => uuid(),
     };
 
-    let batch = StockLineRow {
+    StockLineRow {
         id: stock_line_id,
         item_id,
-        store_id: current_store_id(connection)?,
+        store_id: current_store_id(),
         location_id,
         batch,
         pack_size,
@@ -43,7 +39,5 @@ pub fn generate_batch(
         expiry_date,
         on_hold: false,
         note,
-    };
-
-    Ok(batch)
+    }
 }

--- a/service/src/invoice_line/inbound_shipment_line/insert/generate.rs
+++ b/service/src/invoice_line/inbound_shipment_line/insert/generate.rs
@@ -1,9 +1,6 @@
 use crate::{invoice_line::generate_batch, u32_to_i32};
 use domain::inbound_shipment::InsertInboundShipmentLine;
-use repository::{
-    schema::{InvoiceLineRow, InvoiceRow, InvoiceRowStatus, ItemRow, StockLineRow},
-    StorageConnection,
-};
+use repository::schema::{InvoiceLineRow, InvoiceRow, InvoiceRowStatus, ItemRow, StockLineRow};
 
 use super::InsertInboundShipmentLineError;
 
@@ -11,12 +8,11 @@ pub fn generate(
     input: InsertInboundShipmentLine,
     item_row: ItemRow,
     InvoiceRow { status, .. }: InvoiceRow,
-    connection: &StorageConnection,
 ) -> Result<(InvoiceLineRow, Option<StockLineRow>), InsertInboundShipmentLineError> {
     let mut new_line = generate_line(input, item_row);
 
     let new_batch_option = if status != InvoiceRowStatus::Draft {
-        let new_batch = generate_batch(new_line.clone(), false, connection)?;
+        let new_batch = generate_batch(new_line.clone(), false);
         new_line.stock_line_id = Some(new_batch.id.clone());
         Some(new_batch)
     } else {

--- a/service/src/invoice_line/inbound_shipment_line/insert/mod.rs
+++ b/service/src/invoice_line/inbound_shipment_line/insert/mod.rs
@@ -19,7 +19,7 @@ pub fn insert_inbound_shipment_line(
     let new_line = connection
         .transaction_sync(|connection| {
             let (item, invoice) = validate(&input, &connection)?;
-            let (new_line, new_batch_option) = generate(input, item, invoice, &connection)?;
+            let (new_line, new_batch_option) = generate(input, item, invoice)?;
 
             if let Some(new_batch) = new_batch_option {
                 StockLineRowRepository::new(&connection).upsert_one(&new_batch)?;

--- a/service/src/invoice_line/inbound_shipment_line/update/generate.rs
+++ b/service/src/invoice_line/inbound_shipment_line/update/generate.rs
@@ -1,9 +1,6 @@
 use crate::{invoice_line::inbound_shipment_line::generate_batch, u32_to_i32};
 use domain::inbound_shipment::UpdateInboundShipmentLine;
-use repository::{
-    schema::{InvoiceLineRow, InvoiceRow, InvoiceRowStatus, ItemRow, StockLineRow},
-    StorageConnection,
-};
+use repository::schema::{InvoiceLineRow, InvoiceRow, InvoiceRowStatus, ItemRow, StockLineRow};
 
 use super::UpdateInboundShipmentLineError;
 
@@ -12,7 +9,6 @@ pub fn generate(
     current_line: InvoiceLineRow,
     new_item_option: Option<ItemRow>,
     InvoiceRow { status, .. }: InvoiceRow,
-    connection: &StorageConnection,
 ) -> Result<(InvoiceLineRow, Option<StockLineRow>, Option<String>), UpdateInboundShipmentLineError>
 {
     let batch_to_delete_id = get_batch_to_delete_id(&current_line, &new_item_option);
@@ -20,11 +16,7 @@ pub fn generate(
     let mut update_line = generate_line(input, current_line, new_item_option);
 
     let upsert_batch_option = if status != InvoiceRowStatus::Draft {
-        let new_batch = generate_batch(
-            update_line.clone(),
-            batch_to_delete_id.is_none(),
-            connection,
-        )?;
+        let new_batch = generate_batch(update_line.clone(), batch_to_delete_id.is_none());
         update_line.stock_line_id = Some(new_batch.id.clone());
         Some(new_batch)
     } else {

--- a/service/src/invoice_line/inbound_shipment_line/update/mod.rs
+++ b/service/src/invoice_line/inbound_shipment_line/update/mod.rs
@@ -21,7 +21,7 @@ pub fn update_inbound_shipment_line(
             let (line, item, invoice) = validate(&input, &connection)?;
 
             let (updated_line, upsert_batch_option, delete_batch_id_option) =
-                generate(input, line, item, invoice, &connection)?;
+                generate(input, line, item, invoice)?;
 
             let stock_line_respository = StockLineRowRepository::new(&connection);
 

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -58,6 +58,12 @@ impl<T> WithDBError<T> {
     }
 }
 
+impl<T> From<RepositoryError> for WithDBError<T> {
+    fn from(error: RepositoryError) -> Self {
+        WithDBError::DatabaseError(error)
+    }
+}
+
 impl From<RepositoryError> for ListError {
     fn from(error: RepositoryError) -> Self {
         ListError::DatabaseError(error)
@@ -114,4 +120,9 @@ pub fn usize_to_u32(num: usize) -> u32 {
 
 pub fn u32_to_i32(num: u32) -> i32 {
     num.try_into().unwrap_or(0)
+}
+
+// TODO from session
+pub fn current_store_id() -> String {
+    "store_a".to_owned()
 }

--- a/service/src/location/insert/generate.rs
+++ b/service/src/location/insert/generate.rs
@@ -1,0 +1,21 @@
+use domain::location::InsertLocation;
+use repository::schema::LocationRow;
+
+use crate::current_store_id;
+
+pub fn generate(
+    InsertLocation {
+        id,
+        code,
+        name,
+        on_hold,
+    }: InsertLocation,
+) -> LocationRow {
+    LocationRow {
+        id,
+        name: name.unwrap_or(code.clone()),
+        code,
+        on_hold: on_hold.unwrap_or(false),
+        store_id: current_store_id(),
+    }
+}

--- a/service/src/location/insert/mod.rs
+++ b/service/src/location/insert/mod.rs
@@ -1,0 +1,71 @@
+mod generate;
+mod validate;
+
+use domain::location::{InsertLocation, Location};
+use generate::generate;
+use repository::{LocationRowRepository, RepositoryError};
+use validate::validate;
+
+use crate::{service_provider::ServiceConnection, SingleRecordError, WithDBError};
+
+use super::{LocationQueryService, LocationQueryServiceTrait};
+
+pub trait InsertLocationServiceTrait {
+    fn insert_location(&self, input: InsertLocation) -> Result<Location, InsertLocationError>;
+}
+
+pub struct InsertLocationService<'a>(pub ServiceConnection<'a>);
+
+impl<'a> InsertLocationServiceTrait for InsertLocationService<'a> {
+    fn insert_location(&self, input: InsertLocation) -> Result<Location, InsertLocationError> {
+        let location = self.0.transaction(|connection| {
+            validate(&input, &connection)?;
+            let new_location = generate(input);
+            LocationRowRepository::new(&connection).upsert_one(&new_location)?;
+
+            LocationQueryService(connection.duplicate())
+                .get_location(new_location.id)
+                .map_err(InsertLocationError::from)
+        })?;
+        Ok(location)
+    }
+}
+
+#[derive(PartialEq, Debug)]
+pub enum InsertLocationError {
+    LocationAlreadyExists,
+    LocationWithCodeAlreadyExists,
+    CreatedRecordDoesNotExist,
+    DatabaseError(RepositoryError),
+}
+
+impl From<RepositoryError> for InsertLocationError {
+    fn from(error: RepositoryError) -> Self {
+        InsertLocationError::DatabaseError(error)
+    }
+}
+
+impl From<SingleRecordError> for InsertLocationError {
+    fn from(error: SingleRecordError) -> Self {
+        use InsertLocationError::*;
+        match error {
+            SingleRecordError::DatabaseError(error) => DatabaseError(error),
+            SingleRecordError::NotFound(_) => CreatedRecordDoesNotExist,
+        }
+    }
+}
+
+impl<E> From<WithDBError<E>> for InsertLocationError
+where
+    E: Into<InsertLocationError>,
+{
+    fn from(result: WithDBError<E>) -> Self {
+        match result {
+            WithDBError::DatabaseError(error) => error.into(),
+            WithDBError::Error(error) => error.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/service/src/location/insert/tests.rs
+++ b/service/src/location/insert/tests.rs
@@ -1,0 +1,105 @@
+#[cfg(test)]
+mod query {
+    use domain::location::{InsertLocation, Location, LocationFilter};
+    use repository::{mock::MockDataInserts, test_db::setup_all, LocationRepository};
+
+    use crate::{
+        current_store_id,
+        location::insert::{
+            InsertLocationError, InsertLocationService, InsertLocationServiceTrait,
+        },
+        service_provider::ServiceConnection,
+    };
+
+    #[actix_rt::test]
+    async fn insert_location_service_errors() {
+        let (mock_data, _, connection_manager, _) =
+            setup_all("insert_location_service_errors", MockDataInserts::all()).await;
+
+        let connection = connection_manager.connection().unwrap();
+        let location_repository = LocationRepository::new(&connection);
+        let service = InsertLocationService(ServiceConnection::Connection(
+            connection_manager.connection().unwrap(),
+        ));
+
+        let locations_in_store = location_repository
+            .query_by_filter(LocationFilter::new().match_store_id(&current_store_id()))
+            .unwrap();
+
+        assert_eq!(
+            service.insert_location(InsertLocation {
+                id: mock_data.locations[0].id.clone(),
+                code: "invalid".to_owned(),
+                name: None,
+                on_hold: None
+            }),
+            Err(InsertLocationError::LocationAlreadyExists)
+        );
+
+        assert_eq!(
+            service.insert_location(InsertLocation {
+                id: "new_id".to_owned(),
+                code: locations_in_store[0].code.clone(),
+                name: None,
+                on_hold: None
+            }),
+            Err(InsertLocationError::LocationWithCodeAlreadyExists)
+        );
+    }
+
+    #[actix_rt::test]
+    async fn insert_location_service_success() {
+        let (_, _, connection_manager, _) =
+            setup_all("insert_location_service_success", MockDataInserts::all()).await;
+
+        let connection = connection_manager.connection().unwrap();
+        let location_repository = LocationRepository::new(&connection);
+        let service = InsertLocationService(ServiceConnection::Connection(
+            connection_manager.connection().unwrap(),
+        ));
+
+        let result_location = Location {
+            id: "new_id".to_owned(),
+            name: "new_code".to_owned(),
+            code: "new_code".to_owned(),
+            on_hold: false,
+        };
+
+        assert_eq!(
+            service.insert_location(InsertLocation {
+                id: "new_id".to_owned(),
+                code: "new_code".to_owned(),
+                name: None,
+                on_hold: None
+            }),
+            Ok(result_location.clone())
+        );
+
+        assert_eq!(
+            location_repository
+                .query_by_filter(
+                    LocationFilter::new()
+                        .match_id("new_id")
+                        .match_store_id(&current_store_id())
+                )
+                .unwrap(),
+            vec![result_location]
+        );
+
+        // Insert location with code that appears in location in another store
+        assert_eq!(
+            service.insert_location(InsertLocation {
+                id: "new_id2".to_owned(),
+                code: "store_b_location_code".to_owned(),
+                name: Some("new_location_name".to_owned()),
+                on_hold: Some(true)
+            }),
+            Ok(Location {
+                id: "new_id2".to_owned(),
+                name: "new_location_name".to_owned(),
+                code: "store_b_location_code".to_owned(),
+                on_hold: true
+            })
+        );
+    }
+}

--- a/service/src/location/insert/tests.rs
+++ b/service/src/location/insert/tests.rs
@@ -4,11 +4,7 @@ mod query {
     use repository::{mock::MockDataInserts, test_db::setup_all, LocationRepository};
 
     use crate::{
-        current_store_id,
-        location::insert::{
-            InsertLocationError, InsertLocationService, InsertLocationServiceTrait,
-        },
-        service_provider::ServiceConnection,
+        current_store_id, location::insert::InsertLocationError, service_provider::ServiceProvider,
     };
 
     #[actix_rt::test]
@@ -18,31 +14,37 @@ mod query {
 
         let connection = connection_manager.connection().unwrap();
         let location_repository = LocationRepository::new(&connection);
-        let service = InsertLocationService(ServiceConnection::Connection(
-            connection_manager.connection().unwrap(),
-        ));
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider.context().unwrap();
+        let service = service_provider.insert_location_service;
 
         let locations_in_store = location_repository
             .query_by_filter(LocationFilter::new().match_store_id(&current_store_id()))
             .unwrap();
 
         assert_eq!(
-            service.insert_location(InsertLocation {
-                id: mock_data.locations[0].id.clone(),
-                code: "invalid".to_owned(),
-                name: None,
-                on_hold: None
-            }),
+            service.insert_location(
+                InsertLocation {
+                    id: mock_data.locations[0].id.clone(),
+                    code: "invalid".to_owned(),
+                    name: None,
+                    on_hold: None
+                },
+                &context
+            ),
             Err(InsertLocationError::LocationAlreadyExists)
         );
 
         assert_eq!(
-            service.insert_location(InsertLocation {
-                id: "new_id".to_owned(),
-                code: locations_in_store[0].code.clone(),
-                name: None,
-                on_hold: None
-            }),
+            service.insert_location(
+                InsertLocation {
+                    id: "new_id".to_owned(),
+                    code: locations_in_store[0].code.clone(),
+                    name: None,
+                    on_hold: None
+                },
+                &context
+            ),
             Err(InsertLocationError::LocationWithCodeAlreadyExists)
         );
     }
@@ -54,9 +56,9 @@ mod query {
 
         let connection = connection_manager.connection().unwrap();
         let location_repository = LocationRepository::new(&connection);
-        let service = InsertLocationService(ServiceConnection::Connection(
-            connection_manager.connection().unwrap(),
-        ));
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider.context().unwrap();
+        let service = service_provider.insert_location_service;
 
         let result_location = Location {
             id: "new_id".to_owned(),
@@ -66,12 +68,15 @@ mod query {
         };
 
         assert_eq!(
-            service.insert_location(InsertLocation {
-                id: "new_id".to_owned(),
-                code: "new_code".to_owned(),
-                name: None,
-                on_hold: None
-            }),
+            service.insert_location(
+                InsertLocation {
+                    id: "new_id".to_owned(),
+                    code: "new_code".to_owned(),
+                    name: None,
+                    on_hold: None
+                },
+                &context
+            ),
             Ok(result_location.clone())
         );
 
@@ -88,12 +93,15 @@ mod query {
 
         // Insert location with code that appears in location in another store
         assert_eq!(
-            service.insert_location(InsertLocation {
-                id: "new_id2".to_owned(),
-                code: "store_b_location_code".to_owned(),
-                name: Some("new_location_name".to_owned()),
-                on_hold: Some(true)
-            }),
+            service.insert_location(
+                InsertLocation {
+                    id: "new_id2".to_owned(),
+                    code: "store_b_location_code".to_owned(),
+                    name: Some("new_location_name".to_owned()),
+                    on_hold: Some(true),
+                },
+                &context
+            ),
             Ok(Location {
                 id: "new_id2".to_owned(),
                 name: "new_location_name".to_owned(),

--- a/service/src/location/insert/validate.rs
+++ b/service/src/location/insert/validate.rs
@@ -1,16 +1,13 @@
 use domain::location::{InsertLocation, LocationFilter};
-use repository::LocationRepository;
+use repository::{LocationRepository, StorageConnection};
 
-use crate::{
-    location::validate::{check_location_code_is_unique, LocationWithCodeAlreadyExists},
-    service_provider::ServiceConnection,
-};
+use crate::location::validate::{check_location_code_is_unique, LocationWithCodeAlreadyExists};
 
 use super::InsertLocationError;
 
 pub fn validate(
     input: &InsertLocation,
-    connection: &ServiceConnection,
+    connection: &StorageConnection,
 ) -> Result<(), InsertLocationError> {
     check_location_does_not_exist(&input.id, connection)?;
     check_location_code_is_unique(&input.code, connection)?;
@@ -22,7 +19,7 @@ pub fn validate(
 
 pub fn check_location_does_not_exist(
     id: &str,
-    connection: &ServiceConnection,
+    connection: &StorageConnection,
 ) -> Result<(), InsertLocationError> {
     let locations =
         LocationRepository::new(connection).query_by_filter(LocationFilter::new().match_id(id))?;

--- a/service/src/location/insert/validate.rs
+++ b/service/src/location/insert/validate.rs
@@ -1,0 +1,41 @@
+use domain::location::{InsertLocation, LocationFilter};
+use repository::LocationRepository;
+
+use crate::{
+    location::validate::{check_location_code_is_unique, LocationWithCodeAlreadyExists},
+    service_provider::ServiceConnection,
+};
+
+use super::InsertLocationError;
+
+pub fn validate(
+    input: &InsertLocation,
+    connection: &ServiceConnection,
+) -> Result<(), InsertLocationError> {
+    check_location_does_not_exist(&input.id, connection)?;
+    check_location_code_is_unique(&input.code, connection)?;
+
+    // TODO Check location belongs to current store
+
+    Ok(())
+}
+
+pub fn check_location_does_not_exist(
+    id: &str,
+    connection: &ServiceConnection,
+) -> Result<(), InsertLocationError> {
+    let locations =
+        LocationRepository::new(connection).query_by_filter(LocationFilter::new().match_id(id))?;
+
+    if locations.len() > 0 {
+        Err(InsertLocationError::LocationAlreadyExists)
+    } else {
+        Ok(())
+    }
+}
+
+impl From<LocationWithCodeAlreadyExists> for InsertLocationError {
+    fn from(_: LocationWithCodeAlreadyExists) -> Self {
+        InsertLocationError::LocationWithCodeAlreadyExists
+    }
+}

--- a/service/src/location/mod.rs
+++ b/service/src/location/mod.rs
@@ -5,7 +5,9 @@ use domain::{
     PaginationOption,
 };
 
+pub mod insert;
 pub mod query;
+mod validate;
 
 pub trait LocationQueryServiceTrait {
     fn get_locations(

--- a/service/src/location/validate.rs
+++ b/service/src/location/validate.rs
@@ -1,13 +1,13 @@
 use domain::location::LocationFilter;
-use repository::LocationRepository;
+use repository::{LocationRepository, StorageConnection};
 
-use crate::{current_store_id, service_provider::ServiceConnection, WithDBError};
+use crate::{current_store_id, WithDBError};
 
 pub struct LocationWithCodeAlreadyExists;
 
 pub fn check_location_code_is_unique(
     code: &str,
-    connection: &ServiceConnection,
+    connection: &StorageConnection,
 ) -> Result<(), WithDBError<LocationWithCodeAlreadyExists>> {
     let locations = LocationRepository::new(connection).query_by_filter(
         LocationFilter::new()

--- a/service/src/location/validate.rs
+++ b/service/src/location/validate.rs
@@ -1,0 +1,23 @@
+use domain::location::LocationFilter;
+use repository::LocationRepository;
+
+use crate::{current_store_id, service_provider::ServiceConnection, WithDBError};
+
+pub struct LocationWithCodeAlreadyExists;
+
+pub fn check_location_code_is_unique(
+    code: &str,
+    connection: &ServiceConnection,
+) -> Result<(), WithDBError<LocationWithCodeAlreadyExists>> {
+    let locations = LocationRepository::new(connection).query_by_filter(
+        LocationFilter::new()
+            .match_code(code)
+            .match_store_id(&current_store_id()),
+    )?;
+
+    if locations.len() > 0 {
+        Err(WithDBError::Error(LocationWithCodeAlreadyExists {}))
+    } else {
+        Ok(())
+    }
+}

--- a/service/src/service_provider.rs
+++ b/service/src/service_provider.rs
@@ -1,10 +1,11 @@
 use repository::{RepositoryError, StorageConnection, StorageConnectionManager};
 
-use crate::location::{LocationQueryServiceTrait, query::LocationQueryService};
+use crate::location::{query::LocationQueryService, LocationQueryServiceTrait, insert::{InsertLocationServiceTrait, InsertLocationService}};
 
 pub struct ServiceProvider {
     pub connection_manager: StorageConnectionManager,
     pub location_query_service: Box<dyn LocationQueryServiceTrait>,
+    pub insert_location_service: Box<dyn InsertLocationServiceTrait>,
 }
 
 pub struct ServiceContext {
@@ -16,6 +17,7 @@ impl ServiceProvider {
         ServiceProvider {
             connection_manager,
             location_query_service: Box::new(LocationQueryService {}),
+            insert_location_service: Box::new(InsertLocationService {}),
         }
     }
 


### PR DESCRIPTION
Closes: #619 

I really like the convenience of testing with service and graphql mapping. We might be able to simplify the factory bit, or revert back to anymap way of sharing service, with each method needing &StorageConnection (rather than service needing StorageConnection.

Pretty standard changes:
* Add service, add graphql mapping, add mock and test
* I needed to check store_id on location, which required exact store_id returned by current_store_id(), thus also relocated to one common method (the last commit). Also relocating here would help with TODO's I think (when that method is removed could see all compilation errors)

