### PR TITLE
Enable ilike (case insensitive like) for Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ openssl req -x509 -newkey rsa:4096 -nodes -keyout certs/key.pem -out certs/cert.
 
 ## Dependencies
 
+When using Postgres, Postgres 12 or higher is required.
+
 ### Windows
 
 - Install [rustup.exe](https://www.rust-lang.org/tools/install), following the instructions for installing Visual Studio C++ Build Tools if prompted.


### PR DESCRIPTION
Use ilike for postgres (works for ASCII and UTF8 chars, e.g. tested with Ä <--> ä ).

Sqlite is case insensitive on default. However, it only works for ASCII chars. Using something like ICU or providing a custom UPPER method is a bit more complicated (e.g. https://forum.lazarus.freepascal.org/index.php?topic=34259.0 has some solution for Pascal).

Do we need to filter for non ASCII char?

Closes #604 