### PR TITLE
Android java bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "android"
+version = "0.1.0"
+dependencies = [
+ "jni",
+ "repository",
+ "server",
+ "tokio 0.2.25",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +964,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1015,16 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b2f5d0ee456f3928812dfc8c6d9a1d592b98678f6d56db9b0cd2b7bc6c8db5"
+dependencies = [
+ "bytes 1.1.0",
+ "memchr",
 ]
 
 [[package]]
@@ -1695,7 +1721,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5613c31f18676f164112732202124f373bb2103ff017b3b85ca954ea6a66ada"
 dependencies = [
- "combine",
+ "combine 3.8.1",
  "failure",
 ]
 
@@ -2045,6 +2071,26 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine 4.6.2",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
@@ -2544,6 +2590,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "openssl-src"
+version = "300.0.4+3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e1c6b4549e24182b9d7aa268f645414888a69daf44c7b2d8118da8e7b23e7"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,6 +2607,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -3083,6 +3139,15 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -4000,6 +4065,17 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2612,6 +2612,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "openssl-src"
+version = "300.0.4+3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e1c6b4549e24182b9d7aa268f645414888a69daf44c7b2d8118da8e7b23e7"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,6 +2629,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2612,15 +2612,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
-name = "openssl-src"
-version = "300.0.4+3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e1c6b4549e24182b9d7aa268f645414888a69daf44c7b2d8118da8e7b23e7"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2629,7 +2620,6 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,8 +388,10 @@ dependencies = [
  "android_logger",
  "jni",
  "log",
+ "once_cell",
  "repository",
  "server",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -2573,9 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "opaque-debug"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,10 +384,30 @@ dependencies = [
 name = "android"
 version = "0.1.0"
 dependencies = [
+ "actix-web",
+ "android_logger",
  "jni",
+ "log",
  "repository",
  "server",
- "tokio 0.2.25",
+]
+
+[[package]]
+name = "android_log-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85965b6739a430150bdd138e2374a98af0c3ee0d030b3bb7fc3bddff58d0102e"
+
+[[package]]
+name = "android_logger"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9ed09b18365ed295d722d0b5ed59c01b79a826ff2d2a8f73d5ecca8e6fb2f66"
+dependencies = [
+ "android_log-sys",
+ "env_logger",
+ "lazy_static",
+ "log",
 ]
 
 [[package]]
@@ -1897,7 +1917,7 @@ dependencies = [
  "serde 1.0.130",
  "serde_json",
  "serde_regex",
- "tokio 1.13.0",
+ "tokio 1.15.0",
 ]
 
 [[package]]
@@ -1947,7 +1967,7 @@ dependencies = [
  "itoa",
  "pin-project-lite 0.2.7",
  "socket2 0.4.2",
- "tokio 1.13.0",
+ "tokio 1.15.0",
  "tower-service",
  "tracing",
  "want",
@@ -3748,18 +3768,17 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
- "autocfg",
  "libc",
  "mio 0.7.14",
  "num_cpus",
  "once_cell",
  "pin-project-lite 0.2.7",
  "signal-hook-registry",
- "tokio-macros 1.5.1",
+ "tokio-macros 1.7.0",
  "winapi 0.3.9",
 ]
 
@@ -3776,9 +3795,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 [workspace]
 
 members = [
+    "android",
     "domain",
     "repository",
     "graphql",

--- a/android/Cargo.toml
+++ b/android/Cargo.toml
@@ -12,8 +12,10 @@ name = "remote_server_android"
 repository = { path = "../repository" }
 server = { path = "../server" }
 
-jni = { version = "0.19.0"}
 actix-web = { version= "3.3.2", features = ["openssl"] } # Versions >=v4 depend on Tokio v1.
+android_logger = "0.10.1"
+jni = { version = "0.19.0"}
+log = "0.4.14"
 
 [features]
 default = ["repository/sqlite"]

--- a/android/Cargo.toml
+++ b/android/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "android"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+path = "src/lib.rs"
+name = "remote_server_android"
+
+[dependencies]
+repository = { path = "../repository" }
+server = { path = "../server" }
+
+jni = { version = "0.19.0"}
+tokio = { version = "0.2", features = ["macros" ] } # Bumping to v1 requires actix-web >=v4 and reqwest >=0.11.
+
+[features]
+default = ["repository/sqlite"]
+postgres = ["repository/postgres"]

--- a/android/Cargo.toml
+++ b/android/Cargo.toml
@@ -20,5 +20,4 @@ once_cell = "1.9.0"
 tokio = { version = "0.2", features = ["macros" ] } # Bumping to v1 requires actix-web >=v4 and reqwest >=0.11.
 
 [features]
-default = ["repository/sqlite"]
-postgres = ["repository/postgres"]
+default = ["repository/sqlite", "server/android"]

--- a/android/Cargo.toml
+++ b/android/Cargo.toml
@@ -13,7 +13,7 @@ repository = { path = "../repository" }
 server = { path = "../server" }
 
 jni = { version = "0.19.0"}
-tokio = { version = "0.2", features = ["macros" ] } # Bumping to v1 requires actix-web >=v4 and reqwest >=0.11.
+actix-web = { version= "3.3.2", features = ["openssl"] } # Versions >=v4 depend on Tokio v1.
 
 [features]
 default = ["repository/sqlite"]

--- a/android/Cargo.toml
+++ b/android/Cargo.toml
@@ -16,6 +16,8 @@ actix-web = { version= "3.3.2", features = ["openssl"] } # Versions >=v4 depend 
 android_logger = "0.10.1"
 jni = { version = "0.19.0"}
 log = "0.4.14"
+once_cell = "1.9.0"
+tokio = { version = "0.2", features = ["macros" ] } # Bumping to v1 requires actix-web >=v4 and reqwest >=0.11.
 
 [features]
 default = ["repository/sqlite"]

--- a/android/host.sh
+++ b/android/host.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Possible HOST_TAG values:
+# linux-x86_64, darwin-x86_64, 32-bit Windows: windows, 64-bit Windows: windows-x86_64
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  HOST_TAG="linux-x86_64"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  HOST_TAG="darwin-x86_64"
+else
+  echo "Unsupported host: $OSTYPE"
+  exit 1
+fi
+
+echo $HOST_TAG

--- a/android/host.sh
+++ b/android/host.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+# Find the "HOST_TAG" which is use to locate the correct cross compiler in the Android NDK (see makefile)
 # Possible HOST_TAG values:
 # linux-x86_64, darwin-x86_64, 32-bit Windows: windows, 64-bit Windows: windows-x86_64
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then

--- a/android/makefile
+++ b/android/makefile
@@ -2,12 +2,9 @@
 # The makefile requires that the Android NDK_HOME directory is set correctly in order to find the
 # correct cross compilers.
 
-ARCHS_IOS = i386-apple-ios x86_64-apple-ios armv7-apple-ios armv7s-apple-ios aarch64-apple-ios
 ARCHS_ANDROID = aarch64-linux-android armv7-linux-androideabi i686-linux-android
-LIB=libsigner.a
-
+# host tag for the host platform that does the build
 HOST_TAG := $(shell ./host.sh)
-
 ANDROID_ABI=26
 
 # Some dependencies need env vars to find CC and AR: (TODO is AR needed?)
@@ -28,19 +25,10 @@ CARGO_LINKER_ENV_aarch64-linux-android=CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER
 CARGO_LINKER_ENV_i686-linux-android=CARGO_TARGET_I686_LINUX_ANDROID_LINKER
 
 
-all: ios android
-
-ios: $(LIB)
+all: android
 
 android: $(ARCHS_ANDROID)
-
-.PHONY: $(ARCHS_IOS)
-$(ARCHS_IOS): %:
-	cargo build --target $@ --release
 
 .PHONY: $(ARCHS_ANDROID)
 $(ARCHS_ANDROID): %:
 	$(CARGO_LINKER_ENV_$@)="$(CC_$@)" CC="$(CC_$@)" AR="$(AR_$@)" cargo build --target $@ --release
-
-$(LIB): $(ARCHS_IOS)
-	lipo -create -output $@ $(foreach arch,$(ARCHS_IOS),$(wildcard target/$(arch)/release/$(LIB)))

--- a/android/makefile
+++ b/android/makefile
@@ -1,3 +1,7 @@
+# Makefile to build the remote server for various Android target architectures
+# The makefile requires that the Android NDK_HOME directory is set correctly in order to find the
+# correct cross compilers.
+
 ARCHS_IOS = i386-apple-ios x86_64-apple-ios armv7-apple-ios armv7s-apple-ios aarch64-apple-ios
 ARCHS_ANDROID = aarch64-linux-android armv7-linux-androideabi i686-linux-android
 LIB=libsigner.a

--- a/android/makefile
+++ b/android/makefile
@@ -1,0 +1,42 @@
+ARCHS_IOS = i386-apple-ios x86_64-apple-ios armv7-apple-ios armv7s-apple-ios aarch64-apple-ios
+ARCHS_ANDROID = aarch64-linux-android armv7-linux-androideabi i686-linux-android
+LIB=libsigner.a
+
+HOST_TAG := $(shell ./host.sh)
+
+ANDROID_ABI=26
+
+# Some dependencies need env vars to find CC and AR: (TODO is AR needed?)
+TOOLCHAIN_DIR=$(NDK_HOME)/toolchains/llvm/prebuilt/$(HOST_TAG)/bin
+
+CC_aarch64-linux-android=$(TOOLCHAIN_DIR)/aarch64-linux-android$(ANDROID_ABI)-clang
+AR_aarch64-linux-android=$(TOOLCHAIN_DIR)/aarch64-linux-android-ar
+
+CC_armv7-linux-androideabi=$(TOOLCHAIN_DIR)/armv7a-linux-androideabi$(ANDROID_ABI)-clang
+AR_armv7-linux-androideabi=$(TOOLCHAIN_DIR)/arm-linux-androideabi-ar
+
+CC_i686-linux-android=$(TOOLCHAIN_DIR)/i686-linux-android$(ANDROID_ABI)-clang
+AR_i686-linux-android=$(TOOLCHAIN_DIR)/i686-linux-android-ar
+
+# ENV variable name used by the cargo 
+CARGO_LINKER_ENV_armv7-linux-androideabi=CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER
+CARGO_LINKER_ENV_aarch64-linux-android=CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER
+CARGO_LINKER_ENV_i686-linux-android=CARGO_TARGET_I686_LINUX_ANDROID_LINKER
+
+
+all: ios android
+
+ios: $(LIB)
+
+android: $(ARCHS_ANDROID)
+
+.PHONY: $(ARCHS_IOS)
+$(ARCHS_IOS): %:
+	cargo build --target $@ --release
+
+.PHONY: $(ARCHS_ANDROID)
+$(ARCHS_ANDROID): %:
+	$(CARGO_LINKER_ENV_$@)="$(CC_$@)" CC="$(CC_$@)" AR="$(AR_$@)" cargo build --target $@ --release
+
+$(LIB): $(ARCHS_IOS)
+	lipo -create -output $@ $(foreach arch,$(ARCHS_IOS),$(wildcard target/$(arch)/release/$(LIB)))

--- a/android/src/android.rs
+++ b/android/src/android.rs
@@ -1,0 +1,67 @@
+#[allow(non_snake_case)]
+pub mod android {
+    extern crate jni;
+
+    use std::thread;
+
+    use jni::sys::jchar;
+    use repository::database_settings::DatabaseSettings;
+    use tokio::runtime::Runtime;
+
+    use server::settings::{AuthSettings, ServerSettings, Settings, SyncSettings};
+    use server::start_server;
+
+    use self::jni::objects::{JClass, JString};
+    use self::jni::sys::{jshort, jstring};
+    use self::jni::JNIEnv;
+
+    #[no_mangle]
+    pub unsafe extern "C" fn Java_org_openmsupply_mobile_RemoteServer_rustHelloWorld(
+        env: JNIEnv,
+        _: JClass,
+        name: JString,
+    ) -> jstring {
+        let name: String = env.get_string(name).unwrap().into();
+        let response = format!("Hello {}!", name);
+        env.new_string(response).unwrap().into_inner()
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn Java_org_openmsupply_mobile_RemoteServer_startServer(
+        _: JNIEnv,
+        _: JClass,
+        port: jchar,
+    ) -> jshort {
+        // run server in background thread
+        thread::spawn(move || {
+            let mut runtime = Runtime::new().unwrap();
+            runtime.block_on(async move {
+                let settings = Settings {
+                    server: ServerSettings {
+                        host: "localhost".to_string(),
+                        port,
+                    },
+                    database: DatabaseSettings {
+                        username: "n/a".to_string(),
+                        password: "n/a".to_string(),
+                        port: 0,
+                        host: "n/a".to_string(),
+                        database_name: "omsupply-database".to_string(),
+                    },
+                    sync: SyncSettings {
+                        url: "localhost".to_string(),
+                        username: "username".to_string(),
+                        password: "password".to_string(),
+                        interval: 300,
+                    },
+                    auth: AuthSettings {
+                        token_secret: "Make me configurable".to_string(),
+                    },
+                };
+                let _ = start_server(settings).await;
+            });
+        });
+
+        0
+    }
+}

--- a/android/src/android.rs
+++ b/android/src/android.rs
@@ -54,7 +54,7 @@ pub mod android {
                         database_name: db_path,
                     },
                     sync: SyncSettings {
-                        url: "localhost".to_string(),
+                        url: "http://localhost".to_string(),
                         username: "username".to_string(),
                         password: "password".to_string(),
                         interval: 300,

--- a/android/src/android.rs
+++ b/android/src/android.rs
@@ -1,3 +1,4 @@
+/// This module exports some "C" methods that can directly be called from the Java runtime.
 #[allow(non_snake_case)]
 pub mod android {
     extern crate jni;
@@ -21,12 +22,17 @@ pub mod android {
 
     use once_cell::sync::Lazy;
 
+    /// Handle for a running remote_server instance
     struct RunningServerHandle {
-        thread: JoinHandle<()>,
+        /// Channel to signal the remote_server to exit
         off_switch: oneshot::Sender<()>,
+        /// JoinHandle for the running remote_server thread
+        thread: JoinHandle<()>,
     }
 
-    /// Manage a mapping of integer handle (to be passed to Java) and RunningServerHandle.
+    /// Manages a set of RunningServerHandle
+    /// Each running server is associated with an integer handle which can be passed to the Java
+    /// world, e.g. the handle can be used to shutdown the server from Java.
     struct ServerBucket {
         // next handle ready to be used
         next_handle: i64,
@@ -34,7 +40,7 @@ pub mod android {
     }
 
     impl ServerBucket {
-        /// Returns handle to the running server
+        /// Returns an integer handle to the running server
         fn insert(&mut self, server: RunningServerHandle) -> i64 {
             let handle = self.next_handle;
             self.next_handle = handle + 1;
@@ -50,6 +56,7 @@ pub mod android {
         })
     });
 
+    /// Bindings test method. TODO: remove when not needed anymore
     #[no_mangle]
     pub unsafe extern "C" fn Java_org_openmsupply_client_RemoteServer_rustHelloWorld(
         env: JNIEnv,
@@ -94,6 +101,7 @@ pub mod android {
                         interval: 300,
                     },
                     auth: AuthSettings {
+                        // TODO:
                         token_secret: "Make me configurable".to_string(),
                     },
                 };

--- a/android/src/android.rs
+++ b/android/src/android.rs
@@ -14,6 +14,9 @@ pub mod android {
     use self::jni::sys::{jshort, jstring};
     use self::jni::JNIEnv;
 
+    use android_logger::Config;
+    use log::Level;
+
     #[no_mangle]
     pub unsafe extern "C" fn Java_org_openmsupply_client_RemoteServer_rustHelloWorld(
         env: JNIEnv,
@@ -32,6 +35,8 @@ pub mod android {
         port: jchar,
         db_path: JString,
     ) -> jshort {
+        android_logger::init_once(Config::default().with_min_level(Level::Trace));
+
         let db_path: String = env.get_string(db_path).unwrap().into();
         // run server in background thread
         thread::spawn(move || {

--- a/android/src/lib.rs
+++ b/android/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod android;

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,7 +21,7 @@ util = { path = "../util" }
 
 actix-cors = "0.5.4"
 actix-web = { version= "3.3.2", features = ["openssl"] } # Versions >=v4 depend on Tokio v1.
-openssl = { version = "0.10", features = ["v110"] }
+openssl = { version = "0.10", features = ["v110", "vendored"] }
 anyhow = "1.0.44"
 config = "0.11.0"
 env_logger = "0.8.3"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -42,3 +42,4 @@ httpmock = "0.6"
 [features]
 default = ["repository/sqlite"]
 postgres = ["repository/postgres"]
+android = ["repository/sqlite", "openssl/vendored"]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,7 +21,7 @@ util = { path = "../util" }
 
 actix-cors = "0.5.4"
 actix-web = { version= "3.3.2", features = ["openssl"] } # Versions >=v4 depend on Tokio v1.
-openssl = { version = "0.10", features = ["v110", "vendored"] }
+openssl = { version = "0.10", features = ["v110"] }
 anyhow = "1.0.44"
 config = "0.11.0"
 env_logger = "0.8.3"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,3 +1,27 @@
+use self::{
+    actor_registry::ActorRegistry,
+    middleware::{compress as compress_middleware, logger as logger_middleware},
+    settings::Settings,
+    sync::{SyncConnection, SyncReceiverActor, SyncSenderActor, Synchroniser},
+};
+use openssl::ssl::{SslAcceptor, SslAcceptorBuilder, SslFiletype, SslMethod};
+
+use graphql::{
+    config as graphql_config,
+    loader::{get_loaders, LoaderMap, LoaderRegistry},
+};
+use log::{error, warn};
+use repository::get_storage_connection_manager;
+use service::{auth_data::AuthData, service_provider::ServiceProvider, token_bucket::TokenBucket};
+
+use actix_cors::Cors;
+use actix_web::{web::Data, App, HttpServer};
+use std::{
+    net::TcpListener,
+    sync::{Arc, Mutex, RwLock},
+    time::Duration,
+};
+
 pub mod actor_registry;
 pub mod configuration;
 pub mod environment;
@@ -5,3 +29,82 @@ pub mod middleware;
 pub mod settings;
 pub mod sync;
 pub mod test_utils;
+
+pub async fn start_server(settings: Settings) -> std::io::Result<()> {
+    let auth_data = Data::new(AuthData {
+        auth_token_secret: settings.auth.token_secret.to_owned(),
+        token_bucket: RwLock::new(TokenBucket::new()),
+        debug_no_ssl: false,
+        // TODO: disable once frontend supports auth!
+        debug_no_access_control: true,
+    });
+    let connection_manager = get_storage_connection_manager(&settings.database);
+    let loaders: LoaderMap = get_loaders(&connection_manager).await;
+    let service_provider = ServiceProvider::new(connection_manager.clone());
+    let (mut sync_sender, mut sync_receiver): (SyncSenderActor, SyncReceiverActor) =
+        sync::get_sync_actors();
+
+    let actor_registry = ActorRegistry {
+        sync_sender: Arc::new(Mutex::new(sync_sender.clone())),
+    };
+
+    let connection_manager_data_app = Data::new(connection_manager);
+    let connection_manager_data_sync = connection_manager_data_app.clone();
+    let loader_registry_data = Data::new(LoaderRegistry { loaders });
+    let service_provider_data = Data::new(service_provider);
+    let actor_registry_data = Data::new(actor_registry);
+
+    let mut http_server = HttpServer::new(move || {
+        App::new()
+            .app_data(connection_manager_data_app.clone())
+            .app_data(actor_registry_data.clone())
+            .wrap(logger_middleware())
+            .wrap(Cors::permissive())
+            .wrap(compress_middleware())
+            .configure(graphql_config(
+                connection_manager_data_app.clone(),
+                loader_registry_data.clone(),
+                service_provider_data.clone(),
+                auth_data.clone(),
+            ))
+    });
+    match load_certs() {
+        Ok(ssl_builder) => {
+            http_server = http_server.bind_openssl(
+                format!("{}:{}", settings.server.host, settings.server.port),
+                ssl_builder,
+            )?;
+        }
+        Err(err) => {
+            error!("Failed to load certificates: {}", err);
+            warn!("Run in HTTP mode");
+
+            let listener = TcpListener::bind(settings.server.address())
+                .expect("Failed to bind server to address");
+            http_server = http_server.listen(listener)?;
+        }
+    }
+    let running_sever = http_server.run();
+
+    let connection = SyncConnection::new(&settings.sync);
+    let mut synchroniser = Synchroniser { connection };
+
+    // http_server is the only one that should quit; a proper shutdown signal can cause this,
+    // and so we want an orderly exit. This achieves it nicely.
+    tokio::select! {
+        result = running_sever => result,
+        () = async {
+          sync_sender.schedule_send(Duration::from_secs(settings.sync.interval)).await;
+        } => unreachable!("Sync receiver unexpectedly died!?"),
+        () = async {
+            sync_receiver.listen(&mut synchroniser, &connection_manager_data_sync).await;
+        } => unreachable!("Sync scheduler unexpectedly died!?"),
+    }
+}
+
+fn load_certs() -> Result<SslAcceptorBuilder, anyhow::Error> {
+    let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls()).unwrap();
+    builder.set_private_key_file("certs/key.pem", SslFiletype::PEM)?;
+    builder.set_certificate_chain_file("certs/cert.pem")?;
+    Ok(builder)
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -85,10 +85,15 @@ pub async fn start_server(settings: Settings) -> std::io::Result<()> {
         }
     }
     let running_sever = http_server.run();
-
-    let connection = SyncConnection::new(&settings.sync);
+    let connection = match SyncConnection::new(&settings.sync) {
+        Ok(connection) => connection,
+        Err(err) => {
+            let err_msg = format!("Failed to initialize SyncConnection: {}", err);
+            error!("{}", err_msg);
+            panic!("{}", err_msg);
+        }
+    };
     let mut synchroniser = Synchroniser { connection };
-
     // http_server is the only one that should quit; a proper shutdown signal can cause this,
     // and so we want an orderly exit. This achieves it nicely.
     tokio::select! {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,37 +1,8 @@
 #![allow(where_clauses_object_safety)]
 
-use openssl::ssl::{SslAcceptor, SslAcceptorBuilder, SslFiletype, SslMethod};
-use server::{
-    actor_registry::ActorRegistry,
-    configuration,
-    middleware::{compress as compress_middleware, logger as logger_middleware},
-    settings::Settings,
-    sync::{self, SyncConnection, SyncReceiverActor, SyncSenderActor, Synchroniser},
-};
+use std::env;
 
-use graphql::{
-    config as graphql_config,
-    loader::{get_loaders, LoaderMap, LoaderRegistry},
-};
-use log::{error, warn};
-use repository::get_storage_connection_manager;
-use service::{auth_data::AuthData, service_provider::ServiceProvider, token_bucket::TokenBucket};
-
-use actix_cors::Cors;
-use actix_web::{web::Data, App, HttpServer};
-use std::{
-    env,
-    net::TcpListener,
-    sync::{Arc, Mutex, RwLock},
-    time::Duration,
-};
-
-fn load_certs() -> Result<SslAcceptorBuilder, anyhow::Error> {
-    let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls()).unwrap();
-    builder.set_private_key_file("certs/key.pem", SslFiletype::PEM)?;
-    builder.set_certificate_chain_file("certs/cert.pem")?;
-    Ok(builder)
-}
+use server::{configuration, settings::Settings, start_server};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -41,73 +12,5 @@ async fn main() -> std::io::Result<()> {
     let settings: Settings =
         configuration::get_configuration().expect("Failed to parse configuration settings");
 
-    let auth_data = Data::new(AuthData {
-        auth_token_secret: settings.auth.token_secret.to_owned(),
-        token_bucket: RwLock::new(TokenBucket::new()),
-        debug_no_ssl: false,
-        // TODO: disable once frontend supports auth!
-        debug_no_access_control: true,
-    });
-    let connection_manager = get_storage_connection_manager(&settings.database);
-    let loaders: LoaderMap = get_loaders(&connection_manager).await;
-    let service_provider = ServiceProvider::new(connection_manager.clone());
-    let (mut sync_sender, mut sync_receiver): (SyncSenderActor, SyncReceiverActor) =
-        sync::get_sync_actors();
-
-    let actor_registry = ActorRegistry {
-        sync_sender: Arc::new(Mutex::new(sync_sender.clone())),
-    };
-
-    let connection_manager_data_app = Data::new(connection_manager);
-    let connection_manager_data_sync = connection_manager_data_app.clone();
-    let loader_registry_data = Data::new(LoaderRegistry { loaders });
-    let service_provider_data = Data::new(service_provider);
-    let actor_registry_data = Data::new(actor_registry);
-
-    let mut http_server = HttpServer::new(move || {
-        App::new()
-            .app_data(connection_manager_data_app.clone())
-            .app_data(actor_registry_data.clone())
-            .wrap(logger_middleware())
-            .wrap(Cors::permissive())
-            .wrap(compress_middleware())
-            .configure(graphql_config(
-                connection_manager_data_app.clone(),
-                loader_registry_data.clone(),
-                service_provider_data.clone(),
-                auth_data.clone(),
-            ))
-    });
-    match load_certs() {
-        Ok(ssl_builder) => {
-            http_server = http_server.bind_openssl(
-                format!("{}:{}", settings.server.host, settings.server.port),
-                ssl_builder,
-            )?;
-        }
-        Err(err) => {
-            error!("Failed to load certificates: {}", err);
-            warn!("Run in HTTP mode");
-
-            let listener = TcpListener::bind(settings.server.address())
-                .expect("Failed to bind server to address");
-            http_server = http_server.listen(listener)?;
-        }
-    }
-    let running_sever = http_server.run();
-
-    let connection = SyncConnection::new(&settings.sync);
-    let mut synchroniser = Synchroniser { connection };
-
-    // http_server is the only one that should quit; a proper shutdown signal can cause this,
-    // and so we want an orderly exit. This achieves it nicely.
-    tokio::select! {
-        result = running_sever => result,
-        () = async {
-          sync_sender.schedule_send(Duration::from_secs(settings.sync.interval)).await;
-        } => unreachable!("Sync receiver unexpectedly died!?"),
-        () = async {
-            sync_receiver.listen(&mut synchroniser, &connection_manager_data_sync).await;
-        } => unreachable!("Sync scheduler unexpectedly died!?"),
-    }
+    start_server(settings).await
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -3,6 +3,7 @@
 use std::env;
 
 use server::{configuration, settings::Settings, start_server};
+use tokio::sync::oneshot;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -12,5 +13,6 @@ async fn main() -> std::io::Result<()> {
     let settings: Settings =
         configuration::get_configuration().expect("Failed to parse configuration settings");
 
-    start_server(settings).await
+    let (_, off_switch) = oneshot::channel();
+    start_server(settings, off_switch).await
 }

--- a/server/src/sync/connection.rs
+++ b/server/src/sync/connection.rs
@@ -71,20 +71,20 @@ pub struct SyncConnection {
 }
 
 impl SyncConnection {
-    pub fn new(settings: &SyncSettings) -> SyncConnection {
+    pub fn new(settings: &SyncSettings) -> anyhow::Result<SyncConnection> {
         let url = &settings.url;
         let username = &settings.username;
         let password = &settings.password;
 
         let client = Client::new();
-        let server = SyncServer::new(url);
+        let server = SyncServer::new(url)?;
         let credentials = SyncCredentials::new(username, password);
 
-        SyncConnection {
+        Ok(SyncConnection {
             client,
             server,
             credentials,
-        }
+        })
     }
 
     // Initialize remote sync queue.
@@ -258,7 +258,7 @@ mod tests {
             then.status(401);
         });
 
-        let sync_connection_with_auth = SyncConnection::new(&mock_sync_settings_with_auth);
+        let sync_connection_with_auth = SyncConnection::new(&mock_sync_settings_with_auth).unwrap();
         let initialise_result_with_auth =
             sync_connection_with_auth.initialise_remote_records().await;
 
@@ -268,7 +268,8 @@ mod tests {
             serde_json::to_string(&mock_initialise_body).unwrap()
         );
 
-        let sync_connection_without_auth = SyncConnection::new(&mock_sync_settings_without_auth);
+        let sync_connection_without_auth =
+            SyncConnection::new(&mock_sync_settings_without_auth).unwrap();
         let initialise_result_without_auth = sync_connection_without_auth
             .initialise_remote_records()
             .await;
@@ -340,7 +341,7 @@ mod tests {
             then.status(401);
         });
 
-        let sync_connection_with_auth = SyncConnection::new(&mock_sync_settings_with_auth);
+        let sync_connection_with_auth = SyncConnection::new(&mock_sync_settings_with_auth).unwrap();
         let pull_result_with_auth = sync_connection_with_auth.pull_remote_records().await;
 
         assert!(pull_result_with_auth.is_ok());
@@ -349,7 +350,8 @@ mod tests {
             serde_json::to_string(&mock_remote_records_body).unwrap()
         );
 
-        let sync_connection_without_auth = SyncConnection::new(&mock_sync_settings_without_auth);
+        let sync_connection_without_auth =
+            SyncConnection::new(&mock_sync_settings_without_auth).unwrap();
         let pull_result_without_auth = sync_connection_without_auth.pull_remote_records().await;
 
         assert!(pull_result_without_auth.is_err());
@@ -416,14 +418,15 @@ mod tests {
             then.status(401);
         });
 
-        let sync_connection_with_auth = SyncConnection::new(&mock_sync_settings_with_auth);
+        let sync_connection_with_auth = SyncConnection::new(&mock_sync_settings_with_auth).unwrap();
         let acknowledge_result_with_auth = sync_connection_with_auth
             .acknowledge_remote_records(&mock_acknowledge_records_data)
             .await;
 
         assert!(acknowledge_result_with_auth.is_ok());
 
-        let sync_connection_without_auth = SyncConnection::new(&mock_sync_settings_without_auth);
+        let sync_connection_without_auth =
+            SyncConnection::new(&mock_sync_settings_without_auth).unwrap();
         let acknowledge_result_without_auth = sync_connection_without_auth
             .acknowledge_remote_records(&mock_acknowledge_records_data)
             .await;
@@ -490,13 +493,14 @@ mod tests {
             then.status(401);
         });
 
-        let sync_connection_with_auth = SyncConnection::new(&mock_sync_settings_with_auth);
+        let sync_connection_with_auth = SyncConnection::new(&mock_sync_settings_with_auth).unwrap();
         let pull_central_records_result_with_auth =
             sync_connection_with_auth.pull_central_records(0, 2).await;
 
         assert!(pull_central_records_result_with_auth.is_ok());
 
-        let sync_connection_without_auth = SyncConnection::new(&mock_sync_settings_without_auth);
+        let sync_connection_without_auth =
+            SyncConnection::new(&mock_sync_settings_without_auth).unwrap();
         let pull_central_records_result_without_auth = sync_connection_without_auth
             .pull_central_records(0, 2)
             .await;

--- a/server/src/sync/server.rs
+++ b/server/src/sync/server.rs
@@ -14,10 +14,10 @@ pub struct SyncServer {
 }
 
 impl SyncServer {
-    pub fn new(url: &str) -> SyncServer {
+    pub fn new(url: &str) -> anyhow::Result<SyncServer> {
         // TODO: add error handling.
-        let url = Url::parse(url).unwrap();
-        SyncServer { url }
+        let url = Url::parse(url)?;
+        Ok(SyncServer { url })
     }
 
     pub fn from_url(url: Url) -> SyncServer {

--- a/server/src/sync/synchroniser.rs
+++ b/server/src/sync/synchroniser.rs
@@ -268,7 +268,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_integrate_central_records() {
         let settings = get_test_settings("omsupply-database-integrate_central_records");
-        let sync_connection = SyncConnection::new(&settings.sync);
+        let sync_connection = SyncConnection::new(&settings.sync).unwrap();
 
         test_db::setup(&settings.database).await;
         let connection_manager = get_storage_connection_manager(&settings.database);


### PR DESCRIPTION
- Adds a package for Android java bindings.
- Refactors a start_server method that can be used in main and from Android
- Add "off_switch" parameter to start_server to shutdown the server (e.g. when running on Android)
- Remove unwrap from sync (so that the error can be logged on Android)