### PR TITLE
667 add uallocated line insert graphql

### DIFF
--- a/graphql/src/schema/mutations/mod.rs
+++ b/graphql/src/schema/mutations/mod.rs
@@ -143,6 +143,14 @@ impl Mutations {
         get_delete_outbound_shipment_service_line_response(connection_manager, input)
     }
 
+    async fn insert_outbound_shipment_unallocated_line(
+        &self,
+        ctx: &Context<'_>,
+        input: InsertOutboundShipmentUnallocatedLineInput,
+    ) -> Result<InsertOutboundShipmentUnallocatedLineResponse> {
+        insert_outbound_shipment_unallocated_line(ctx, input)
+    }
+
     async fn insert_inbound_shipment(
         &self,
         ctx: &Context<'_>,

--- a/graphql/src/schema/mutations/outbound_shipment/mod.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/mod.rs
@@ -4,6 +4,7 @@ mod error;
 mod insert;
 mod line;
 mod service_line;
+mod unallocated_line;
 mod update;
 
 pub use batch::*;
@@ -12,4 +13,5 @@ pub use error::*;
 pub use insert::*;
 pub use line::*;
 pub use service_line::*;
+pub use unallocated_line::*;
 pub use update::*;

--- a/graphql/src/schema/mutations/outbound_shipment/unallocated_line/insert.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/unallocated_line/insert.rs
@@ -1,0 +1,122 @@
+use async_graphql::*;
+use service::invoice_line::{
+    InsertOutboundShipmentUnallocatedLine as ServiceInput,
+    InsertOutboundShipmentUnallocatedLineError as ServiceError,
+};
+
+use crate::{
+    schema::{
+        mutations::{ForeignKey, ForeignKeyError},
+        types::InvoiceLineNode,
+    },
+    standard_graphql_error::StandardGraphqlError,
+    ContextExt,
+};
+
+#[derive(InputObject)]
+pub struct InsertOutboundShipmentUnallocatedLineInput {
+    pub id: String,
+    pub invoice_id: String,
+    pub item_id: String,
+    pub quantity: u32,
+}
+
+use InsertOutboundShipmentUnallocatedLineInput as Input;
+
+#[derive(Interface)]
+#[graphql(field(name = "description", type = "String"))]
+pub enum InsertOutboundShipmentUnallocatedLineInterface {
+    ForeignKeyError(ForeignKeyError),
+    UnallocatedLinesOnlyEditableInNewInvoice(UnallocatedLinesOnlyEditableInNewInvoice),
+    UnallocatedLineForItemAlreadyExists(UnallocatedLineForItemAlreadyExists),
+}
+
+use InsertOutboundShipmentUnallocatedLineInterface as ErrorInterface;
+
+#[derive(SimpleObject)]
+pub struct InsertOutboundShipmentUnallocatedLineError {
+    pub error: ErrorInterface,
+}
+
+use InsertOutboundShipmentUnallocatedLineError as Error;
+
+#[derive(Union)]
+pub enum InsertOutboundShipmentUnallocatedLineResponse {
+    Error(Error),
+    Response(InvoiceLineNode),
+}
+
+use InsertOutboundShipmentUnallocatedLineResponse as Response;
+
+use super::{UnallocatedLineForItemAlreadyExists, UnallocatedLinesOnlyEditableInNewInvoice};
+
+impl From<Input> for ServiceInput {
+    fn from(
+        Input {
+            id,
+            invoice_id,
+            item_id,
+            quantity,
+        }: Input,
+    ) -> Self {
+        ServiceInput {
+            id,
+            invoice_id,
+            item_id,
+            quantity,
+        }
+    }
+}
+
+pub fn insert_outbound_shipment_unallocated_line(
+    ctx: &Context<'_>,
+    input: Input,
+) -> Result<Response> {
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.context()?;
+
+    let response = match service_provider
+        .outbound_shipment_line
+        .insert_outbound_shipment_unallocated_line(&service_context, input.into())
+    {
+        Ok(invoice_line) => Response::Response(invoice_line.into()),
+        Err(error) => Response::Error(Error {
+            error: map_error(error)?,
+        }),
+    };
+
+    Ok(response)
+}
+
+pub fn map_error(error: ServiceError) -> Result<ErrorInterface> {
+    use StandardGraphqlError::*;
+    let formatted_error = format!("{:#?}", error);
+
+    let graphql_error = match error {
+        // Structured Errors
+        ServiceError::InvoiceDoesNotExist => {
+            return Ok(ErrorInterface::ForeignKeyError(ForeignKeyError(
+                ForeignKey::InvoiceId,
+            )))
+        }
+        ServiceError::CanOnlyAddLinesToNewOutboundShipment => {
+            return Ok(ErrorInterface::UnallocatedLinesOnlyEditableInNewInvoice(
+                UnallocatedLinesOnlyEditableInNewInvoice {},
+            ))
+        }
+        ServiceError::UnallocatedLineForItemAlreadyExistsInInvoice => {
+            return Ok(ErrorInterface::UnallocatedLineForItemAlreadyExists(
+                UnallocatedLineForItemAlreadyExists {},
+            ))
+        }
+        // Standard Graphql Errors
+        ServiceError::LineAlreadyExists => BadUserInput(formatted_error),
+        ServiceError::NotAnOutboundShipment => BadUserInput(formatted_error),
+        ServiceError::ItemNotFound => BadUserInput(formatted_error),
+        ServiceError::NotAStockItem => BadUserInput(formatted_error),
+        ServiceError::NewlyCreatedLineDoesNotExist => InternalError(formatted_error),
+        ServiceError::DatabaseError(_) => InternalError(formatted_error),
+    };
+
+    Err(graphql_error.extend())
+}

--- a/graphql/src/schema/mutations/outbound_shipment/unallocated_line/mod.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/unallocated_line/mod.rs
@@ -1,0 +1,20 @@
+use async_graphql::*;
+
+mod insert;
+pub use insert::*;
+
+pub struct UnallocatedLinesOnlyEditableInNewInvoice;
+#[Object]
+impl UnallocatedLinesOnlyEditableInNewInvoice {
+    pub async fn description(&self) -> &'static str {
+        "Can only insert or edit unallocated lines in new invoice"
+    }
+}
+
+pub struct UnallocatedLineForItemAlreadyExists;
+#[Object]
+impl UnallocatedLineForItemAlreadyExists {
+    pub async fn description(&self) -> &'static str {
+        "Unallocated line already exists for this item"
+    }
+}

--- a/graphql/src/schema/types/invoice_line.rs
+++ b/graphql/src/schema/types/invoice_line.rs
@@ -43,6 +43,9 @@ impl InvoiceLineNode {
     pub async fn id(&self) -> &str {
         &self.invoice_line.id
     }
+    pub async fn invoice_id(&self) -> &str {
+        &self.invoice_line.invoice_id
+    }
     pub async fn item_id(&self) -> &str {
         &self.invoice_line.item_id
     }

--- a/graphql/src/standard_graphql_error.rs
+++ b/graphql/src/standard_graphql_error.rs
@@ -24,14 +24,11 @@ pub enum StandardGraphqlError {
 impl ErrorExtensions for StandardGraphqlError {
     // lets define our base extensions
     fn extend(self) -> async_graphql::Error {
-        async_graphql::Error::new(format!("{}", self)).extend_with(|_, e| {
-            e.set("code", format!("{:?}", self));
-            match self {
-                StandardGraphqlError::InternalError(details) => e.set("details", details),
-                StandardGraphqlError::BadUserInput(details) => e.set("details", details),
-                StandardGraphqlError::Unauthenticated(details) => e.set("details", details),
-                StandardGraphqlError::Forbidden(details) => e.set("details", details),
-            }
+        async_graphql::Error::new(format!("{}", self)).extend_with(|_, e| match self {
+            StandardGraphqlError::InternalError(details) => e.set("details", details),
+            StandardGraphqlError::BadUserInput(details) => e.set("details", details),
+            StandardGraphqlError::Unauthenticated(details) => e.set("details", details),
+            StandardGraphqlError::Forbidden(details) => e.set("details", details),
         })
     }
 }

--- a/server/tests/graphql/mod.rs
+++ b/server/tests/graphql/mod.rs
@@ -210,7 +210,7 @@ macro_rules! assert_standard_graphql_error {
                 }]
             }
         );
-
+        // Inclusive means only match fields in rhs against lhs (lhs can have more fields)
         let config = assert_json_diff::Config::new(assert_json_diff::CompareMode::Inclusive);
 
         match assert_json_diff::assert_json_matches_no_panic(

--- a/server/tests/graphql/mod.rs
+++ b/server/tests/graphql/mod.rs
@@ -38,6 +38,7 @@ mod outbound_shipment_line_update;
 mod outbound_shipment_update;
 mod pagination;
 mod requisition;
+mod unallocated_line;
 
 pub async fn get_gql_result<IN, OUT>(settings: &Settings, query: IN) -> OUT
 where
@@ -168,6 +169,7 @@ fn assert_gql_no_response_error(value: &serde_json::Value) {
     }
 }
 
+// TODO rename to assert_structured_error
 async fn assert_gql_query(
     settings: &Settings,
     query: &str,
@@ -185,6 +187,52 @@ async fn assert_gql_query(
     assert_json_eq!(&actual, expected_with_data);
     actual
 }
+
+macro_rules! assert_standard_graphql_error {
+    // expected_etensions should be an Option<serde_json::json>>
+    ($settings:expr, $query:expr, $variables:expr, $expected_message:expr, $expected_extensions:expr, $service_provider_override:expr) => {{
+        let actual = crate::graphql::run_gql_query(
+            $settings,
+            $query,
+            $variables,
+            $service_provider_override
+        )
+        .await;
+
+        let expected_with_message = serde_json::json!(
+            {
+                "data": null,
+                "errors": [{
+                    "message": $expected_message,
+                    // Need to check that extensions are indeed present,
+                    // and if expected_extensions is not, None check content of extensions
+                    "extensions": $expected_extensions.unwrap_or(serde_json::json!({}))
+                }]
+            }
+        );
+
+        let config = assert_json_diff::Config::new(assert_json_diff::CompareMode::Inclusive);
+
+        match assert_json_diff::assert_json_matches_no_panic(
+            &actual,
+            &expected_with_message,
+            config,
+        ) {
+            Ok(_) => assert!(true),
+            Err(error) => {
+                panic!(
+                    "\n{}\n**actual**\n{}\n**expected**\n{}\n**query**\n{}",
+                    error,
+                    serde_json::to_string_pretty(&actual).unwrap(),
+                    serde_json::to_string_pretty(&expected_with_message).unwrap(),
+                    $query
+                );
+            }
+        }
+    }};
+}
+
+pub(crate) use assert_standard_graphql_error;
 
 use chrono::{DateTime as ChronoDateTime, NaiveDate, Utc};
 use graphql_client::GraphQLQuery;

--- a/server/tests/graphql/mod.rs
+++ b/server/tests/graphql/mod.rs
@@ -169,7 +169,7 @@ fn assert_gql_no_response_error(value: &serde_json::Value) {
     }
 }
 
-// TODO rename to assert_structured_error
+// TODO https://github.com/openmsupply/remote-server/issues/682
 async fn assert_gql_query(
     settings: &Settings,
     query: &str,

--- a/server/tests/graphql/unallocated_line/insert.rs
+++ b/server/tests/graphql/unallocated_line/insert.rs
@@ -1,0 +1,278 @@
+mod graphql {
+    use crate::graphql::{assert_gql_query, assert_standard_graphql_error};
+    use domain::invoice_line::{InvoiceLine, InvoiceLineType};
+    use repository::{mock::MockDataInserts, StorageConnectionManager};
+    use serde_json::json;
+    use server::test_utils::setup_all;
+    use service::{
+        invoice_line::{
+            InsertOutboundShipmentUnallocatedLine as ServiceInput,
+            InsertOutboundShipmentUnallocatedLineError as ServiceError,
+            OutboundShipmentLineServiceTrait,
+        },
+        service_provider::{ServiceContext, ServiceProvider},
+    };
+
+    type InsertLineMethod = dyn Fn(ServiceInput) -> Result<InvoiceLine, ServiceError> + Sync + Send;
+
+    pub struct TestService(pub Box<InsertLineMethod>);
+
+    impl OutboundShipmentLineServiceTrait for TestService {
+        fn insert_outbound_shipment_unallocated_line(
+            &self,
+            _: &ServiceContext,
+            input: ServiceInput,
+        ) -> Result<InvoiceLine, ServiceError> {
+            self.0(input)
+        }
+    }
+
+    fn service_provider(
+        test_service: TestService,
+        connection_manager: &StorageConnectionManager,
+    ) -> ServiceProvider {
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
+        service_provider.outbound_shipment_line = Box::new(test_service);
+        service_provider
+    }
+
+    fn empty_variables() -> serde_json::Value {
+        json!({
+          "input": {
+            "id": "n/a",
+            "invoiceId": "n/a",
+            "itemId": "n/a",
+            "quantity": 0,
+          }
+        })
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_insert_unallocated_structured_errors() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_insert_unallocated_line_structured_errors",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($input: InsertOutboundShipmentUnallocatedLineInput!) {
+            insertOutboundShipmentUnallocatedLine(input: $input) {
+              ... on InsertOutboundShipmentUnallocatedLineError {
+                error {
+                  __typename
+                }
+              }
+            }
+          }
+        "#;
+
+        // UnallocatedLinesOnlyEditableInNewInvoice
+        let test_service = TestService(Box::new(|_| {
+            Err(ServiceError::CanOnlyAddLinesToNewOutboundShipment)
+        }));
+
+        let expected = json!({
+            "insertOutboundShipmentUnallocatedLine": {
+              "error": {
+                "__typename": "UnallocatedLinesOnlyEditableInNewInvoice"
+              }
+            }
+          }
+        );
+
+        assert_gql_query(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager)),
+        )
+        .await;
+
+        // UnallocatedLineForItemAlreadyExists
+        let test_service = TestService(Box::new(|_| {
+            Err(ServiceError::UnallocatedLineForItemAlreadyExistsInInvoice)
+        }));
+
+        let expected = json!({
+            "insertOutboundShipmentUnallocatedLine": {
+              "error": {
+                "__typename": "UnallocatedLineForItemAlreadyExists"
+              }
+            }
+          }
+        );
+
+        assert_gql_query(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager)),
+        )
+        .await;
+
+        // ForeignKeyError (invoice does not exists)
+        let mutation = r#"
+        mutation ($input: InsertOutboundShipmentUnallocatedLineInput!) {
+            insertOutboundShipmentUnallocatedLine(input: $input) {
+                ... on InsertOutboundShipmentUnallocatedLineError {
+                    error {
+                    __typename
+                    ... on ForeignKeyError {
+                        key
+                    }
+                    }
+                }
+            }
+        }
+        "#;
+
+        let test_service = TestService(Box::new(|_| Err(ServiceError::InvoiceDoesNotExist)));
+
+        let expected = json!({
+            "insertOutboundShipmentUnallocatedLine": {
+              "error": {
+                "__typename": "ForeignKeyError",
+                "key": "invoiceId"
+              }
+            }
+          }
+        );
+        assert_gql_query(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager)),
+        )
+        .await;
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_insert_unallocated_standard_errors() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_insert_unallocated_line_standard_errors",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($input: InsertOutboundShipmentUnallocatedLineInput!) {
+            insertOutboundShipmentUnallocatedLine(input: $input) {
+                __typename
+            }
+          }
+        "#;
+
+        // LineAlreadyExists
+        let test_service = TestService(Box::new(|_| Err(ServiceError::LineAlreadyExists)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+        // NotAnOutboundShipment
+        let test_service = TestService(Box::new(|_| Err(ServiceError::NotAnOutboundShipment)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+        // ItemNotFound
+        let test_service = TestService(Box::new(|_| Err(ServiceError::ItemNotFound)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+        // NotAStockItem
+        let test_service = TestService(Box::new(|_| Err(ServiceError::NotAStockItem)));
+        let expected_message = "Bad user input";
+        let expected_extensions =
+            json!({ "details": format!("{:#?}", ServiceError::NotAStockItem) });
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            Some(expected_extensions),
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+
+    fn successfull_invoice_line() -> InvoiceLine {
+        InvoiceLine {
+            id: "test_id".to_owned(),
+            invoice_id: "invoice_id".to_owned(),
+            item_id: "item_id".to_owned(),
+            item_name: "item_name".to_owned(),
+            item_code: "item_code".to_owned(),
+            r#type: InvoiceLineType::UnallocatedStock,
+            pack_size: 1,
+            number_of_packs: 2,
+            cost_price_per_pack: 0.0,
+            sell_price_per_pack: 0.0,
+            batch: None,
+            expiry_date: None,
+            note: None,
+            stock_line_id: None,
+            location_id: None,
+            location_name: None,
+        }
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_insert_unallocated_line_success() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_insert_unallocated_line_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($input: InsertOutboundShipmentUnallocatedLineInput!) {
+            insertOutboundShipmentUnallocatedLine(input: $input) {
+                ... on InvoiceLineNode {
+                    id
+                    invoiceId
+                    itemName
+                }
+            }
+          }
+        "#;
+
+        // Record Already Exists
+        let test_service = TestService(Box::new(|_| Ok(successfull_invoice_line())));
+        let out_line = successfull_invoice_line();
+        let expected = json!({
+            "insertOutboundShipmentUnallocatedLine": {
+                "id": out_line.id,
+                "invoiceId": out_line.invoice_id,
+                "itemName": out_line.item_name
+            }
+          }
+        );
+        assert_gql_query(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager)),
+        )
+        .await;
+    }
+}

--- a/server/tests/graphql/unallocated_line/mod.rs
+++ b/server/tests/graphql/unallocated_line/mod.rs
@@ -1,0 +1,1 @@
+mod insert;


### PR DESCRIPTION
Fixes: #667 

* Removed 'code' from error extensions, this changes:
* 
**from**
```json
"extensions": {
        "code": "BadUserInput(\"NotAStockItem\")",
        "details": "NotAStockItem"
}
```
**to**
```json
"extensions": {
        "details": "NotAStockItem"
}
```
standard graphql error already has "Bad user input" in the 'message' field

Noticed that `extend` must be called in order for details to be present in error output (not sure if this is called in other standard error outputs):
https://github.com/openmsupply/remote-server/blob/66b8f22e6459b17bacdbfb88fabd98f9c4ec4913/graphql/src/schema/mutations/outbound_shipment/unallocated_line/insert.rs#L121

Created helper for `assert_standard_graphql_error`, I've made it a macro (to locate the error quickly) and made sure it return all required info when error happens. I remember during the initial helper implementation I've asked for more information to be present if errors in test occur, this was issue for me and i think for Clemens (since I've noticed a commit of commented println present in `assert_gql_query`). In a seperate PR I'll make `assert_graphql_query` a macro with improved verbose. https://github.com/openmsupply/remote-server/issues/682

Only one example of testing the extensions of the error, this can be easily done for all of the bad input tests in that file, but wanted to show that we can be flexible on that front (to reduce overhead):

https://github.com/openmsupply/remote-server/blob/956898a06ba6ed062627f159d436d6d111ed3da0/server/tests/graphql/unallocated_line/insert.rs#L203-L214

**vs**

https://github.com/openmsupply/remote-server/blob/956898a06ba6ed062627f159d436d6d111ed3da0/server/tests/graphql/unallocated_line/insert.rs#L192-L201

I've put the test in a folder, since I think service/tests/graphql is becoming hard to navigate (tests should just be grouped in folders by type)



