### PR TITLE
664 fix unallocated line for item already exists in invoice error criteria

### DIFF
--- a/repository/src/mock/test_unallocated_line.rs
+++ b/repository/src/mock/test_unallocated_line.rs
@@ -11,8 +11,12 @@ pub fn mock_test_unallocated_line() -> MockData {
     result
         .invoices
         .push(mock_new_invoice_with_unallocated_line());
+    result
+        .invoices
+        .push(mock_new_invoice_with_unallocated_line2());
     result.invoices.push(mock_allocated_invoice());
     result.invoice_lines.push(mock_unallocated_line());
+    result.invoice_lines.push(mock_unallocated_line2());
     result
 }
 
@@ -44,6 +48,52 @@ pub fn mock_unallocated_line() -> InvoiceLineRow {
         item_id: "item_a".to_owned(),
         item_name: "Item A".to_owned(),
         item_code: "item_a_code".to_owned(),
+        stock_line_id: None,
+        location_id: None,
+        batch: None,
+        expiry_date: None,
+        pack_size: 1,
+        cost_price_per_pack: 0.0,
+        sell_price_per_pack: 0.0,
+        total_before_tax: 0.0,
+        total_after_tax: 0.0,
+        tax: None,
+        r#type: InvoiceLineRowType::UnallocatedStock,
+        number_of_packs: 1,
+        note: None,
+    }
+}
+
+// Used to test successfull insert where another invoice has row with the item id in unallocated line
+// to make sure filtering for `UnallocatedLineForItemAlreadyExistsInInvoice` is done for invoice (not globally)
+pub fn mock_new_invoice_with_unallocated_line2() -> InvoiceRow {
+    InvoiceRow {
+        id: "unallocated_line_new_invoice2".to_owned(),
+        name_id: "name_store_a".to_owned(),
+        store_id: "store_a".to_owned(),
+        invoice_number: 2,
+        r#type: InvoiceRowType::OutboundShipment,
+        status: InvoiceRowStatus::New,
+        on_hold: false,
+        comment: None,
+        their_reference: None,
+        created_datetime: NaiveDate::from_ymd(1970, 1, 5).and_hms_milli(15, 30, 0, 0),
+        allocated_datetime: None,
+        picked_datetime: None,
+        shipped_datetime: None,
+        delivered_datetime: None,
+        verified_datetime: None,
+        color: None,
+    }
+}
+
+pub fn mock_unallocated_line2() -> InvoiceLineRow {
+    InvoiceLineRow {
+        id: "unallocated_line_new_invoice2_line_1".to_owned(),
+        invoice_id: "unallocated_line_new_invoice2".to_owned(),
+        item_id: "item_b".to_owned(),
+        item_name: "Item B".to_owned(),
+        item_code: "item_b_code".to_owned(),
         stock_line_id: None,
         location_id: None,
         batch: None,

--- a/server/tests/graphql/outbound_shipment_update.rs
+++ b/server/tests/graphql/outbound_shipment_update.rs
@@ -3,7 +3,7 @@
 mod graphql {
     use crate::graphql::assert_gql_query;
     use repository::{
-        mock::{MockDataInserts, mock_unallocated_line_new_invoice},
+        mock::{MockDataInserts, mock_new_invoice_with_unallocated_line},
         schema::{InvoiceLineRow, StockLineRow},
         InvoiceLineRowRepository, StockLineRowRepository,
     };
@@ -152,7 +152,7 @@ mod graphql {
         // CanOnlyChangeToAllocatedWhenNoUnallocatedLines
         let variables = Some(json!({
           "input": {
-            "id": mock_unallocated_line_new_invoice().id.clone(),
+            "id": mock_new_invoice_with_unallocated_line().id.clone(),
             "status": "ALLOCATED"
           }
         }));

--- a/service/src/invoice_line/outbound_shipment_unallocated_line/delete.rs
+++ b/service/src/invoice_line/outbound_shipment_unallocated_line/delete.rs
@@ -61,10 +61,7 @@ impl From<RepositoryError> for DeleteOutboundShipmentUnallocatedLineError {
 mod test_delete {
 
     use repository::{
-        mock::{
-            mock_outbound_shipment_a_invoice_lines, mock_unallocated_line_new_invoice_line_1,
-            MockDataInserts,
-        },
+        mock::{mock_outbound_shipment_a_invoice_lines, MockDataInserts, mock_unallocated_line},
         test_db::setup_all,
         InvoiceLineRowRepository, RepositoryError,
     };
@@ -119,7 +116,7 @@ mod test_delete {
         let context = service_provider.context().unwrap();
         let service = service_provider.outbound_shipment_line;
 
-        let mut line_to_delete = mock_unallocated_line_new_invoice_line_1();
+        let mut line_to_delete = mock_unallocated_line();
         // Succesfull delete
         let result = service
             .delete_outbound_shipment_unallocated_line(

--- a/service/src/invoice_line/outbound_shipment_unallocated_line/update.rs
+++ b/service/src/invoice_line/outbound_shipment_unallocated_line/update.rs
@@ -82,10 +82,7 @@ impl From<RepositoryError> for UpdateOutboundShipmentUnallocatedLineError {
 mod test_update {
 
     use repository::{
-        mock::{
-            mock_outbound_shipment_a_invoice_lines, mock_unallocated_line_new_invoice_line_1,
-            MockDataInserts,
-        },
+        mock::{mock_outbound_shipment_a_invoice_lines, mock_unallocated_line, MockDataInserts},
         test_db::setup_all,
         InvoiceLineRowRepository,
     };
@@ -142,7 +139,7 @@ mod test_update {
         let context = service_provider.context().unwrap();
         let service = service_provider.outbound_shipment_line;
 
-        let mut line_to_update = mock_unallocated_line_new_invoice_line_1();
+        let mut line_to_update = mock_unallocated_line();
         // Succesfull update
         let result = service
             .update_outbound_shipment_unallocated_line(


### PR DESCRIPTION
As per: https://github.com/openmsupply/remote-server/pull/668#discussion_r773434184, plus test compilation fix