### PR TITLE
Mock data collection

### DIFF
--- a/repository/src/mock/invoice.rs
+++ b/repository/src/mock/invoice.rs
@@ -258,48 +258,6 @@ pub fn mock_outbound_shipment_invalid_stock_line() -> InvoiceRow {
     }
 }
 
-// Added for invoice_count_service_test
-pub fn mock_inbound_shipment_invoice_count_service_a() -> InvoiceRow {
-    InvoiceRow {
-        id: String::from("inbound_shipment_invoice_count_a"),
-        name_id: String::from("name_store_b"),
-        store_id: String::from("store_a"),
-        invoice_number: 4,
-        r#type: InvoiceRowType::InboundShipment,
-        status: InvoiceRowStatus::New,
-        on_hold: false,
-        comment: Some("Sort comment test Ac".to_owned()),
-        their_reference: Some(String::from("")),
-        created_datetime: NaiveDate::from_ymd(2021, 12, 7).and_hms_milli(13, 30, 0, 0),
-        allocated_datetime: None,
-        picked_datetime: None,
-        shipped_datetime: None,
-        delivered_datetime: None,
-        verified_datetime: None,
-        color: None,
-    }
-}
-pub fn mock_inbound_shipment_invoice_count_service_b() -> InvoiceRow {
-    InvoiceRow {
-        id: String::from("inbound_shipment_invoice_count_b"),
-        name_id: String::from("name_store_b"),
-        store_id: String::from("store_a"),
-        invoice_number: 4,
-        r#type: InvoiceRowType::InboundShipment,
-        status: InvoiceRowStatus::New,
-        on_hold: false,
-        comment: Some("Sort comment test Ac".to_owned()),
-        their_reference: Some(String::from("")),
-        created_datetime: NaiveDate::from_ymd(2021, 12, 8).and_hms_milli(8, 30, 0, 0),
-        allocated_datetime: None,
-        picked_datetime: None,
-        shipped_datetime: None,
-        delivered_datetime: None,
-        verified_datetime: None,
-        color: None,
-    }
-}
-
 pub fn mock_empty_draft_inbound_shipment() -> InvoiceRow {
     InvoiceRow {
         id: String::from("empty_draft_inbound_shipment"),
@@ -341,8 +299,6 @@ pub fn mock_inbound_shipments() -> Vec<InvoiceRow> {
         mock_inbound_shipment_c(),
         mock_inbound_shipment_d(),
         mock_empty_draft_inbound_shipment(),
-        mock_inbound_shipment_invoice_count_service_a(),
-        mock_inbound_shipment_invoice_count_service_b(),
     ]
 }
 

--- a/repository/src/mock/invoice.rs
+++ b/repository/src/mock/invoice.rs
@@ -235,29 +235,6 @@ pub fn mock_inbound_shipment_d() -> InvoiceRow {
     }
 }
 
-// Added for CI update test
-// invoice containing invoice lines without stock line
-pub fn mock_outbound_shipment_invalid_stock_line() -> InvoiceRow {
-    InvoiceRow {
-        id: String::from("outbound_shipment_invalid_stock_line"),
-        name_id: String::from("name_store_a"),
-        store_id: String::from("store_c"),
-        invoice_number: 3,
-        r#type: InvoiceRowType::OutboundShipment,
-        status: InvoiceRowStatus::New,
-        on_hold: false,
-        comment: Some("Sort comment test cA".to_owned()),
-        their_reference: Some(String::from("")),
-        created_datetime: NaiveDate::from_ymd(1970, 1, 6).and_hms_milli(15, 30, 0, 0),
-        color: None,
-        allocated_datetime: None,
-        picked_datetime: None,
-        shipped_datetime: None,
-        delivered_datetime: None,
-        verified_datetime: None,
-    }
-}
-
 pub fn mock_empty_draft_inbound_shipment() -> InvoiceRow {
     InvoiceRow {
         id: String::from("empty_draft_inbound_shipment"),
@@ -286,7 +263,6 @@ pub fn mock_outbound_shipments() -> Vec<InvoiceRow> {
         mock_outbound_shipment_c(),
         mock_outbound_shipment_d(),
         mock_outbound_shipment_shipped(),
-        mock_outbound_shipment_invalid_stock_line(),
         mock_outbound_shipment_picked(),
         mock_outbound_shipment_no_lines(),
     ]

--- a/repository/src/mock/invoice_line.rs
+++ b/repository/src/mock/invoice_line.rs
@@ -43,31 +43,9 @@ pub fn mock_outbound_shipment_a_invoice_lines() -> Vec<InvoiceLineRow> {
         note: None,
     };
 
-    // Added for CI update test
-    let mock_outbound_shipment_line_no_stock_line: InvoiceLineRow = InvoiceLineRow {
-        id: String::from("outbound_shipment_line_no_stock_line"),
-        invoice_id: String::from("outbound_shipment_invalid_stock_line"),
-        item_id: String::from("item_with_no_stock_line"),
-        location_id: None,
-        item_name: String::from("item_b"),
-        item_code: String::from("item_b"),
-        stock_line_id: None,
-        batch: Some(String::from("item_a_line_a")),
-        expiry_date: Some(NaiveDate::from_ymd(2020, 8, 2)),
-        pack_size: 1,
-        cost_price_per_pack: 0.0,
-        sell_price_per_pack: 0.0,
-        total_before_tax: 2.0,
-        total_after_tax: 2.0,
-        tax: None,
-        number_of_packs: 1,
-        note: None,
-    };
-
     vec![
         mock_outbound_shipment_a_invoice_line_a,
         mock_outbound_shipment_a_invoice_line_b,
-        mock_outbound_shipment_line_no_stock_line,
     ]
 }
 

--- a/repository/src/mock/item.rs
+++ b/repository/src/mock/item.rs
@@ -30,17 +30,6 @@ pub fn mock_item_c() -> ItemRow {
     }
 }
 
-// Added for CI update test
-pub fn mock_item_with_no_stock_line() -> ItemRow {
-    ItemRow {
-        id: String::from("item_with_no_stock_line"),
-        name: String::from("Item with no stock line"),
-        code: String::from("code"),
-        unit_id: None,
-        r#type: ItemType::Stock,
-    }
-}
-
 pub fn item_query_test1() -> ItemRow {
     ItemRow {
         id: String::from("item_query_test1"),
@@ -66,7 +55,6 @@ pub fn mock_items() -> Vec<ItemRow> {
         mock_item_a(),
         mock_item_b(),
         mock_item_c(),
-        mock_item_with_no_stock_line(),
         item_query_test1(),
         item_query_test2(),
     ]

--- a/repository/src/mock/mod.rs
+++ b/repository/src/mock/mod.rs
@@ -10,10 +10,10 @@ mod requisition;
 mod requisition_line;
 mod stock_line;
 mod store;
+mod test_invoice_count_service;
 mod unit;
 mod user_account;
-
-use std::collections::HashMap;
+use std::{collections::HashMap, ops::Index};
 
 pub use full_invoice::mock_full_invoices;
 pub use invoice::{mock_invoices, mock_outbound_shipment_a, mock_outbound_shipments};
@@ -26,6 +26,7 @@ pub use requisition::mock_requisitions;
 pub use requisition_line::mock_requisition_lines;
 pub use stock_line::mock_stock_lines;
 pub use store::{mock_store_b, mock_stores};
+pub use test_invoice_count_service::*;
 pub use user_account::mock_user_accounts;
 
 use crate::{InvoiceLineRowRepository, LocationRowRepository, StockLineRowRepository};
@@ -44,6 +45,7 @@ use super::{
     schema::*,
 };
 
+#[derive(Default)]
 pub struct MockData {
     pub names: Vec<NameRow>,
     pub stores: Vec<StoreRow>,
@@ -160,98 +162,144 @@ impl MockDataInserts {
     }
 }
 
+#[derive(Default)]
+pub struct MockDataCollection {
+    // Note: can't use a HashMap since mock data should be inserted in order
+    data: Vec<(String, MockData)>,
+}
+
+impl MockDataCollection {
+    pub fn insert(&mut self, name: &str, data: MockData) {
+        self.data.push((name.to_string(), data));
+    }
+
+    pub fn get_mut(&mut self, name: &str) -> &mut MockData {
+        for (n, data) in &mut self.data {
+            if n != name {
+                continue;
+            }
+            return data;
+        }
+        unreachable!("Missing mock data");
+    }
+}
+
+impl Index<&str> for MockDataCollection {
+    type Output = MockData;
+
+    fn index(&self, name: &str) -> &Self::Output {
+        &self.data.iter().find(|entry| entry.0 == name).unwrap().1
+    }
+}
+
+fn all_mock_data() -> MockDataCollection {
+    let mut data: MockDataCollection = Default::default();
+    data.insert(
+        "base",
+        MockData {
+            names: mock_names(),
+            stores: mock_stores(),
+            units: mock_units(),
+            items: mock_items(),
+            locations: mock_locations(),
+            name_store_joins: mock_name_store_joins(),
+            invoices: mock_invoices(),
+            stock_lines: mock_stock_lines(),
+            invoice_lines: mock_invoice_lines(),
+            full_invoices: mock_full_invoices(),
+            full_master_list: mock_full_master_list(),
+        },
+    );
+    data.insert(
+        "test_invoice_count_service_data",
+        test_invoice_count_service_data(),
+    );
+
+    data
+}
+
 pub async fn insert_mock_data(
     connection: &StorageConnection,
     inserts: MockDataInserts,
-) -> MockData {
-    let result = MockData {
-        names: mock_names(),
-        stores: mock_stores(),
-        units: mock_units(),
-        items: mock_items(),
-        locations: mock_locations(),
-        name_store_joins: mock_name_store_joins(),
-        invoices: mock_invoices(),
-        stock_lines: mock_stock_lines(),
-        invoice_lines: mock_invoice_lines(),
-        full_invoices: mock_full_invoices(),
-        full_master_list: mock_full_master_list(),
-    };
+) -> MockDataCollection {
+    let all_mock_data = all_mock_data();
+    for (_, mock_data) in &all_mock_data.data {
+        if inserts.names {
+            let repo = NameRepository::new(connection);
+            for row in &mock_data.names {
+                repo.insert_one(&row).await.unwrap();
+            }
+        }
 
-    if inserts.names {
-        let repo = NameRepository::new(connection);
-        for row in &result.names {
-            repo.insert_one(&row).await.unwrap();
+        if inserts.stores {
+            let repo = StoreRepository::new(connection);
+            for row in &mock_data.stores {
+                repo.insert_one(&row).await.unwrap();
+            }
+        }
+
+        if inserts.units {
+            let repo = UnitRowRepository::new(connection);
+            for row in &mock_data.units {
+                repo.upsert_one(&row).unwrap();
+            }
+        }
+
+        if inserts.items {
+            let repo = ItemRepository::new(connection);
+            for row in &mock_data.items {
+                repo.insert_one(&row).await.unwrap();
+            }
+        }
+
+        if inserts.locations {
+            let repo = LocationRowRepository::new(connection);
+            for row in &mock_data.locations {
+                repo.upsert_one(&row).unwrap();
+            }
+        }
+
+        if inserts.name_store_joins {
+            let repo = NameStoreJoinRepository::new(connection);
+            for row in &mock_data.name_store_joins {
+                repo.upsert_one(&row).unwrap();
+            }
+        }
+
+        if inserts.invoices {
+            let repo = InvoiceRepository::new(connection);
+            for row in &mock_data.invoices {
+                println!("{:?}", row);
+                repo.upsert_one(&row).unwrap();
+            }
+        }
+
+        if inserts.stock_lines {
+            let repo = StockLineRowRepository::new(connection);
+            for row in &mock_data.stock_lines {
+                repo.upsert_one(&row).unwrap();
+            }
+        }
+
+        if inserts.invoice_lines {
+            let repo = InvoiceLineRowRepository::new(connection);
+            for row in &mock_data.invoice_lines {
+                repo.upsert_one(&row).unwrap();
+            }
+        }
+
+        if inserts.full_invoices {
+            for row in mock_data.full_invoices.values() {
+                insert_full_mock_invoice(row, connection)
+            }
+        }
+
+        if inserts.full_master_list {
+            for row in mock_data.full_master_list.values() {
+                insert_full_mock_master_list(row, connection)
+            }
         }
     }
 
-    if inserts.stores {
-        let repo = StoreRepository::new(connection);
-        for row in &result.stores {
-            repo.insert_one(&row).await.unwrap();
-        }
-    }
-
-    if inserts.units {
-        let repo = UnitRowRepository::new(connection);
-        for row in &result.units {
-            repo.upsert_one(&row).unwrap();
-        }
-    }
-
-    if inserts.items {
-        let repo = ItemRepository::new(connection);
-        for row in &result.items {
-            repo.insert_one(&row).await.unwrap();
-        }
-    }
-
-    if inserts.locations {
-        let repo = LocationRowRepository::new(connection);
-        for row in &result.locations {
-            repo.upsert_one(&row).unwrap();
-        }
-    }
-
-    if inserts.name_store_joins {
-        let repo = NameStoreJoinRepository::new(connection);
-        for row in &result.name_store_joins {
-            repo.upsert_one(&row).unwrap();
-        }
-    }
-
-    if inserts.invoices {
-        let repo = InvoiceRepository::new(connection);
-        for row in &result.invoices {
-            repo.upsert_one(&row).unwrap();
-        }
-    }
-
-    if inserts.stock_lines {
-        let repo = StockLineRowRepository::new(connection);
-        for row in &result.stock_lines {
-            repo.upsert_one(&row).unwrap();
-        }
-    }
-
-    if inserts.invoice_lines {
-        let repo = InvoiceLineRowRepository::new(connection);
-        for row in &result.invoice_lines {
-            repo.upsert_one(&row).unwrap();
-        }
-    }
-
-    if inserts.full_invoices {
-        for row in result.full_invoices.values() {
-            insert_full_mock_invoice(row, connection)
-        }
-    }
-
-    if inserts.full_master_list {
-        for row in result.full_master_list.values() {
-            insert_full_mock_master_list(row, connection)
-        }
-    }
-
-    result
+    all_mock_data
 }

--- a/repository/src/mock/mod.rs
+++ b/repository/src/mock/mod.rs
@@ -275,7 +275,6 @@ pub async fn insert_mock_data(
         if inserts.invoices {
             let repo = InvoiceRepository::new(connection);
             for row in &mock_data.invoices {
-                println!("{:?}", row);
                 repo.upsert_one(&row).unwrap();
             }
         }

--- a/repository/src/mock/mod.rs
+++ b/repository/src/mock/mod.rs
@@ -11,6 +11,7 @@ mod requisition_line;
 mod stock_line;
 mod store;
 mod test_invoice_count_service;
+mod test_outbound_shipment_update;
 mod unit;
 mod user_account;
 use std::{collections::HashMap, ops::Index};
@@ -27,6 +28,7 @@ pub use requisition_line::mock_requisition_lines;
 pub use stock_line::mock_stock_lines;
 pub use store::{mock_store_b, mock_stores};
 pub use test_invoice_count_service::*;
+pub use test_outbound_shipment_update::*;
 pub use user_account::mock_user_accounts;
 
 use crate::{InvoiceLineRowRepository, LocationRowRepository, StockLineRowRepository};
@@ -213,6 +215,10 @@ fn all_mock_data() -> MockDataCollection {
     data.insert(
         "test_invoice_count_service_data",
         test_invoice_count_service_data(),
+    );
+    data.insert(
+        "test_outbound_shipment_update_data",
+        test_outbound_shipment_update_data(),
     );
 
     data

--- a/repository/src/mock/test_invoice_count_service.rs
+++ b/repository/src/mock/test_invoice_count_service.rs
@@ -1,0 +1,56 @@
+use chrono::NaiveDate;
+
+use crate::schema::{InvoiceRow, InvoiceRowStatus, InvoiceRowType};
+
+use super::MockData;
+
+pub fn mock_inbound_shipment_invoice_count_service_a() -> InvoiceRow {
+    InvoiceRow {
+        id: String::from("inbound_shipment_invoice_count_a"),
+        name_id: String::from("name_store_b"),
+        store_id: String::from("store_a"),
+        invoice_number: 4,
+        r#type: InvoiceRowType::InboundShipment,
+        status: InvoiceRowStatus::New,
+        on_hold: false,
+        comment: Some("Sort comment test Ac".to_owned()),
+        their_reference: Some(String::from("")),
+        created_datetime: NaiveDate::from_ymd(2021, 12, 7).and_hms_milli(13, 30, 0, 0),
+        allocated_datetime: None,
+        picked_datetime: None,
+        shipped_datetime: None,
+        delivered_datetime: None,
+        verified_datetime: None,
+        color: None,
+    }
+}
+
+pub fn mock_inbound_shipment_invoice_count_service_b() -> InvoiceRow {
+    InvoiceRow {
+        id: String::from("inbound_shipment_invoice_count_b"),
+        name_id: String::from("name_store_b"),
+        store_id: String::from("store_a"),
+        invoice_number: 4,
+        r#type: InvoiceRowType::InboundShipment,
+        status: InvoiceRowStatus::New,
+        on_hold: false,
+        comment: Some("Sort comment test Ac".to_owned()),
+        their_reference: Some(String::from("")),
+        created_datetime: NaiveDate::from_ymd(2021, 12, 8).and_hms_milli(8, 30, 0, 0),
+        allocated_datetime: None,
+        picked_datetime: None,
+        shipped_datetime: None,
+        delivered_datetime: None,
+        verified_datetime: None,
+        color: None,
+    }
+}
+
+pub fn test_invoice_count_service_data() -> MockData {
+    let mut data: MockData = Default::default();
+    data.invoices.append(&mut vec![
+        mock_inbound_shipment_invoice_count_service_a(),
+        mock_inbound_shipment_invoice_count_service_b(),
+    ]);
+    data
+}

--- a/repository/src/mock/test_outbound_shipment_update.rs
+++ b/repository/src/mock/test_outbound_shipment_update.rs
@@ -1,0 +1,74 @@
+use chrono::NaiveDate;
+
+use crate::schema::{
+    InvoiceLineRow, InvoiceRow, InvoiceRowStatus, InvoiceRowType, ItemRow, ItemType,
+};
+
+use super::MockData;
+
+// Added for CI update test
+fn mock_outbound_shipment_line_no_stock_line() -> InvoiceLineRow {
+    InvoiceLineRow {
+        id: String::from("outbound_shipment_line_no_stock_line"),
+        invoice_id: String::from("outbound_shipment_invalid_stock_line"),
+        item_id: String::from("item_with_no_stock_line"),
+        location_id: None,
+        item_name: String::from("item_b"),
+        item_code: String::from("item_b"),
+        stock_line_id: None,
+        batch: Some(String::from("item_a_line_a")),
+        expiry_date: Some(NaiveDate::from_ymd(2020, 8, 2)),
+        pack_size: 1,
+        cost_price_per_pack: 0.0,
+        sell_price_per_pack: 0.0,
+        total_before_tax: 2.0,
+        total_after_tax: 2.0,
+        tax: None,
+        number_of_packs: 1,
+        note: None,
+    }
+}
+
+// Added for CI update test
+fn mock_item_with_no_stock_line() -> ItemRow {
+    ItemRow {
+        id: String::from("item_with_no_stock_line"),
+        name: String::from("Item with no stock line"),
+        code: String::from("code"),
+        unit_id: None,
+        r#type: ItemType::Stock,
+    }
+}
+
+// Added for CI update test
+// invoice containing invoice lines without stock line
+fn mock_outbound_shipment_invalid_stock_line() -> InvoiceRow {
+    InvoiceRow {
+        id: String::from("outbound_shipment_invalid_stock_line"),
+        name_id: String::from("name_store_a"),
+        store_id: String::from("store_c"),
+        invoice_number: 3,
+        r#type: InvoiceRowType::OutboundShipment,
+        status: InvoiceRowStatus::New,
+        on_hold: false,
+        comment: Some("Sort comment test cA".to_owned()),
+        their_reference: Some(String::from("")),
+        created_datetime: NaiveDate::from_ymd(1970, 1, 6).and_hms_milli(15, 30, 0, 0),
+        color: None,
+        allocated_datetime: None,
+        picked_datetime: None,
+        shipped_datetime: None,
+        delivered_datetime: None,
+        verified_datetime: None,
+    }
+}
+
+pub fn test_outbound_shipment_update_data() -> MockData {
+    let mut data: MockData = Default::default();
+    data.items.append(&mut vec![mock_item_with_no_stock_line()]);
+    data.invoices
+        .append(&mut vec![mock_outbound_shipment_invalid_stock_line()]);
+    data.invoice_lines
+        .append(&mut vec![mock_outbound_shipment_line_no_stock_line()]);
+    data
+}

--- a/repository/src/mock/test_outbound_shipment_update.rs
+++ b/repository/src/mock/test_outbound_shipment_update.rs
@@ -6,7 +6,6 @@ use crate::schema::{
 
 use super::MockData;
 
-// Added for CI update test
 fn mock_outbound_shipment_line_no_stock_line() -> InvoiceLineRow {
     InvoiceLineRow {
         id: String::from("outbound_shipment_line_no_stock_line"),
@@ -29,7 +28,6 @@ fn mock_outbound_shipment_line_no_stock_line() -> InvoiceLineRow {
     }
 }
 
-// Added for CI update test
 fn mock_item_with_no_stock_line() -> ItemRow {
     ItemRow {
         id: String::from("item_with_no_stock_line"),
@@ -40,7 +38,6 @@ fn mock_item_with_no_stock_line() -> ItemRow {
     }
 }
 
-// Added for CI update test
 // invoice containing invoice lines without stock line
 fn mock_outbound_shipment_invalid_stock_line() -> InvoiceRow {
     InvoiceRow {

--- a/repository/src/test_db.rs
+++ b/repository/src/test_db.rs
@@ -1,7 +1,7 @@
 use crate::{
     database_settings::DatabaseSettings,
     db_diesel::{DBBackendConnection, StorageConnection, StorageConnectionManager},
-    mock::{insert_mock_data, MockData, MockDataInserts},
+    mock::{insert_mock_data, MockDataCollection, MockDataInserts},
 };
 
 use diesel::r2d2::{ConnectionManager, Pool};
@@ -120,7 +120,7 @@ pub async fn setup_all(
     db_name: &str,
     inserts: MockDataInserts,
 ) -> (
-    MockData,
+    MockDataCollection,
     StorageConnection,
     StorageConnectionManager,
     DatabaseSettings,

--- a/server/src/test_utils.rs
+++ b/server/src/test_utils.rs
@@ -1,5 +1,5 @@
 use repository::{
-    mock::{MockData, MockDataInserts},
+    mock::{MockDataCollection, MockDataInserts},
     test_db::{self, get_test_db_settings},
     StorageConnection, StorageConnectionManager,
 };
@@ -31,7 +31,7 @@ pub async fn setup_all(
     db_name: &str,
     inserts: MockDataInserts,
 ) -> (
-    MockData,
+    MockDataCollection,
     StorageConnection,
     StorageConnectionManager,
     Settings,

--- a/server/tests/graphql/inbound_shipment_line_insert.rs
+++ b/server/tests/graphql/inbound_shipment_line_insert.rs
@@ -71,7 +71,7 @@ mod graphql {
             MockDataInserts::all(),
         )
         .await;
-
+        let mock_data = mock_data.get_mut("base");
         // Setup
 
         let draft_inbound_shipment = get_invoice_inline!(

--- a/server/tests/graphql/inbound_shipment_line_update.rs
+++ b/server/tests/graphql/inbound_shipment_line_update.rs
@@ -101,7 +101,7 @@ mod graphql {
             InvoiceFilter::new().r#type(InvoiceType::OutboundShipment.equal_to()),
             &connection
         );
-        let item = mock_data.items.first().unwrap();
+        let item = mock_data["base"].items.first().unwrap();
         let delivered_invoice_lines =
             get_invoice_lines_inline!(&delivered_inbound_shipment.id.clone(), &connection);
         let outbound_shipment_lines =

--- a/server/tests/graphql/inbound_shipment_update.rs
+++ b/server/tests/graphql/inbound_shipment_update.rs
@@ -290,7 +290,7 @@ mod graphql {
 
         // Test CannotChangeStatusOfInvoiceOnHold
 
-        let full_invoice = mock_data
+        let full_invoice = mock_data["base"]
             .full_invoices
             .get("inbound_shipment_on_hold")
             .unwrap();
@@ -311,7 +311,7 @@ mod graphql {
 
         // Test can change status if on hold is update in the same mutation
 
-        let full_invoice = mock_data
+        let full_invoice = mock_data["base"]
             .full_invoices
             .get("inbound_shipment_on_hold")
             .unwrap();

--- a/server/tests/graphql/invoice_query.rs
+++ b/server/tests/graphql/invoice_query.rs
@@ -15,7 +15,7 @@ mod graphql {
         )
         .await;
 
-        let full_invoice = mock_data.full_invoices.get("draft_ci_a").unwrap();
+        let full_invoice = mock_data["base"].full_invoices.get("draft_ci_a").unwrap();
 
         let query = r#"query Invoice($id: String) {            
                 invoice(id: $id) {

--- a/server/tests/graphql/outbound_shipment_insert.rs
+++ b/server/tests/graphql/outbound_shipment_insert.rs
@@ -14,8 +14,8 @@ mod graphql {
         )
         .await;
 
-        let other_party_supplier = &mock_data.names[2];
-        let other_party_customer = &mock_data.names[0];
+        let other_party_supplier = &mock_data["base"].names[2];
+        let other_party_customer = &mock_data["base"].names[0];
 
         let query = r#"mutation InsertOutboundShipment($input: InsertOutboundShipmentInput!) {
             insertOutboundShipment(input: $input) {

--- a/server/tests/graphql/outbound_shipment_update.rs
+++ b/server/tests/graphql/outbound_shipment_update.rs
@@ -99,7 +99,7 @@ mod graphql {
         assert_gql_query(&settings, query, &variables, &expected, None).await;
 
         // OtherPartyNotACustomerError
-        let other_party_supplier = &mock_data.names[2];
+        let other_party_supplier = &mock_data["base"].names[2];
         let variables = Some(json!({
           "input": {
             "id": "outbound_shipment_a",
@@ -207,7 +207,7 @@ mod graphql {
         assert_stock_line_totals(&invoice_lines, &expected_totals);
 
         // test DRAFT to FINALISED (while setting onHold to true)
-        let full_invoice = mock_data.full_invoices.get("draft_ci_a").unwrap();
+        let full_invoice = mock_data["base"].full_invoices.get("draft_ci_a").unwrap();
         let invoice_id = full_invoice.invoice.id.clone();
         let invoice_lines = full_invoice.get_lines();
         let expected_totals = expected_stock_line_totals(&invoice_lines);
@@ -230,7 +230,7 @@ mod graphql {
         assert_stock_line_totals(&invoice_lines, &expected_totals);
 
         // test Status Change on Hold
-        let full_invoice = mock_data
+        let full_invoice = mock_data["base"]
             .full_invoices
             .get("outbound_shipment_on_hold")
             .unwrap();
@@ -254,7 +254,7 @@ mod graphql {
         assert_gql_query(&settings, query, &variables, &expected, None).await;
 
         // test Status Change and on hold change
-        let full_invoice = mock_data
+        let full_invoice = mock_data["base"]
             .full_invoices
             .get("outbound_shipment_on_hold")
             .unwrap();

--- a/service/src/location/tests/insert.rs
+++ b/service/src/location/tests/insert.rs
@@ -31,7 +31,7 @@ mod query {
             service.insert_location(
                 &context,
                 InsertLocation {
-                    id: mock_data.locations[0].id.clone(),
+                    id: mock_data["base"].locations[0].id.clone(),
                     code: "invalid".to_owned(),
                     name: None,
                     on_hold: None

--- a/service/src/location/tests/query.rs
+++ b/service/src/location/tests/query.rs
@@ -125,7 +125,7 @@ mod query {
             )
             .unwrap();
 
-        let mut locations = mock_data.locations.clone();
+        let mut locations = mock_data["base"].locations.clone();
         locations.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
 
         let result_names: Vec<String> = result
@@ -153,7 +153,7 @@ mod query {
             )
             .unwrap();
 
-        let mut locations = mock_data.locations.clone();
+        let mut locations = mock_data["base"].locations.clone();
         locations.sort_by(|a, b| b.name.to_lowercase().cmp(&a.name.to_lowercase()));
 
         let result_names: Vec<String> = result


### PR DESCRIPTION
I tried to use a simple HashMap for the MockDataCollection but I need to write mock data in a fixed order to the DB. For this reason MockDataCollection looks a little bit complicated since I made it behave like a HashMap... Otherwise it should be quite straight forward. Currently there are three MockData entries in the collection, the base MockData and mock data for two tests.

This approach could actually also make it easier to find test specific mock data in a test (e.g. mock_data["my-test"].names[0])