### PR TITLE
657 apply number sequence logic on invoices

### DIFF
--- a/domain/src/invoice.rs
+++ b/domain/src/invoice.rs
@@ -24,7 +24,7 @@ pub struct Invoice {
     pub status: InvoiceStatus,
     pub on_hold: bool,
     pub r#type: InvoiceType,
-    pub invoice_number: i32,
+    pub invoice_number: i64,
     pub their_reference: Option<String>,
     pub comment: Option<String>,
     pub created_datetime: NaiveDateTime,
@@ -38,7 +38,7 @@ pub struct Invoice {
 #[derive(Clone)]
 pub struct InvoiceFilter {
     pub id: Option<EqualFilter<String>>,
-    pub invoice_number: Option<EqualFilter<i32>>,
+    pub invoice_number: Option<EqualFilter<i64>>,
     pub name_id: Option<EqualFilter<String>>,
     pub store_id: Option<EqualFilter<String>>,
     pub r#type: Option<EqualFilter<InvoiceType>>,

--- a/graphql/src/schema/types/invoice_query.rs
+++ b/graphql/src/schema/types/invoice_query.rs
@@ -14,7 +14,7 @@ use serde::Serialize;
 use service::invoice::get_invoice;
 
 use super::{
-    Connector, ConnectorError, DatetimeFilterInput, EqualFilterInput, EqualFilterNumberInput,
+    Connector, ConnectorError, DatetimeFilterInput, EqualFilterBigNumberInput, EqualFilterInput,
     EqualFilterStringInput, ErrorWrapper, InvoiceLinesResponse, NameResponse, NodeError,
     NodeErrorInterface, SimpleStringFilterInput, SortInput,
 };
@@ -40,7 +40,7 @@ pub type InvoiceSortInput = SortInput<InvoiceSortFieldInput>;
 
 #[derive(InputObject, Clone)]
 pub struct InvoiceFilterInput {
-    pub invoice_number: Option<EqualFilterNumberInput>,
+    pub invoice_number: Option<EqualFilterBigNumberInput>,
     pub name_id: Option<EqualFilterStringInput>,
     pub store_id: Option<EqualFilterStringInput>,
     pub r#type: Option<EqualFilterInput<InvoiceNodeType>>,
@@ -147,7 +147,7 @@ impl InvoiceNode {
         self.invoice.status.clone().into()
     }
 
-    pub async fn invoice_number(&self) -> i32 {
+    pub async fn invoice_number(&self) -> i64 {
         self.invoice.invoice_number
     }
 

--- a/graphql/src/schema/types/sort_filter_types.rs
+++ b/graphql/src/schema/types/sort_filter_types.rs
@@ -72,6 +72,7 @@ impl From<SimpleStringFilterInput> for SimpleStringFilter {
 #[graphql(concrete(name = "EqualFilterStringInput", params(String)))]
 #[graphql(concrete(name = "EqualFilterBooleanInput", params(bool)))]
 #[graphql(concrete(name = "EqualFilterNumberInput", params(i32)))]
+#[graphql(concrete(name = "EqualFilterBigNumberInput", params(i64)))]
 #[graphql(concrete(name = "EqualFilterInvoiceTypeInput", params(InvoiceNodeType)))]
 #[graphql(concrete(name = "EqualFilterInvoiceStatusInput", params(InvoiceNodeStatus)))]
 pub struct EqualFilterInput<T: InputType> {
@@ -83,6 +84,7 @@ pub struct EqualFilterInput<T: InputType> {
 pub type EqualFilterBoolInput = EqualFilterInput<bool>;
 pub type EqualFilterStringInput = EqualFilterInput<String>;
 pub type EqualFilterNumberInput = EqualFilterInput<i32>;
+pub type EqualFilterBigNumberInput = EqualFilterInput<i64>;
 
 impl<T> From<EqualFilterInput<T>> for EqualFilter<T>
 where

--- a/repository/migrations/postgres/00000106_create_invoice_table/up.sql
+++ b/repository/migrations/postgres/00000106_create_invoice_table/up.sql
@@ -20,7 +20,7 @@ CREATE TABLE invoice (
     -- For outbound shipments, the id of the issuing store.
     -- For inbound shipments, the id of the receiving store.
     store_id text NOT NULL REFERENCES store (id),
-    invoice_number integer NOT NULL,
+    invoice_number BIGINT NOT NULL,
     type invoice_type NOT NULL,
     status invoice_status NOT NULL,
     on_hold boolean NOT NULL,

--- a/repository/migrations/postgres/00000118_number_table/up.sql
+++ b/repository/migrations/postgres/00000118_number_table/up.sql
@@ -1,8 +1,13 @@
--- Numbering table holding a list of named counters
+CREATE TYPE number_type AS ENUM (
+    'INBOUND_SHIPMENT',
+    'OUTBOUND_SHIPMENT'
+);
+
+-- Numbering table holding a list of typed counters
 CREATE TABLE number (
-    -- unique key in the format: `${name}_${store_id}`
     id TEXT NOT NULL PRIMARY KEY,
     -- current counter value
     value BIGINT NOT NULL,
-    store_id TEXT NOT NULL REFERENCES store(id)
+    store_id TEXT NOT NULL REFERENCES store(id),
+    type number_type NOT NULL
 )

--- a/repository/migrations/sqlite/00000118_number_table/up.sql
+++ b/repository/migrations/sqlite/00000118_number_table/up.sql
@@ -1,8 +1,8 @@
--- Numbering table holding a list of named counters
+-- Numbering table holding a list of typed counters
 CREATE TABLE number (
-    -- unique key in the format: `${name}_${store_id}`
     id TEXT NOT NULL PRIMARY KEY,
     -- current counter value
     value BIGINT NOT NULL,
-    store_id TEXT NOT NULL REFERENCES store(id)
+    store_id TEXT NOT NULL REFERENCES store(id),
+    type TEXT CHECK (type IN ('INBOUND_SHIPMENT', 'OUTBOUND_SHIPMENT')) NOT NULL
 )

--- a/repository/src/db_diesel/item_query.rs
+++ b/repository/src/db_diesel/item_query.rs
@@ -233,19 +233,11 @@ mod tests {
     async fn test_item_query_filter_repository() {
         let (_, storage_connection, _, _) = test_db::setup_all(
             "test_item_query_filter_repository",
-            MockDataInserts {
-                names: true,
-                stores: false,
-                units: true,
-                items: true,
-                locations: false,
-                name_store_joins: false,
-                invoices: false,
-                stock_lines: false,
-                invoice_lines: false,
-                full_invoices: false,
-                full_master_list: true,
-            },
+            MockDataInserts::none()
+                .units()
+                .items()
+                .names()
+                .full_master_list(),
         )
         .await;
         let item_query_repository = ItemQueryRepository::new(&storage_connection);

--- a/repository/src/db_diesel/number_row.rs
+++ b/repository/src/db_diesel/number_row.rs
@@ -36,7 +36,7 @@ impl<'a> NumberRowRepository<'a> {
     pub fn upsert_one(&self, number_row: &NumberRow) -> Result<(), RepositoryError> {
         diesel::insert_into(number_dsl::number)
             .values(number_row)
-            .on_conflict(id)
+            .on_conflict(number_dsl::id)
             .do_update()
             .set(number_row)
             .execute(&self.connection.connection)?;

--- a/repository/src/mock/mod.rs
+++ b/repository/src/mock/mod.rs
@@ -6,6 +6,7 @@ mod item;
 mod location;
 mod name;
 mod name_store_join;
+mod number;
 mod requisition;
 mod requisition_line;
 mod stock_line;
@@ -23,6 +24,7 @@ pub use item::mock_items;
 pub use location::mock_locations;
 pub use name::{mock_name_store_a, mock_name_store_b, mock_names};
 pub use name_store_join::mock_name_store_joins;
+pub use number::*;
 pub use requisition::mock_requisitions;
 pub use requisition_line::mock_requisition_lines;
 pub use stock_line::mock_stock_lines;
@@ -31,7 +33,9 @@ pub use test_invoice_count_service::*;
 pub use test_outbound_shipment_update::*;
 pub use user_account::mock_user_accounts;
 
-use crate::{InvoiceLineRowRepository, LocationRowRepository, StockLineRowRepository};
+use crate::{
+    InvoiceLineRowRepository, LocationRowRepository, NumberRowRepository, StockLineRowRepository,
+};
 
 use self::{
     full_invoice::{insert_full_mock_invoice, FullMockInvoice},
@@ -60,6 +64,7 @@ pub struct MockData {
     pub invoice_lines: Vec<InvoiceLineRow>,
     pub full_invoices: HashMap<String, FullMockInvoice>,
     pub full_master_list: HashMap<String, FullMockMasterList>,
+    pub numbers: Vec<NumberRow>,
 }
 pub struct MockDataInserts {
     pub names: bool,
@@ -73,6 +78,7 @@ pub struct MockDataInserts {
     pub invoice_lines: bool,
     pub full_invoices: bool,
     pub full_master_list: bool,
+    pub numbers: bool,
 }
 
 impl MockDataInserts {
@@ -89,6 +95,7 @@ impl MockDataInserts {
             invoice_lines: true,
             full_invoices: true,
             full_master_list: true,
+            numbers: true,
         }
     }
 
@@ -105,6 +112,7 @@ impl MockDataInserts {
             invoice_lines: false,
             full_invoices: false,
             full_master_list: false,
+            numbers: false,
         }
     }
 
@@ -210,6 +218,7 @@ fn all_mock_data() -> MockDataCollection {
             invoice_lines: mock_invoice_lines(),
             full_invoices: mock_full_invoices(),
             full_master_list: mock_full_master_list(),
+            numbers: mock_numbers(),
         },
     );
     data.insert(
@@ -302,6 +311,13 @@ pub async fn insert_mock_data(
         if inserts.full_master_list {
             for row in mock_data.full_master_list.values() {
                 insert_full_mock_master_list(row, connection)
+            }
+        }
+
+        if inserts.numbers {
+            let repo = NumberRowRepository::new(connection);
+            for row in &mock_data.numbers {
+                repo.upsert_one(&row).unwrap();
             }
         }
     }

--- a/repository/src/mock/number.rs
+++ b/repository/src/mock/number.rs
@@ -1,0 +1,26 @@
+use crate::schema::{NumberRow, NumberRowType};
+
+pub fn mock_inbound_shipment_number_store_a() -> NumberRow {
+    NumberRow {
+        id: String::from("inbound_shipment_number_store_a"),
+        r#type: NumberRowType::InboundShipment,
+        store_id: "store_a".to_owned(),
+        value: 1000,
+    }
+}
+
+pub fn mock_outbound_shipment_number_store_a() -> NumberRow {
+    NumberRow {
+        id: String::from("outbound_shipment_number_store_a"),
+        r#type: NumberRowType::OutboundShipment,
+        store_id: "store_a".to_owned(),
+        value: 100,
+    }
+}
+
+pub fn mock_numbers() -> Vec<NumberRow> {
+    vec![
+        mock_inbound_shipment_number_store_a(),
+        mock_outbound_shipment_number_store_a(),
+    ]
+}

--- a/repository/src/schema/diesel_schema.rs
+++ b/repository/src/schema/diesel_schema.rs
@@ -219,8 +219,9 @@ table! {
 table! {
     number (id) {
         id -> Text,
-        value -> BigInt,
+        value -> Integer,
         store_id -> Text,
+        #[sql_name = "type"] type_ -> crate::schema::number::NumberRowTypeMapping,
     }
 }
 

--- a/repository/src/schema/diesel_schema.rs
+++ b/repository/src/schema/diesel_schema.rs
@@ -115,7 +115,7 @@ table! {
         id -> Text,
         name_id -> Text,
         store_id -> Text,
-        invoice_number -> Integer,
+        invoice_number -> BigInt,
         #[sql_name = "type"] type_ -> crate::schema::invoice::InvoiceRowTypeMapping,
         status -> crate::schema::invoice::InvoiceRowStatusMapping,
         on_hold -> Bool,
@@ -219,7 +219,7 @@ table! {
 table! {
     number (id) {
         id -> Text,
-        value -> Integer,
+        value -> BigInt,
         store_id -> Text,
         #[sql_name = "type"] type_ -> crate::schema::number::NumberRowTypeMapping,
     }

--- a/repository/src/schema/invoice.rs
+++ b/repository/src/schema/invoice.rs
@@ -26,7 +26,7 @@ pub struct InvoiceRow {
     pub id: String,
     pub name_id: String,
     pub store_id: String,
-    pub invoice_number: i32,
+    pub invoice_number: i64,
     #[column_name = "type_"]
     pub r#type: InvoiceRowType,
     pub status: InvoiceRowStatus,

--- a/repository/src/schema/mod.rs
+++ b/repository/src/schema/mod.rs
@@ -50,7 +50,7 @@ pub use master_list_line::MasterListLineRow;
 pub use master_list_name_join::MasterListNameJoinRow;
 pub use name::NameRow;
 pub use name_store_join::NameStoreJoinRow;
-pub use number::NumberRow;
+pub use number::{NumberRow, NumberRowType};
 pub use requisition::{RequisitionRow, RequisitionRowType};
 pub use requisition_line::RequisitionLineRow;
 pub use stock_line::StockLineRow;

--- a/repository/src/schema/number.rs
+++ b/repository/src/schema/number.rs
@@ -13,7 +13,7 @@ pub enum NumberRowType {
 #[table_name = "number"]
 pub struct NumberRow {
     pub id: String,
-    pub value: i32,
+    pub value: i64,
     /// Note, store id will be needed mainly for sync.
     pub store_id: String,
     // Table

--- a/repository/src/schema/number.rs
+++ b/repository/src/schema/number.rs
@@ -1,10 +1,22 @@
+use diesel_derive_enum::DbEnum;
+
 use super::diesel_schema::number;
+
+#[derive(DbEnum, Debug, Clone, PartialEq, Eq)]
+#[DbValueStyle = "SCREAMING_SNAKE_CASE"]
+pub enum NumberRowType {
+    InboundShipment,
+    OutboundShipment,
+}
 
 #[derive(Clone, Insertable, Queryable, Debug, PartialEq, Eq, AsChangeset)]
 #[table_name = "number"]
 pub struct NumberRow {
     pub id: String,
-    pub value: i64,
+    pub value: i32,
     /// Note, store id will be needed mainly for sync.
     pub store_id: String,
+    // Table
+    #[column_name = "type_"]
+    pub r#type: NumberRowType,
 }

--- a/repository/src/tests.rs
+++ b/repository/src/tests.rs
@@ -359,13 +359,17 @@ mod repository_test {
     }
 
     use crate::{
-        database_settings::get_storage_connection_manager, schema::InvoiceStatsRow, test_db,
-        CentralSyncBufferRepository, InvoiceLineRepository, InvoiceLineRowRepository,
+        database_settings::get_storage_connection_manager,
+        mock::{
+            mock_inbound_shipment_number_store_a, mock_outbound_shipment_number_store_a,
+            MockDataInserts,
+        },
+        schema::{InvoiceStatsRow, NumberRowType},
+        test_db, CentralSyncBufferRepository, InvoiceLineRepository, InvoiceLineRowRepository,
         InvoiceRepository, ItemRepository, MasterListLineRowRepository,
         MasterListNameJoinRepository, MasterListRowRepository, NameQueryRepository, NameRepository,
-        NumberRowRepository, OutboundShipmentRepository, RepositoryError,
-        RequisitionLineRepository, RequisitionRepository, StockLineRowRepository, StoreRepository,
-        UserAccountRepository,
+        NumberRowRepository, OutboundShipmentRepository, RequisitionLineRepository,
+        RequisitionRepository, StockLineRowRepository, StoreRepository, UserAccountRepository,
     };
     use domain::{
         name::{NameFilter, NameSort, NameSortField},
@@ -922,35 +926,28 @@ mod repository_test {
 
     #[actix_rt::test]
     async fn test_number() {
-        let settings = test_db::get_test_db_settings("omsupply-database-number");
-        test_db::setup(&settings).await;
-        let connection_manager = get_storage_connection_manager(&settings);
-        let connection = connection_manager.connection().unwrap();
+        let (_, connection, _, _) = test_db::setup_all("test_number", MockDataInserts::all()).await;
 
-        let name_1 = data::name_1();
-        NameRepository::new(&connection)
-            .upsert_one(&name_1)
-            .unwrap();
-        let store_1 = data::store_1();
-        StoreRepository::new(&connection)
-            .upsert_one(&store_1)
-            .unwrap();
-
-        let test_counter = "test_counter_name";
         let repo = NumberRowRepository::new(&connection);
-        matches!(
-            repo.find_one_by_id(test_counter),
-            Err(RepositoryError::NotFound)
-        );
 
-        let row = repo.increment(test_counter, &store_1.id).unwrap();
-        assert_eq!(1, row.value);
-        let row = repo.find_one_by_id(test_counter).unwrap().unwrap();
-        assert_eq!(1, row.value);
-        let row = repo.increment(test_counter, &store_1.id).unwrap();
-        assert_eq!(2, row.value);
-        let row = repo.find_one_by_id(test_counter).unwrap().unwrap();
-        assert_eq!(2, row.value);
+        let inbound_shipment_store_a_number = mock_inbound_shipment_number_store_a();
+        let outbound_shipment_store_b_number = mock_outbound_shipment_number_store_a();
+
+        let result = repo
+            .find_one_by_type_and_store(&NumberRowType::InboundShipment, "store_a")
+            .unwrap();
+        assert_eq!(result, Some(inbound_shipment_store_a_number));
+
+        let result = repo
+            .find_one_by_type_and_store(&NumberRowType::OutboundShipment, "store_a")
+            .unwrap();
+        assert_eq!(result, Some(outbound_shipment_store_b_number));
+
+        // Test not existing
+        let result = repo
+            .find_one_by_type_and_store(&NumberRowType::OutboundShipment, "store_b")
+            .unwrap();
+        assert_eq!(result, None);
     }
 
     #[cfg(test)]
@@ -978,7 +975,7 @@ mod repository_test {
                 ))
                 .unwrap();
 
-            for (count, line) in mock_data
+            for (count, line) in mock_data["base"]
                 .full_master_list
                 .get("master_list_master_list_line_filter_test")
                 .unwrap()

--- a/repository/src/tests.rs
+++ b/repository/src/tests.rs
@@ -368,9 +368,9 @@ mod repository_test {
         test_db, CentralSyncBufferRepository, InvoiceLineRepository, InvoiceLineRowRepository,
         InvoiceRepository, ItemRepository, MasterListLineRowRepository,
         MasterListNameJoinRepository, MasterListRowRepository, NameQueryRepository, NameRepository,
-        NumberRowRepository, OutboundShipmentRepository, RepositoryError,
-        RequisitionLineRepository, RequisitionRepository, StockLineRepository,
-        StockLineRowRepository, StoreRepository, UserAccountRepository,
+        NumberRowRepository, OutboundShipmentRepository, RequisitionLineRepository,
+        RequisitionRepository, StockLineRepository, StockLineRowRepository, StoreRepository,
+        UserAccountRepository,
     };
     use chrono::Duration;
     use domain::{

--- a/server/tests/graphql/master_lists.rs
+++ b/server/tests/graphql/master_lists.rs
@@ -90,7 +90,7 @@ mod graphql {
         // TODO would prefer for loaders to be using service provider
         // in which case we would override both item and master list line service
         // and test it's mapping here, rather then from mock data
-        let mock_data_lines = &mock_data
+        let mock_data_lines = &mock_data["base"]
             .full_master_list
             .get("master_list_master_list_line_filter_test")
             .unwrap()

--- a/server/tests/graphql/outbound_shipment_insert.rs
+++ b/server/tests/graphql/outbound_shipment_insert.rs
@@ -2,7 +2,10 @@
 
 mod graphql {
     use crate::graphql::assert_gql_query;
-    use repository::{mock::MockDataInserts, InvoiceRepository};
+    use repository::{
+        mock::{mock_outbound_shipment_number_store_a, MockDataInserts},
+        InvoiceRepository,
+    };
     use serde_json::json;
     use server::test_utils::setup_all;
 
@@ -16,6 +19,8 @@ mod graphql {
 
         let other_party_supplier = &mock_data["base"].names[2];
         let other_party_customer = &mock_data["base"].names[0];
+
+        let starting_invoice_number = mock_outbound_shipment_number_store_a().value;
 
         let query = r#"mutation InsertOutboundShipment($input: InsertOutboundShipmentInput!) {
             insertOutboundShipment(input: $input) {
@@ -32,6 +37,7 @@ mod graphql {
                 ... on InvoiceNode {
                     id
                     otherPartyId
+                    invoiceNumber
                     type
                     comment
                     theirReference
@@ -99,6 +105,7 @@ mod graphql {
         let expected = json!({
             "insertOutboundShipment": {
               "id": "ci_insert_1",
+              "invoiceNumber": starting_invoice_number+1,
               "otherPartyId": other_party_customer.id,
               "type": "OUTBOUND_SHIPMENT",
               "comment": "ci comment",
@@ -127,6 +134,7 @@ mod graphql {
         let expected = json!({
             "insertOutboundShipment": {
               "id": "ci_insert_2",
+              "invoiceNumber": starting_invoice_number+2,
               "otherPartyId": other_party_customer.id,
               "type": "OUTBOUND_SHIPMENT",
               "comment": null,

--- a/service/src/number.rs
+++ b/service/src/number.rs
@@ -8,7 +8,7 @@ pub fn next_number(
     connection: &StorageConnection,
     r#type: &NumberRowType,
     store_id: &str,
-) -> Result<i32, RepositoryError> {
+) -> Result<i64, RepositoryError> {
     // Should be done in transaction
     let next_number = connection.transaction_sync(|connection_tx| {
         let repo = NumberRowRepository::new(&connection_tx);

--- a/service/src/number.rs
+++ b/service/src/number.rs
@@ -1,19 +1,17 @@
 use repository::{
     schema::{NumberRow, NumberRowType},
-    NumberRowRepository, RepositoryError,
+    NumberRowRepository, RepositoryError, StorageConnection,
 };
 use util::uuid::uuid;
 
-use crate::service_provider::ServiceContext;
-
 pub fn next_number(
-    ctx: &ServiceContext,
+    connection: &StorageConnection,
     r#type: &NumberRowType,
     store_id: &str,
-) -> Result<i64, RepositoryError> {
+) -> Result<i32, RepositoryError> {
     // Should be done in transaction
-    let next_number = ctx.transaction(|ctx| {
-        let repo = NumberRowRepository::new(&ctx.connection);
+    let next_number = connection.transaction_sync(|connection_tx| {
+        let repo = NumberRowRepository::new(&connection_tx);
 
         let updated_number_row = match repo.find_one_by_type_and_store(r#type, store_id)? {
             Some(mut row) => {
@@ -37,4 +35,45 @@ pub fn next_number(
         Ok(updated_number_row.value)
     })?;
     Ok(next_number)
+}
+
+#[cfg(test)]
+mod test {
+    use repository::{
+        mock::{
+            mock_inbound_shipment_number_store_a, mock_outbound_shipment_number_store_a,
+            MockDataInserts,
+        },
+        schema::NumberRowType,
+        test_db::setup_all,
+    };
+
+    use crate::number::next_number;
+
+    #[actix_rt::test]
+    async fn test_number_service() {
+        let (_, connection, _, _) = setup_all("test_number_service", MockDataInserts::all()).await;
+
+        let inbound_shipment_store_a_number = mock_inbound_shipment_number_store_a();
+        let outbound_shipment_store_b_number = mock_outbound_shipment_number_store_a();
+
+        // Test existing
+
+        let result = next_number(&connection, &NumberRowType::InboundShipment, "store_a").unwrap();
+        assert_eq!(result, inbound_shipment_store_a_number.value + 1);
+
+        let result = next_number(&connection, &NumberRowType::InboundShipment, "store_a").unwrap();
+        assert_eq!(result, inbound_shipment_store_a_number.value + 2);
+
+        let result = next_number(&connection, &NumberRowType::OutboundShipment, "store_a").unwrap();
+        assert_eq!(result, outbound_shipment_store_b_number.value + 1);
+
+        // Test new
+
+        let result = next_number(&connection, &NumberRowType::OutboundShipment, "store_b").unwrap();
+        assert_eq!(result, 1);
+
+        let result = next_number(&connection, &NumberRowType::OutboundShipment, "store_b").unwrap();
+        assert_eq!(result, 2);
+    }
 }


### PR DESCRIPTION
Closes #657 

Sorry a few changes from the original implementation.

* Added type to number row (want to be type strict, and avoid concatenating string to identify database entities). This made id a uuid, in previous repo test "test_counter_name" would only work for one store, as the id wouldn't be unique across stores (although it was tested with store_id)
* Ended up relocating number logic to service, I thought it was too much logic in repo (including transaction logic), I feel like the logic is responsibility of service.
* Added number logic to both inbound and outbound shipments.

Really wanted to make number service accept ServiceContext, and went a fair way down that track (ServiceContext would have transaction method, which is really a one liner), but it required quite a lot of changes to the inbound/outbound insert services (especially when they are used in batch), so refrained, but i think all services should use ServiceContext and it should have transaction method (closure gets ServiceContext ref as param)

Didn't end up doing queries for inbound and outbound (where invoice number is the parameters), thought to keep PR to scope (I think i already went over the scope)