### PR TITLE
716 requisition queries

### DIFF
--- a/domain/src/invoice.rs
+++ b/domain/src/invoice.rs
@@ -36,6 +36,7 @@ pub struct Invoice {
     pub delivered_datetime: Option<NaiveDateTime>,
     pub verified_datetime: Option<NaiveDateTime>,
     pub colour: Option<String>,
+    pub requisition_id: Option<String>,
 }
 #[derive(Clone)]
 pub struct InvoiceFilter {
@@ -53,6 +54,7 @@ pub struct InvoiceFilter {
     pub shipped_datetime: Option<DatetimeFilter>,
     pub delivered_datetime: Option<DatetimeFilter>,
     pub verified_datetime: Option<DatetimeFilter>,
+    pub requisition_id: Option<EqualFilter<String>>,
 }
 
 impl InvoiceFilter {
@@ -72,6 +74,7 @@ impl InvoiceFilter {
             shipped_datetime: None,
             delivered_datetime: None,
             verified_datetime: None,
+            requisition_id: None,
         }
     }
 
@@ -122,6 +125,11 @@ impl InvoiceFilter {
 
     pub fn verified_datetime(mut self, filter: DatetimeFilter) -> Self {
         self.verified_datetime = Some(filter);
+        self
+    }
+
+    pub fn requisition_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.requisition_id = Some(filter);
         self
     }
 }

--- a/domain/src/invoice_line.rs
+++ b/domain/src/invoice_line.rs
@@ -26,6 +26,7 @@ pub struct InvoiceLine {
     pub batch: Option<String>,
     pub expiry_date: Option<NaiveDate>,
     pub note: Option<String>,
+    pub requisition_id: Option<String>,
 }
 
 pub type InvoiceLineSort = Sort<()>;

--- a/graphql/src/loader/invoice.rs
+++ b/graphql/src/loader/invoice.rs
@@ -8,7 +8,10 @@ use repository::{InvoiceLineRepository, InvoiceQueryRepository};
 
 use async_graphql::dataloader::*;
 use async_graphql::*;
+use service::invoice::get_invoices;
 use std::collections::HashMap;
+
+use crate::standard_graphql_error::StandardGraphqlError;
 
 pub struct InvoiceLoader {
     pub connection_manager: StorageConnectionManager,
@@ -78,6 +81,41 @@ impl Loader<String> for InvoiceStatsLoader {
                 (invoice_id, row)
             })
             .collect();
+        Ok(result)
+    }
+}
+
+pub struct InvoiceByRequisitionIdLoader {
+    pub connection_manager: StorageConnectionManager,
+}
+
+#[async_trait::async_trait]
+impl Loader<String> for InvoiceByRequisitionIdLoader {
+    type Value = Vec<Invoice>;
+    type Error = async_graphql::Error;
+
+    async fn load(
+        &self,
+        requisition_ids: &[String],
+    ) -> Result<HashMap<String, Self::Value>, Self::Error> {
+        let filter = InvoiceFilter::new().requisition_id(EqualFilter {
+            equal_any: Some(requisition_ids.iter().map(String::clone).collect()),
+            equal_to: None,
+            not_equal_to: None,
+        });
+
+        let invoices = get_invoices(&self.connection_manager, None, Some(filter), None)
+            .map_err(StandardGraphqlError::from_list_error)?;
+
+        let mut result: HashMap<String, Vec<Invoice>> = HashMap::new();
+        for invoice in invoices.rows {
+            if let Some(requisition_id) = &invoice.requisition_id {
+                let list = result
+                    .entry(requisition_id.clone())
+                    .or_insert_with(|| Vec::<Invoice>::new());
+                list.push(invoice);
+            }
+        }
         Ok(result)
     }
 }

--- a/graphql/src/loader/invoice_line_query.rs
+++ b/graphql/src/loader/invoice_line_query.rs
@@ -6,6 +6,10 @@ use std::collections::HashMap;
 
 use service::ListError;
 
+use crate::standard_graphql_error::StandardGraphqlError;
+
+use super::{extract_unique_requisition_and_item_id, RequisitionAndItemId};
+
 pub struct InvoiceLineQueryLoader {
     pub connection_manager: StorageConnectionManager,
 }
@@ -34,6 +38,49 @@ impl Loader<String> for InvoiceLineQueryLoader {
                 .entry(line.invoice_id.clone())
                 .or_insert_with(|| Vec::<InvoiceLine>::new());
             list.push(line);
+        }
+        Ok(map)
+    }
+}
+
+pub struct InvoiceLineForRequisitionLine {
+    pub connection_manager: StorageConnectionManager,
+}
+
+#[async_trait::async_trait]
+impl Loader<RequisitionAndItemId> for InvoiceLineForRequisitionLine {
+    type Value = Vec<InvoiceLine>;
+    type Error = async_graphql::Error;
+
+    async fn load(
+        &self,
+        requisition_and_item_id: &[RequisitionAndItemId],
+    ) -> Result<HashMap<RequisitionAndItemId, Self::Value>, Self::Error> {
+        let connection = self.connection_manager.connection()?;
+        let repo = InvoiceLineRepository::new(&connection);
+
+        let (requisition_ids, item_ids) =
+            extract_unique_requisition_and_item_id(requisition_and_item_id);
+
+        let all_invoice_lines = repo
+            .query_by_filter(
+                InvoiceLineFilter::new()
+                    .requisition_id(EqualFilter::equal_any(requisition_ids))
+                    .item_id(EqualFilter::equal_any(item_ids)),
+            )
+            .map_err(StandardGraphqlError::from_repository_error)?;
+
+        let mut map: HashMap<RequisitionAndItemId, Vec<InvoiceLine>> = HashMap::new();
+        for line in all_invoice_lines {
+            if let Some(requisition_id) = &line.requisition_id {
+                let list = map
+                    .entry(RequisitionAndItemId {
+                        item_id: line.item_id.clone(),
+                        requisition_id: requisition_id.clone(),
+                    })
+                    .or_insert_with(|| Vec::<InvoiceLine>::new());
+                list.push(line);
+            }
         }
         Ok(map)
     }

--- a/graphql/src/loader/invoice_line_query.rs
+++ b/graphql/src/loader/invoice_line_query.rs
@@ -8,7 +8,7 @@ use service::ListError;
 
 use crate::standard_graphql_error::StandardGraphqlError;
 
-use super::{extract_unique_requisition_and_item_id, RequisitionAndItemId};
+use super::{extract_unique_requisition_and_item_ids, RequisitionAndItemId};
 
 pub struct InvoiceLineQueryLoader {
     pub connection_manager: StorageConnectionManager,
@@ -60,7 +60,7 @@ impl Loader<RequisitionAndItemId> for InvoiceLineForRequisitionLine {
         let repo = InvoiceLineRepository::new(&connection);
 
         let (requisition_ids, item_ids) =
-            extract_unique_requisition_and_item_id(requisition_and_item_id);
+            extract_unique_requisition_and_item_ids(requisition_and_item_id);
 
         let all_invoice_lines = repo
             .query_by_filter(

--- a/graphql/src/loader/loader_registry.rs
+++ b/graphql/src/loader/loader_registry.rs
@@ -1,4 +1,6 @@
+use actix_web::web::Data;
 use anymap::{any::Any, Map};
+use service::service_provider::ServiceProvider;
 
 use crate::loader::{InvoiceLineLoader, InvoiceLoader, ItemLoader, StoreLoader, UserAccountLoader};
 
@@ -7,9 +9,10 @@ use repository::StorageConnectionManager;
 use async_graphql::dataloader::DataLoader;
 
 use super::{
-    name::NameByIdLoader, InvoiceLineQueryLoader, InvoiceQueryLoader, InvoiceStatsLoader,
-    LocationByIdLoader, MasterListLineByMasterListId, StockLineByIdLoader, StockLineByItemIdLoader,
-    StockLineByLocationIdLoader, StockTakeLineByStockTakeIdLoader,
+    invoice::InvoiceByRequisitionIdLoader, name::NameByIdLoader, InvoiceLineForRequisitionLine,
+    InvoiceLineQueryLoader, InvoiceQueryLoader, InvoiceStatsLoader, LinkedRequisitionLineLoader,
+    LocationByIdLoader, MasterListLineByMasterListId, RequisitionsByIdLoader, StockLineByIdLoader,
+    StockLineByItemIdLoader, StockLineByLocationIdLoader, StockTakeLineByStockTakeIdLoader,
 };
 
 pub type LoaderMap = Map<AnyLoader>;
@@ -28,7 +31,10 @@ impl LoaderRegistry {
     }
 }
 
-pub async fn get_loaders(connection_manager: &StorageConnectionManager) -> LoaderMap {
+pub async fn get_loaders(
+    connection_manager: &StorageConnectionManager,
+    service_provider: Data<ServiceProvider>,
+) -> LoaderMap {
     let mut loaders: LoaderMap = LoaderMap::new();
 
     let item_loader = DataLoader::new(ItemLoader {
@@ -47,11 +53,19 @@ pub async fn get_loaders(connection_manager: &StorageConnectionManager) -> Loade
         connection_manager: connection_manager.clone(),
     });
 
+    let invoice_by_requisition_id_loader = DataLoader::new(InvoiceByRequisitionIdLoader {
+        connection_manager: connection_manager.clone(),
+    });
+
     let invoice_line_loader = DataLoader::new(InvoiceLineLoader {
         connection_manager: connection_manager.clone(),
     });
 
     let invoice_line_query_loader = DataLoader::new(InvoiceLineQueryLoader {
+        connection_manager: connection_manager.clone(),
+    });
+
+    let invoice_line_for_requistion_line = DataLoader::new(InvoiceLineForRequisitionLine {
         connection_manager: connection_manager.clone(),
     });
 
@@ -91,14 +105,25 @@ pub async fn get_loaders(connection_manager: &StorageConnectionManager) -> Loade
         connection_manager: connection_manager.clone(),
     });
 
+    let requisitions_by_id_loader = DataLoader::new(RequisitionsByIdLoader {
+        service_provider: service_provider.clone(),
+    });
+
+    let requisition_line_by_linked_requistion_line_id_loader =
+        DataLoader::new(LinkedRequisitionLineLoader {
+            service_provider: service_provider.clone(),
+        });
+
     loaders.insert(item_loader);
     loaders.insert(name_by_id_loader);
     loaders.insert(store_loader);
     loaders.insert(invoice_loader);
     loaders.insert(invoice_query_loader);
+    loaders.insert(invoice_by_requisition_id_loader);
     loaders.insert(invoice_line_loader);
     loaders.insert(invoice_line_query_loader);
     loaders.insert(invoice_line_stats_loader);
+    loaders.insert(invoice_line_for_requistion_line);
     loaders.insert(stock_line_by_item_id_loader);
     loaders.insert(stock_line_by_location_id_loader);
     loaders.insert(stock_line_by_id_loader);
@@ -106,6 +131,9 @@ pub async fn get_loaders(connection_manager: &StorageConnectionManager) -> Loade
     loaders.insert(location_by_id_loader);
     loaders.insert(master_list_line_by_master_list_id);
     loaders.insert(stock_take_line_loader);
+    loaders.insert(requisitions_by_id_loader);
+
+    loaders.insert(requisition_line_by_linked_requistion_line_id_loader);
 
     loaders
 }

--- a/graphql/src/loader/mod.rs
+++ b/graphql/src/loader/mod.rs
@@ -6,20 +6,53 @@ mod loader_registry;
 mod location;
 mod master_list_line;
 mod name;
+mod requisition;
+mod requisition_line;
 mod stock_line;
 mod stock_take_lines;
 mod store;
 mod user_account;
 
-pub use invoice::{InvoiceLoader, InvoiceQueryLoader, InvoiceStatsLoader};
+use std::collections::HashSet;
+
+pub use invoice::*;
 pub use invoice_line::InvoiceLineLoader;
-pub use invoice_line_query::InvoiceLineQueryLoader;
+pub use invoice_line_query::*;
 pub use item::ItemLoader;
 pub use loader_registry::{get_loaders, LoaderMap, LoaderRegistry};
 pub use location::LocationByIdLoader;
 pub use master_list_line::MasterListLineByMasterListId;
 pub use name::NameByIdLoader;
+pub use requisition::*;
+pub use requisition_line::*;
 pub use stock_line::{StockLineByIdLoader, StockLineByItemIdLoader, StockLineByLocationIdLoader};
 pub use stock_take_lines::StockTakeLineByStockTakeIdLoader;
 pub use store::StoreLoader;
 pub use user_account::UserAccountLoader;
+
+#[derive(Hash, Clone, PartialEq, Eq)]
+pub struct RequisitionAndItemId {
+    pub requisition_id: String,
+    pub item_id: String,
+}
+
+fn extract_unique_requisition_and_item_id(
+    requisition_and_item_ids: &[RequisitionAndItemId],
+) -> (Vec<String>, Vec<String>) {
+    let mut requisition_ids: HashSet<String> = HashSet::new();
+    let mut item_ids: HashSet<String> = HashSet::new();
+
+    for RequisitionAndItemId {
+        requisition_id,
+        item_id,
+    } in requisition_and_item_ids
+    {
+        requisition_ids.insert(requisition_id.clone());
+        item_ids.insert(item_id.clone());
+    }
+
+    (
+        requisition_ids.into_iter().collect(),
+        item_ids.into_iter().collect(),
+    )
+}

--- a/graphql/src/loader/mod.rs
+++ b/graphql/src/loader/mod.rs
@@ -36,7 +36,7 @@ pub struct RequisitionAndItemId {
     pub item_id: String,
 }
 
-fn extract_unique_requisition_and_item_id(
+fn extract_unique_requisition_and_item_ids(
     requisition_and_item_ids: &[RequisitionAndItemId],
 ) -> (Vec<String>, Vec<String>) {
     let mut requisition_ids: HashSet<String> = HashSet::new();

--- a/graphql/src/loader/requisition.rs
+++ b/graphql/src/loader/requisition.rs
@@ -1,0 +1,44 @@
+use std::collections::HashMap;
+
+use actix_web::web::Data;
+use async_graphql::dataloader::*;
+use domain::EqualFilter;
+use repository::{Requisition, RequisitionFilter};
+use service::service_provider::ServiceProvider;
+
+use crate::standard_graphql_error::StandardGraphqlError;
+
+pub struct RequisitionsByIdLoader {
+    pub service_provider: Data<ServiceProvider>,
+}
+
+#[async_trait::async_trait]
+impl Loader<String> for RequisitionsByIdLoader {
+    type Value = Requisition;
+    type Error = async_graphql::Error;
+
+    async fn load(
+        &self,
+        requisition_ids: &[String],
+    ) -> Result<HashMap<String, Self::Value>, Self::Error> {
+        let service_context = self.service_provider.context()?;
+
+        let filter = RequisitionFilter::new().id(EqualFilter {
+            equal_any: Some(requisition_ids.iter().map(String::clone).collect()),
+            equal_to: None,
+            not_equal_to: None,
+        });
+
+        let requisitions = self
+            .service_provider
+            .requisition_service
+            .get_requisitions(&service_context, None, None, Some(filter), None)
+            .map_err(StandardGraphqlError::from_list_error)?;
+
+        Ok(requisitions
+            .rows
+            .into_iter()
+            .map(|requisition| (requisition.requisition_row.id.clone(), requisition))
+            .collect())
+    }
+}

--- a/graphql/src/loader/requisition_line.rs
+++ b/graphql/src/loader/requisition_line.rs
@@ -8,7 +8,7 @@ use service::service_provider::ServiceProvider;
 
 use crate::standard_graphql_error::StandardGraphqlError;
 
-use super::{extract_unique_requisition_and_item_id, RequisitionAndItemId};
+use super::{extract_unique_requisition_and_item_ids, RequisitionAndItemId};
 
 pub struct RequisitionLinesByRequisitionIdLoader {
     pub service_provider: Data<ServiceProvider>,
@@ -64,7 +64,7 @@ impl Loader<RequisitionAndItemId> for LinkedRequisitionLineLoader {
         let service_context = self.service_provider.context()?;
 
         let (requisition_ids, item_ids) =
-            extract_unique_requisition_and_item_id(requisition_and_item_id);
+            extract_unique_requisition_and_item_ids(requisition_and_item_id);
 
         let filter = RequisitionLineFilter::new()
             .requisition_id(EqualFilter::equal_any(requisition_ids))

--- a/graphql/src/loader/requisition_line.rs
+++ b/graphql/src/loader/requisition_line.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+
+use actix_web::web::Data;
+use async_graphql::dataloader::*;
+use domain::EqualFilter;
+use repository::{RequisitionLine, RequisitionLineFilter};
+use service::service_provider::ServiceProvider;
+
+use crate::standard_graphql_error::StandardGraphqlError;
+
+use super::{extract_unique_requisition_and_item_id, RequisitionAndItemId};
+
+pub struct RequisitionLinesByRequisitionIdLoader {
+    pub service_provider: Data<ServiceProvider>,
+}
+
+#[async_trait::async_trait]
+impl Loader<String> for RequisitionLinesByRequisitionIdLoader {
+    type Value = Vec<RequisitionLine>;
+    type Error = async_graphql::Error;
+
+    async fn load(
+        &self,
+        requisition_ids: &[String],
+    ) -> Result<HashMap<String, Self::Value>, Self::Error> {
+        let service_context = self.service_provider.context()?;
+
+        let filter = RequisitionLineFilter::new().requisition_id(EqualFilter {
+            equal_any: Some(requisition_ids.iter().map(String::clone).collect()),
+            equal_to: None,
+            not_equal_to: None,
+        });
+
+        let requisition_lines = self
+            .service_provider
+            .requisition_line_service
+            .get_requisition_lines(&service_context, None, Some(filter))
+            .map_err(StandardGraphqlError::from_list_error)?;
+
+        let mut result: HashMap<String, Vec<RequisitionLine>> = HashMap::new();
+        for requisition_line in requisition_lines.rows {
+            let list = result
+                .entry(requisition_line.requisition_line_row.requisition_id.clone())
+                .or_insert_with(|| Vec::<RequisitionLine>::new());
+            list.push(requisition_line);
+        }
+        Ok(result)
+    }
+}
+
+pub struct LinkedRequisitionLineLoader {
+    pub service_provider: Data<ServiceProvider>,
+}
+
+#[async_trait::async_trait]
+impl Loader<RequisitionAndItemId> for LinkedRequisitionLineLoader {
+    type Value = RequisitionLine;
+    type Error = async_graphql::Error;
+
+    async fn load(
+        &self,
+        requisition_and_item_id: &[RequisitionAndItemId],
+    ) -> Result<HashMap<RequisitionAndItemId, Self::Value>, Self::Error> {
+        let service_context = self.service_provider.context()?;
+
+        let (requisition_ids, item_ids) =
+            extract_unique_requisition_and_item_id(requisition_and_item_id);
+
+        let filter = RequisitionLineFilter::new()
+            .requisition_id(EqualFilter::equal_any(requisition_ids))
+            .item_id(EqualFilter::equal_any(item_ids));
+
+        let requisition_lines = self
+            .service_provider
+            .requisition_line_service
+            .get_requisition_lines(&service_context, None, Some(filter))
+            .map_err(StandardGraphqlError::from_list_error)?;
+
+        Ok(requisition_lines
+            .rows
+            .into_iter()
+            .map(|line| {
+                (
+                    RequisitionAndItemId {
+                        item_id: line.requisition_line_row.item_id.clone(),
+                        requisition_id: line.requisition_line_row.requisition_id.clone(),
+                    },
+                    line,
+                )
+            })
+            .collect())
+    }
+}

--- a/graphql/src/schema/mutations/mod.rs
+++ b/graphql/src/schema/mutations/mod.rs
@@ -410,7 +410,7 @@ impl Mutations {
         request_requisition::use_calculated_quantity(ctx, store_id, input)
     }
 
-    /// Add requistion lines from master item master list
+    /// Add requisition lines from master item master list
     async fn add_from_master_list(
         &self,
         ctx: &Context<'_>,

--- a/graphql/src/schema/queries/mod.rs
+++ b/graphql/src/schema/queries/mod.rs
@@ -211,30 +211,30 @@ impl Queries {
     pub async fn requisition(
         &self,
         ctx: &Context<'_>,
-        store_id: Option<String>,
+        store_id: String,
         id: String,
     ) -> Result<RequisitionResponse> {
-        get_requisition(ctx, store_id, id)
+        get_requisition(ctx, &store_id, &id)
     }
 
     pub async fn requisitions(
         &self,
         ctx: &Context<'_>,
-        store_id: Option<String>,
+        store_id: String,
         page: Option<PaginationInput>,
         filter: Option<RequisitionFilterInput>,
         sort: Option<Vec<RequisitionSortInput>>,
     ) -> Result<RequisitionsResponse> {
-        get_requisitions(ctx, store_id, page, filter, sort)
+        get_requisitions(ctx, &store_id, page, filter, sort)
     }
 
     pub async fn requisition_by_number(
         &self,
         ctx: &Context<'_>,
-        store_id: Option<String>,
+        store_id: String,
         requisition_number: u32,
         r#type: RequisitionNodeType,
     ) -> Result<RequisitionResponse> {
-        get_requisition_by_number(ctx, store_id, requisition_number, r#type)
+        get_requisition_by_number(ctx, &store_id, requisition_number, r#type)
     }
 }

--- a/graphql/src/schema/queries/requisition.rs
+++ b/graphql/src/schema/queries/requisition.rs
@@ -1,8 +1,19 @@
 use async_graphql::*;
+use domain::{DatetimeFilter, EqualFilter, PaginationOption, SimpleStringFilter};
+use repository::{RequisitionFilter, RequisitionSort, RequisitionSortField};
+use service::permission_validation::{Resource, ResourceAccessRequest};
 
-use crate::schema::types::{
-    sort_filter_types::{DatetimeFilterInput, EqualFilterBigNumberInput, EqualFilterInput},
-    PaginationInput, RequisitionNode, RequisitionNodeStatus, RequisitionNodeType,
+use crate::{
+    schema::types::{
+        sort_filter_types::{
+            DatetimeFilterInput, EqualFilterBigNumberInput, EqualFilterInput,
+            SimpleStringFilterInput,
+        },
+        PaginationInput, RecordNotFound, RequisitionConnector, RequisitionNode,
+        RequisitionNodeStatus, RequisitionNodeType,
+    },
+    standard_graphql_error::{validate_auth, StandardGraphqlError},
+    ContextExt,
 };
 
 use super::EqualFilterStringInput;
@@ -37,17 +48,11 @@ pub struct RequisitionFilterInput {
     pub created_datetime: Option<DatetimeFilterInput>,
     pub sent_datetime: Option<DatetimeFilterInput>,
     pub finalised_datetime: Option<DatetimeFilterInput>,
-    pub other_party_name: Option<EqualFilterStringInput>,
+    pub other_party_name: Option<SimpleStringFilterInput>,
     pub other_party_id: Option<EqualFilterStringInput>,
     pub colour: Option<EqualFilterStringInput>,
-    pub their_reference: Option<EqualFilterStringInput>,
-    pub comment: Option<EqualFilterStringInput>,
-}
-
-#[derive(SimpleObject)]
-pub struct RequisitionConnector {
-    total_count: u32,
-    nodes: Vec<RequisitionNode>,
+    pub their_reference: Option<SimpleStringFilterInput>,
+    pub comment: Option<SimpleStringFilterInput>,
 }
 
 #[derive(Union)]
@@ -55,34 +60,154 @@ pub enum RequisitionsResponse {
     Response(RequisitionConnector),
 }
 
-pub fn get_requisitions(
-    _ctx: &Context<'_>,
-    _store_id: Option<String>,
-    _page: Option<PaginationInput>,
-    _filter: Option<RequisitionFilterInput>,
-    _sort: Option<Vec<RequisitionSortInput>>,
-) -> Result<RequisitionsResponse> {
-    todo!()
-}
-
 #[derive(Union)]
 pub enum RequisitionResponse {
+    Error(RecordNotFound),
     Response(RequisitionNode),
 }
 
-pub fn get_requisition(
-    _ctx: &Context<'_>,
-    _store_id: Option<String>,
-    _id: String,
-) -> Result<RequisitionResponse> {
-    todo!()
+pub fn get_requisition(ctx: &Context<'_>, store_id: &str, id: &str) -> Result<RequisitionResponse> {
+    validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::QueryRequisition,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.context()?;
+
+    let requisition_option = service_provider.requisition_service.get_requisition(
+        &service_context,
+        Some(store_id),
+        id,
+    )?;
+
+    let response = match requisition_option {
+        Some(requisition) => {
+            RequisitionResponse::Response(RequisitionNode::from_domain(requisition))
+        }
+        None => RequisitionResponse::Error(RecordNotFound {}),
+    };
+
+    Ok(response)
+}
+
+pub fn get_requisitions(
+    ctx: &Context<'_>,
+    store_id: &str,
+    page: Option<PaginationInput>,
+    filter: Option<RequisitionFilterInput>,
+    sort: Option<Vec<RequisitionSortInput>>,
+) -> Result<RequisitionsResponse> {
+    validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::QueryRequisition,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.context()?;
+
+    let requisitions = service_provider
+        .requisition_service
+        .get_requisitions(
+            &service_context,
+            Some(&store_id),
+            page.map(PaginationOption::from),
+            filter.map(|filter| filter.to_domain()),
+            // Currently only one sort option is supported, use the first from the list.
+            sort.map(|mut sort_list| sort_list.pop())
+                .flatten()
+                .map(|sort| sort.to_domain()),
+        )
+        .map_err(StandardGraphqlError::from_list_error)?;
+
+    Ok(RequisitionsResponse::Response(
+        RequisitionConnector::from_domain(requisitions),
+    ))
 }
 
 pub fn get_requisition_by_number(
-    _ctx: &Context<'_>,
-    _store_id: Option<String>,
-    _requisition_number: u32,
-    _type: RequisitionNodeType,
+    ctx: &Context<'_>,
+    store_id: &str,
+    requisition_number: u32,
+    r#type: RequisitionNodeType,
 ) -> Result<RequisitionResponse> {
-    todo!()
+    validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::QueryRequisition,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.context()?;
+
+    let requisition_option = service_provider
+        .requisition_service
+        .get_requisition_by_number(
+            &service_context,
+            store_id,
+            requisition_number,
+            r#type.to_domain(),
+        )?;
+
+    let response = match requisition_option {
+        Some(requisition) => {
+            RequisitionResponse::Response(RequisitionNode::from_domain(requisition))
+        }
+        None => RequisitionResponse::Error(RecordNotFound {}),
+    };
+
+    Ok(response)
+}
+
+impl RequisitionSortInput {
+    pub fn to_domain(self) -> RequisitionSort {
+        use RequisitionSortField as to;
+        use RequisitionSortFieldInput as from;
+        let key = match self.key {
+            from::RequisitionNumber => to::RequisitionNumber,
+            from::Type => to::Type,
+            from::Status => to::Status,
+            from::OtherPartyName => to::OtherPartyName,
+            from::SentDatetime => to::SentDatetime,
+            from::CreatedDatetime => to::CreatedDatetime,
+            from::FinalisedDatetime => to::FinalisedDatetime,
+        };
+
+        RequisitionSort {
+            key,
+            desc: self.desc,
+        }
+    }
+}
+
+impl RequisitionFilterInput {
+    pub fn to_domain(self) -> RequisitionFilter {
+        RequisitionFilter {
+            id: self.id.map(EqualFilter::from),
+            requisition_number: self.requisition_number.map(EqualFilter::from),
+            r#type: self
+                .r#type
+                .map(|t| t.map_to_domain(RequisitionNodeType::to_domain)),
+            status: self
+                .status
+                .map(|t| t.map_to_domain(RequisitionNodeStatus::to_domain)),
+            created_datetime: self.created_datetime.map(DatetimeFilter::from),
+            sent_datetime: self.sent_datetime.map(DatetimeFilter::from),
+            finalised_datetime: self.finalised_datetime.map(DatetimeFilter::from),
+            name: self.other_party_name.map(SimpleStringFilter::from),
+            name_id: self.other_party_id.map(EqualFilter::from),
+            colour: self.colour.map(EqualFilter::from),
+            their_reference: self.their_reference.map(SimpleStringFilter::from),
+            comment: self.comment.map(SimpleStringFilter::from),
+            store_id: None,
+        }
+    }
 }

--- a/graphql/src/schema/types/invoice_query.rs
+++ b/graphql/src/schema/types/invoice_query.rs
@@ -71,6 +71,7 @@ impl From<InvoiceFilterInput> for InvoiceFilter {
             shipped_datetime: f.shipped_datetime.map(DatetimeFilter::from),
             delivered_datetime: f.delivered_datetime.map(DatetimeFilter::from),
             verified_datetime: f.verified_datetime.map(DatetimeFilter::from),
+            requisition_id: None,
         }
     }
 }

--- a/graphql/src/schema/types/item_stats.rs
+++ b/graphql/src/schema/types/item_stats.rs
@@ -1,17 +1,20 @@
 use async_graphql::*;
-pub struct ItemStats {}
+pub struct ItemStats {
+    pub average_monthly_consumption: i32,
+    pub stock_on_hand: i32,
+}
 
 #[Object]
 impl ItemStats {
-    pub async fn average_monthly_consumption(&self) -> f64 {
-        todo!()
+    pub async fn average_monthly_consumption(&self) -> i32 {
+        self.average_monthly_consumption
     }
 
-    pub async fn stock_on_hand(&self) -> u32 {
-        todo!()
+    pub async fn stock_on_hand(&self) -> i32 {
+        self.stock_on_hand
     }
 
     pub async fn months_of_stock(&self) -> f64 {
-        todo!()
+        self.stock_on_hand as f64 / self.average_monthly_consumption as f64
     }
 }

--- a/graphql/src/schema/types/master_list_line.rs
+++ b/graphql/src/schema/types/master_list_line.rs
@@ -54,7 +54,7 @@ impl MasterListLineNode {
             .await?;
         let item = item_option.ok_or(
             StandardGraphqlError::InternalError(format!(
-                "Cannot find item_id {} for invoice_line_id {}",
+                "Cannot find item_id {} for master_list_line_id {}",
                 self.master_list_line.item_id, self.master_list_line.id
             ))
             .extend(),

--- a/graphql/src/schema/types/mod.rs
+++ b/graphql/src/schema/types/mod.rs
@@ -68,6 +68,15 @@ pub struct Connector<T: OutputType> {
     nodes: Vec<T>,
 }
 
+impl<T: OutputType> Connector<T> {
+    pub fn empty() -> Connector<T> {
+        Connector {
+            total_count: 0,
+            nodes: vec![],
+        }
+    }
+}
+
 /// Convert from ListResult (service return) to Generic Connector
 impl<DomainType, GQLType> From<ListResult<DomainType>> for Connector<GQLType>
 where

--- a/graphql/src/schema/types/requisition.rs
+++ b/graphql/src/schema/types/requisition.rs
@@ -1,5 +1,22 @@
+use std::ops::Deref;
+
+use self::dataloader::DataLoader;
+use crate::{
+    loader::{
+        InvoiceByRequisitionIdLoader, NameByIdLoader, RequisitionLinesByRequisitionIdLoader,
+        RequisitionsByIdLoader,
+    },
+    standard_graphql_error::StandardGraphqlError,
+    ContextExt,
+};
 use async_graphql::*;
 use chrono::{DateTime, Utc};
+use repository::{
+    schema::{RequisitionRow, RequisitionRowStatus, RequisitionRowType},
+    Requisition,
+};
+use service::ListResult;
+use StandardGraphqlError::*;
 
 use super::{Connector, InvoiceNode, NameNode, RequisitionLineConnector};
 
@@ -25,93 +42,205 @@ pub enum RequisitionNodeStatus {
 }
 
 #[derive(PartialEq, Debug)]
-pub struct RequisitionNode {}
+pub struct RequisitionNode {
+    requisition: Requisition,
+}
+
+#[derive(SimpleObject)]
+pub struct RequisitionConnector {
+    total_count: u32,
+    nodes: Vec<RequisitionNode>,
+}
 
 #[Object]
 impl RequisitionNode {
     pub async fn id(&self) -> &str {
-        todo!()
+        &self.id
     }
 
-    pub async fn r#type(&self) -> &RequisitionNodeType {
-        todo!()
+    pub async fn r#type(&self) -> RequisitionNodeType {
+        RequisitionNodeType::from_domain(&self.r#type)
     }
 
-    pub async fn status(&self) -> &RequisitionNodeStatus {
-        todo!()
+    pub async fn status(&self) -> RequisitionNodeStatus {
+        RequisitionNodeStatus::from_domain(&self.status)
     }
 
     pub async fn created_datetime(&self) -> DateTime<Utc> {
-        todo!()
+        DateTime::<Utc>::from_utc(*&self.created_datetime.clone(), Utc)
     }
 
     /// Applicable to request requisition only
     pub async fn sent_datetime(&self) -> Option<DateTime<Utc>> {
-        todo!()
+        let sent_datetime = *&self.sent_datetime.clone();
+        sent_datetime.map(|v| DateTime::<Utc>::from_utc(v, Utc))
     }
 
     pub async fn finalised_datetime(&self) -> Option<DateTime<Utc>> {
-        todo!()
+        let finalised_datetime = *&self.finalised_datetime.clone();
+        finalised_datetime.map(|v| DateTime::<Utc>::from_utc(v, Utc))
     }
 
-    /// Link to request requisition, for request requisition it's the same as current node
-    pub async fn request_requisition(&self) -> Result<RequisitionNode> {
-        todo!()
-    }
-
-    pub async fn requisition_number(&self) -> u32 {
-        todo!()
+    pub async fn requisition_number(&self) -> &i64 {
+        &self.requisition_number
     }
 
     pub async fn colour(&self) -> &Option<String> {
-        todo!()
+        &self.colour
     }
 
     pub async fn their_reference(&self) -> &Option<String> {
-        todo!()
+        &self.their_reference
     }
 
     // TODO our reference ? How does their reference reflect in other half of requisition ?
 
     pub async fn comment(&self) -> &Option<String> {
-        todo!()
+        &self.comment
     }
 
     /// Request Requisition: Supplying store (store that is supplying stock)
     /// Response Requisition: Customer store (store that is ordering stock)
-    pub async fn other_party(&self, _ctx: &Context<'_>) -> Result<NameNode> {
-        todo!()
+    pub async fn other_party(&self, ctx: &Context<'_>) -> Result<NameNode> {
+        let loader = ctx.get_loader::<DataLoader<NameByIdLoader>>();
+
+        let response_option = loader.load_one(self.name_id.clone()).await?;
+
+        response_option.map(NameNode::from).ok_or(
+            InternalError(format!(
+                "Cannot find name ({}) linked to requisition ({})",
+                &self.name_id, &self.id
+            ))
+            .extend(),
+        )
     }
 
     pub async fn other_party_name(&self) -> &str {
-        todo!()
+        &self.requisition.name_row.name
     }
 
     pub async fn other_party_id(&self) -> &str {
-        todo!()
+        &self.name_id
     }
 
     /// Maximum calculated quantity, used to deduce calculated quantity for each line, see calculated in requisition line
-    pub async fn max_months_of_stock(&self) -> f64 {
-        todo!()
+    pub async fn max_months_of_stock(&self) -> &f64 {
+        &self.max_months_of_stock
     }
 
     /// Minimum quantity to have for stock to be ordered, used to deduce calculated quantity for each line, see calculated in requisition line
-    pub async fn threshold_months_of_stock(&self) -> f64 {
-        todo!()
+    pub async fn threshold_months_of_stock(&self) -> &f64 {
+        &self.threshold_months_of_stock
     }
 
-    pub async fn lines(&self, _ctx: &Context<'_>) -> Result<RequisitionLineConnector> {
-        todo!()
+    pub async fn lines(&self, ctx: &Context<'_>) -> Result<RequisitionLineConnector> {
+        let loader = ctx.get_loader::<DataLoader<RequisitionLinesByRequisitionIdLoader>>();
+        let result_option = loader.load_one((&self.id).to_owned()).await?;
+
+        let result = result_option.unwrap_or(vec![]);
+
+        Ok(RequisitionLineConnector::from_vec(result))
+    }
+
+    /// Link to request requisition
+    pub async fn request_requisition(&self, ctx: &Context<'_>) -> Result<Option<RequisitionNode>> {
+        if &self.r#type == &RequisitionRowType::Request {
+            return Ok(None);
+        }
+
+        let request_requisition_id = if let Some(id) = &self.linked_requisition_id {
+            id
+        } else {
+            return Ok(None);
+        };
+
+        let loader = ctx.get_loader::<DataLoader<RequisitionsByIdLoader>>();
+
+        Ok(loader
+            .load_one(request_requisition_id.clone())
+            .await?
+            .map(RequisitionNode::from_domain))
     }
 
     /// Response Requisition: Outbound Shipments linked requisition
     /// Request Requisition: Inbound Shipments linked to requisition
-    pub async fn shipments(&self, _ctx: &Context<'_>) -> Result<Connector<InvoiceNode>> {
-        todo!()
+    pub async fn shipments(&self, ctx: &Context<'_>) -> Result<Connector<InvoiceNode>> {
+        let loader = ctx.get_loader::<DataLoader<InvoiceByRequisitionIdLoader>>();
+        let result_option = loader.load_one((&self.id).to_owned()).await?;
+
+        let list_result = result_option.unwrap_or(vec![]);
+
+        Ok(list_result.into())
     }
 
     // % allocated ?
     // % shipped ?
     // lead time ?
+}
+
+impl Deref for RequisitionNode {
+    type Target = RequisitionRow;
+
+    fn deref(&self) -> &Self::Target {
+        &self.requisition.requisition_row
+    }
+}
+
+impl RequisitionNode {
+    pub fn from_domain(requisition: Requisition) -> RequisitionNode {
+        RequisitionNode { requisition }
+    }
+}
+
+impl RequisitionConnector {
+    pub fn from_domain(requisitions: ListResult<Requisition>) -> RequisitionConnector {
+        RequisitionConnector {
+            total_count: requisitions.count,
+            nodes: requisitions
+                .rows
+                .into_iter()
+                .map(RequisitionNode::from_domain)
+                .collect(),
+        }
+    }
+}
+
+impl RequisitionNodeType {
+    pub fn to_domain(self) -> RequisitionRowType {
+        use RequisitionNodeType::*;
+        match self {
+            Request => RequisitionRowType::Request,
+            Response => RequisitionRowType::Response,
+        }
+    }
+
+    pub fn from_domain(r#type: &RequisitionRowType) -> RequisitionNodeType {
+        use RequisitionRowType::*;
+        match r#type {
+            Request => RequisitionNodeType::Request,
+            Response => RequisitionNodeType::Response,
+        }
+    }
+}
+
+impl RequisitionNodeStatus {
+    pub fn to_domain(self) -> RequisitionRowStatus {
+        use RequisitionNodeStatus::*;
+        match self {
+            Draft => RequisitionRowStatus::Draft,
+            New => RequisitionRowStatus::New,
+            Sent => RequisitionRowStatus::Sent,
+            Finalised => RequisitionRowStatus::Finalised,
+        }
+    }
+
+    pub fn from_domain(status: &RequisitionRowStatus) -> RequisitionNodeStatus {
+        use RequisitionRowStatus::*;
+        match status {
+            Draft => RequisitionNodeStatus::Draft,
+            New => RequisitionNodeStatus::New,
+            Sent => RequisitionNodeStatus::Sent,
+            Finalised => RequisitionNodeStatus::Finalised,
+        }
+    }
 }

--- a/graphql/src/schema/types/requisition_line.rs
+++ b/graphql/src/schema/types/requisition_line.rs
@@ -1,9 +1,28 @@
+use std::ops::Deref;
+
 use async_graphql::*;
+use dataloader::DataLoader;
+use repository::{
+    schema::{RequisitionLineRow, RequisitionRowType},
+    RequisitionLine,
+};
+use service::{usize_to_u32, ListResult};
+
+use crate::{
+    loader::{
+        InvoiceLineForRequisitionLine, ItemLoader, LinkedRequisitionLineLoader,
+        RequisitionAndItemId,
+    },
+    standard_graphql_error::StandardGraphqlError,
+    ContextExt,
+};
 
 use super::{Connector, InvoiceLineNode, ItemNode, ItemStats};
 
 #[derive(PartialEq, Debug)]
-pub struct RequisitionLineNode {}
+pub struct RequisitionLineNode {
+    requisition_line: RequisitionLine,
+}
 
 #[derive(SimpleObject)]
 pub struct RequisitionLineConnector {
@@ -14,51 +33,166 @@ pub struct RequisitionLineConnector {
 #[Object]
 impl RequisitionLineNode {
     pub async fn id(&self) -> &str {
-        todo!()
+        &self.id
     }
 
     pub async fn item_id(&self) -> &str {
-        todo!()
+        &self.item_id
     }
 
-    pub async fn item(&self) -> Result<ItemNode> {
-        todo!()
+    pub async fn item(&self, ctx: &Context<'_>) -> Result<ItemNode> {
+        let loader = ctx.get_loader::<DataLoader<ItemLoader>>();
+        let item_option = loader.load_one((&self.item_id).to_owned()).await?;
+        let item = item_option.ok_or(
+            StandardGraphqlError::InternalError(format!(
+                "Cannot find item_id {} for requisition_line_id {}",
+                &self.item_id, &self.id
+            ))
+            .extend(),
+        )?;
+
+        Ok(ItemNode::from(item))
     }
 
     /// Quantity requested
-    pub async fn requested_quantity(&self) -> u32 {
-        todo!()
+    pub async fn requested_quantity(&self) -> &i32 {
+        &self.requested_quantity
     }
 
     /// Quantity to be supplied in the next shipment, only used in response requisition
-    pub async fn supply_quantity(&self) -> u32 {
-        todo!()
+    pub async fn supply_quantity(&self) -> &i32 {
+        &self.supply_quantity
     }
 
     /// Calculated quantity
     /// When months_of_stock < requisition.threshold_months_of_stock, calculated = average_monthy_consumption * requisition.max_months_of_stock - months_of_stock
-    pub async fn calculated_quantity(&self) -> u32 {
-        todo!()
+    pub async fn calculated_quantity(&self) -> &i32 {
+        &self.calculated_quantity
     }
 
     /// OutboundShipment lines linked to requisitions line
-    pub async fn outbound_shipment_lines(&self) -> Result<Connector<InvoiceLineNode>> {
-        todo!()
+    pub async fn outbound_shipment_lines(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<Connector<InvoiceLineNode>> {
+        // Outbound shipments link to response requisition, so for request requisition
+        // use linked requisition id
+        let requistion_row = &self.requisition_line.requisition_row;
+        let requisition_id = match requistion_row.r#type {
+            RequisitionRowType::Request => match &requistion_row.linked_requisition_id {
+                Some(linked_requisition_id) => linked_requisition_id,
+                None => return Ok(Connector::empty()),
+            },
+            _ => &self.id,
+        };
+
+        let loader = ctx.get_loader::<DataLoader<InvoiceLineForRequisitionLine>>();
+        let result_option = loader
+            .load_one(RequisitionAndItemId {
+                requisition_id: requisition_id.clone(),
+                item_id: (&self.item_id).clone(),
+            })
+            .await?;
+
+        let list_result = result_option.unwrap_or(vec![]);
+
+        Ok(list_result.into())
     }
 
     /// InboundShipment lines linked to requisitions line
-    pub async fn inbound_shipment_lines(&self) -> Result<Connector<InvoiceLineNode>> {
-        todo!()
+    pub async fn inbound_shipment_lines(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<Connector<InvoiceLineNode>> {
+        // Outbound shipments links to request requisition, so for response requisition
+        // use linked requisition id
+        let requistion_row = &self.requisition_line.requisition_row;
+        let requisition_id = match requistion_row.r#type {
+            RequisitionRowType::Response => match &requistion_row.linked_requisition_id {
+                Some(linked_requisition_id) => linked_requisition_id,
+                None => return Ok(Connector::empty()),
+            },
+            _ => &self.id,
+        };
+
+        let loader = ctx.get_loader::<DataLoader<InvoiceLineForRequisitionLine>>();
+        let result_option = loader
+            .load_one(RequisitionAndItemId {
+                requisition_id: requisition_id.clone(),
+                item_id: (&self.item_id).clone(),
+            })
+            .await?;
+
+        let list_result = result_option.unwrap_or(vec![]);
+
+        Ok(list_result.into())
     }
 
-    /// Snapshot of item statistics for requisition owner store
-    pub async fn stats(&self) -> Result<ItemStats> {
-        todo!()
+    /// Snapshot Stats (when requisition was created)
+    pub async fn average_monthly_consumption(&self) -> ItemStats {
+        ItemStats {
+            average_monthly_consumption: *&self.average_monthly_consumption,
+            stock_on_hand: *&self.stock_on_hand,
+        }
     }
 
-    /// Snapshot of item statistics from request requisition
-    /// For request requisition it's the same as stats
-    pub async fn request_stats(&self) -> Result<ItemStats> {
-        todo!()
+    pub async fn linked_requisition_line_id(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<Option<RequisitionLineNode>> {
+        let linked_requisition_id = if let Some(linked_requisition_id) =
+            &self.requisition_line.requisition_row.linked_requisition_id
+        {
+            linked_requisition_id
+        } else {
+            return Ok(None);
+        };
+
+        let loader = ctx.get_loader::<DataLoader<LinkedRequisitionLineLoader>>();
+        let result_option = loader
+            .load_one(RequisitionAndItemId {
+                requisition_id: linked_requisition_id.clone(),
+                item_id: (&self.item_id).clone(),
+            })
+            .await?;
+
+        Ok(result_option.map(RequisitionLineNode::from_domain))
+    }
+}
+
+impl Deref for RequisitionLineNode {
+    type Target = RequisitionLineRow;
+
+    fn deref(&self) -> &Self::Target {
+        &self.requisition_line.requisition_line_row
+    }
+}
+
+impl RequisitionLineNode {
+    pub fn from_domain(requisition_line: RequisitionLine) -> RequisitionLineNode {
+        RequisitionLineNode { requisition_line }
+    }
+}
+
+impl RequisitionLineConnector {
+    pub fn from_domain(requisition_lines: ListResult<RequisitionLine>) -> RequisitionLineConnector {
+        RequisitionLineConnector {
+            total_count: requisition_lines.count,
+            nodes: requisition_lines
+                .rows
+                .into_iter()
+                .map(RequisitionLineNode::from_domain)
+                .collect(),
+        }
+    }
+
+    pub fn from_vec(requisition_lines: Vec<RequisitionLine>) -> RequisitionLineConnector {
+        RequisitionLineConnector {
+            total_count: usize_to_u32(requisition_lines.len()),
+            nodes: requisition_lines
+                .into_iter()
+                .map(RequisitionLineNode::from_domain)
+                .collect(),
+        }
     }
 }

--- a/graphql/src/schema/types/sort_filter_types.rs
+++ b/graphql/src/schema/types/sort_filter_types.rs
@@ -96,6 +96,21 @@ pub type EqualFilterStringInput = EqualFilterInput<String>;
 pub type EqualFilterNumberInput = EqualFilterInput<i32>;
 pub type EqualFilterBigNumberInput = EqualFilterInput<i64>;
 
+impl<I: InputType> EqualFilterInput<I> {
+    pub fn map_to_domain<F, T>(self, to_domain: F) -> EqualFilter<T>
+    where
+        F: Fn(I) -> T,
+    {
+        EqualFilter {
+            equal_to: self.equal_to.map(&to_domain),
+            not_equal_to: self.not_equal_to.map(&to_domain),
+            equal_any: self
+                .equal_any
+                .map(|inputs| inputs.into_iter().map(&to_domain).collect()),
+        }
+    }
+}
+
 impl<T> From<EqualFilterInput<T>> for EqualFilter<T>
 where
     T: InputType,

--- a/graphql/src/standard_graphql_error.rs
+++ b/graphql/src/standard_graphql_error.rs
@@ -43,6 +43,22 @@ impl From<RepositoryError> for StandardGraphqlError {
     }
 }
 
+impl StandardGraphqlError {
+    pub fn from_list_error(error: ListError) -> async_graphql::Error {
+        let formatted_error = format!("{:#?}", error);
+        let graphql_error = match error {
+            ListError::DatabaseError(error) => error.into(),
+            ListError::LimitBelowMin(_) => StandardGraphqlError::BadUserInput(formatted_error),
+            ListError::LimitAboveMax(_) => StandardGraphqlError::BadUserInput(formatted_error),
+        };
+        graphql_error.extend()
+    }
+
+    pub fn from_repository_error(error: RepositoryError) -> async_graphql::Error {
+        StandardGraphqlError::from(error).extend()
+    }
+}
+
 /// Validates current user is authenticated and authorized
 pub fn validate_auth(
     ctx: &Context<'_>,

--- a/repository/migrations/postgres/2021-09-18T10:00_create_requisition_line table/up.sql
+++ b/repository/migrations/postgres/2021-09-18T10:00_create_requisition_line table/up.sql
@@ -7,8 +7,6 @@ CREATE TABLE requisition_line (
     requested_quantity INTEGER NOT NULL,
     calculated_quantity INTEGER NOT NULL,
     supply_quantity INTEGER NOT NULL,
-    request_stock_on_hand INTEGER NOT NULL,
-    request_average_monthly_consumption INTEGER NOT NULL,
-    response_stock_on_hand INTEGER NOT NULL,
-    response_average_monthly_consumption INTEGER NOT NULL
+    stock_on_hand INTEGER NOT NULL,
+    average_monthly_consumption INTEGER NOT NULL
 )

--- a/repository/migrations/sqlite/2021-09-18T10:00_create_requisition_line_table/up.sql
+++ b/repository/migrations/sqlite/2021-09-18T10:00_create_requisition_line_table/up.sql
@@ -7,8 +7,6 @@ CREATE TABLE requisition_line (
     requested_quantity INTEGER NOT NULL,
     calculated_quantity INTEGER NOT NULL,
     supply_quantity INTEGER NOT NULL,
-    request_stock_on_hand INTEGER NOT NULL,
-    request_average_monthly_consumption INTEGER NOT NULL,
-    response_stock_on_hand INTEGER NOT NULL,
-    response_average_monthly_consumption INTEGER NOT NULL
+    stock_on_hand INTEGER NOT NULL,
+    average_monthly_consumption INTEGER NOT NULL
 )

--- a/repository/src/db_diesel/invoice_query.rs
+++ b/repository/src/db_diesel/invoice_query.rs
@@ -180,6 +180,7 @@ fn to_domain((invoice_row, name_row, _store_row): InvoiceQueryJoin) -> Invoice {
         delivered_datetime: invoice_row.delivered_datetime,
         verified_datetime: invoice_row.verified_datetime,
         colour: invoice_row.colour,
+        requisition_id: invoice_row.requisition_id,
     }
 }
 
@@ -198,6 +199,7 @@ pub fn create_filtered_query<'a>(filter: Option<InvoiceFilter>) -> BoxedInvoiceQ
         apply_equal_filter!(query, f.name_id, invoice_dsl::name_id);
         apply_equal_filter!(query, f.store_id, invoice_dsl::store_id);
         apply_equal_filter!(query, f.their_reference, invoice_dsl::their_reference);
+        apply_equal_filter!(query, f.requisition_id, invoice_dsl::requisition_id);
         apply_simple_string_filter!(query, f.comment, invoice_dsl::comment);
 
         if let Some(value) = f.r#type {

--- a/repository/src/db_diesel/requisition/requisition.rs
+++ b/repository/src/db_diesel/requisition/requisition.rs
@@ -23,7 +23,7 @@ use super::{RequisitionFilter, RequisitionSort, RequisitionSortField};
 
 pub type RequisitionJoin = (RequisitionRow, NameRow);
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Requisition {
     pub requisition_row: RequisitionRow,
     pub name_row: NameRow,

--- a/repository/src/db_diesel/requisition_line/mod.rs
+++ b/repository/src/db_diesel/requisition_line/mod.rs
@@ -10,6 +10,7 @@ pub use self::requisition_line_row::*;
 pub struct RequisitionLineFilter {
     pub id: Option<EqualFilter<String>>,
     pub requisition_id: Option<EqualFilter<String>>,
+    pub item_id: Option<EqualFilter<String>>,
     pub requested_quantity: Option<EqualFilter<i32>>,
 }
 
@@ -19,6 +20,7 @@ impl RequisitionLineFilter {
             id: None,
             requisition_id: None,
             requested_quantity: None,
+            item_id: None,
         }
     }
 
@@ -34,6 +36,11 @@ impl RequisitionLineFilter {
 
     pub fn requested_quantity(mut self, filter: EqualFilter<i32>) -> Self {
         self.requested_quantity = Some(filter);
+        self
+    }
+
+    pub fn item_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.item_id = Some(filter);
         self
     }
 }

--- a/repository/src/mock/test_requisition_line_repository.rs
+++ b/repository/src/mock/test_requisition_line_repository.rs
@@ -21,10 +21,8 @@ pub fn mock_draft_request_requisition_line() -> RequisitionLineRow {
         requested_quantity: 10,
         calculated_quantity: 3,
         supply_quantity: 0,
-        request_stock_on_hand: 1,
-        request_average_monthly_consumption: 10,
-        response_stock_on_hand: 1000,
-        response_average_monthly_consumption: 100000,
+        stock_on_hand: 1,
+        average_monthly_consumption: 10,
     }
 }
 
@@ -36,9 +34,7 @@ pub fn mock_draft_request_requisition_line2() -> RequisitionLineRow {
         requested_quantity: 10,
         calculated_quantity: 3,
         supply_quantity: 0,
-        request_stock_on_hand: 1,
-        request_average_monthly_consumption: 10,
-        response_stock_on_hand: 1000,
-        response_average_monthly_consumption: 100000,
+        stock_on_hand: 1,
+        average_monthly_consumption: 10,
     }
 }

--- a/repository/src/schema/diesel_schema.rs
+++ b/repository/src/schema/diesel_schema.rs
@@ -99,10 +99,8 @@ table! {
         requested_quantity -> Integer,
         calculated_quantity -> Integer,
         supply_quantity -> Integer,
-        request_stock_on_hand -> Integer ,
-        request_average_monthly_consumption -> Integer,
-        response_stock_on_hand -> Integer,
-        response_average_monthly_consumption -> Integer,
+        stock_on_hand -> Integer ,
+        average_monthly_consumption -> Integer,
     }
 }
 

--- a/repository/src/schema/requisition_line.rs
+++ b/repository/src/schema/requisition_line.rs
@@ -9,8 +9,6 @@ pub struct RequisitionLineRow {
     pub requested_quantity: i32,
     pub calculated_quantity: i32,
     pub supply_quantity: i32,
-    pub request_stock_on_hand: i32,
-    pub request_average_monthly_consumption: i32,
-    pub response_stock_on_hand: i32,
-    pub response_average_monthly_consumption: i32,
+    pub stock_on_hand: i32,
+    pub average_monthly_consumption: i32,
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -49,8 +49,12 @@ async fn main() -> std::io::Result<()> {
         debug_no_access_control: true,
     });
     let connection_manager = get_storage_connection_manager(&settings.database);
-    let loaders: LoaderMap = get_loaders(&connection_manager).await;
     let service_provider = ServiceProvider::new(connection_manager.clone());
+    let service_provider_data = Data::new(service_provider);
+
+    let loaders: LoaderMap = get_loaders(&connection_manager, service_provider_data.clone()).await;
+    let loader_registry_data = Data::new(LoaderRegistry { loaders });
+
     let (mut sync_sender, mut sync_receiver): (SyncSenderActor, SyncReceiverActor) =
         sync::get_sync_actors();
 
@@ -60,8 +64,7 @@ async fn main() -> std::io::Result<()> {
 
     let connection_manager_data_app = Data::new(connection_manager);
     let connection_manager_data_sync = connection_manager_data_app.clone();
-    let loader_registry_data = Data::new(LoaderRegistry { loaders });
-    let service_provider_data = Data::new(service_provider);
+
     let actor_registry_data = Data::new(actor_registry);
 
     let mut http_server = HttpServer::new(move || {

--- a/server/tests/graphql/invoice_by_number.rs
+++ b/server/tests/graphql/invoice_by_number.rs
@@ -96,6 +96,7 @@ mod graphql {
                 verified_datetime: None,
                 colour: None,
                 r#type: InvoiceType::OutboundShipment,
+                requisition_id: None,
             }))
         }));
 

--- a/server/tests/graphql/location_delete.rs
+++ b/server/tests/graphql/location_delete.rs
@@ -169,6 +169,7 @@ mod graphql {
                     batch: None,
                     expiry_date: None,
                     note: None,
+                    requisition_id: None,
                 }],
             }))
         }));

--- a/server/tests/graphql/mod.rs
+++ b/server/tests/graphql/mod.rs
@@ -37,7 +37,6 @@ mod outbound_shipment_line_insert;
 mod outbound_shipment_line_update;
 mod outbound_shipment_update;
 mod pagination;
-mod requisition;
 mod stock_take_delete;
 mod stock_take_insert;
 mod stock_take_line_delete;
@@ -53,12 +52,13 @@ where
     OUT: DeserializeOwned,
 {
     let connection_manager = get_storage_connection_manager(&settings.database);
-    let loaders = get_loaders(&connection_manager).await;
-
     let connection_manager_data = actix_web::web::Data::new(connection_manager.clone());
-    let loader_registry = actix_web::web::Data::new(LoaderRegistry { loaders });
+
     let service_provider_data =
         actix_web::web::Data::new(ServiceProvider::new(connection_manager.clone()));
+
+    let loaders = get_loaders(&connection_manager, service_provider_data.clone()).await;
+    let loader_registry = actix_web::web::Data::new(LoaderRegistry { loaders });
 
     let auth_data = Data::new(AuthData {
         auth_token_secret: settings.auth.token_secret.to_owned(),
@@ -105,14 +105,15 @@ async fn run_gql_query(
     service_provider_override: Option<ServiceProvider>,
 ) -> serde_json::Value {
     let connection_manager = get_storage_connection_manager(&settings.database);
-    let loaders = get_loaders(&connection_manager).await;
-
     let connection_manager_data = actix_web::web::Data::new(connection_manager.clone());
-    let loader_registry = actix_web::web::Data::new(LoaderRegistry { loaders });
+
     let service_provider_data = actix_web::web::Data::new(match service_provider_override {
         Some(service_provider) => service_provider,
         None => ServiceProvider::new(connection_manager.clone()),
     });
+
+    let loaders = get_loaders(&connection_manager, service_provider_data.clone()).await;
+    let loader_registry = actix_web::web::Data::new(LoaderRegistry { loaders });
 
     let auth_data = Data::new(AuthData {
         auth_token_secret: settings.auth.token_secret.to_owned(),

--- a/server/tests/graphql/unallocated_line/mod.rs
+++ b/server/tests/graphql/unallocated_line/mod.rs
@@ -22,5 +22,6 @@ pub fn successfull_invoice_line() -> InvoiceLine {
         stock_line_id: None,
         location_id: None,
         location_name: None,
+        requisition_id: None,
     }
 }

--- a/service/src/permission_validation.rs
+++ b/service/src/permission_validation.rs
@@ -24,6 +24,8 @@ pub enum Resource {
     InsertStockTake,
     UpdateStockTake,
     DeleteStockTake,
+    // requisition
+    QueryRequisition,
     // stock take line
     InsertStockTakeLine,
     UpdateStockTakeLine,

--- a/service/src/requisition/mod.rs
+++ b/service/src/requisition/mod.rs
@@ -3,7 +3,9 @@ use self::query::{get_requisition, get_requisition_by_number, get_requisitions};
 use super::{ListError, ListResult};
 use crate::service_provider::ServiceContext;
 use domain::PaginationOption;
-use repository::{schema::RequisitionRowType, Requisition, RequisitionFilter, RequisitionSort};
+use repository::{
+    schema::RequisitionRowType, RepositoryError, Requisition, RequisitionFilter, RequisitionSort,
+};
 
 pub mod query;
 
@@ -11,21 +13,21 @@ pub trait RequisitionServiceTrait: Sync + Send {
     fn get_requisitions(
         &self,
         ctx: &ServiceContext,
-        store_id: &str,
+        store_id_option: Option<&str>,
         pagination: Option<PaginationOption>,
         filter: Option<RequisitionFilter>,
         sort: Option<RequisitionSort>,
     ) -> Result<ListResult<Requisition>, ListError> {
-        get_requisitions(ctx, store_id, pagination, filter, sort)
+        get_requisitions(ctx, store_id_option, pagination, filter, sort)
     }
 
     fn get_requisition(
         &self,
         ctx: &ServiceContext,
-        store_id: &str,
+        store_id_option: Option<&str>,
         id: &str,
-    ) -> Result<Option<Requisition>, ListError> {
-        get_requisition(ctx, store_id, id)
+    ) -> Result<Option<Requisition>, RepositoryError> {
+        get_requisition(ctx, store_id_option, id)
     }
 
     fn get_requisition_by_number(
@@ -34,7 +36,7 @@ pub trait RequisitionServiceTrait: Sync + Send {
         store_id: &str,
         requisition_number: u32,
         r#type: RequisitionRowType,
-    ) -> Result<Option<Requisition>, ListError> {
+    ) -> Result<Option<Requisition>, RepositoryError> {
         get_requisition_by_number(ctx, store_id, requisition_number, r#type)
     }
 }


### PR DESCRIPTION
Closes https://github.com/openmsupply/remote-server/issues/716

Added a few variations to loaders. 
* Needed to load by both requisition and item id (and in future pr by store_id filter), so added a hashable struct that holds both (`RequistionAndItemId`)
* Added service provider to loaders (that use it), Clemens, is that what you meant by https://github.com/openmsupply/remote-server/issues/700 ?

Queries
* store_id not optional (for requisition queries)
* Use simple string filters
* Used deref of `node` object to point to main record (i.e. for RequisitionNode it's self.requisition.requisition_row (this could also just be a method, would that be simpler ? self.row())

* Added equal filter generic impl of map_to_domain, so we can easily map enum filters
* Added `QueryRequisition` to permissions
* Added from_list_error for StandardGraphqlError (not that happy with this one as it actually returns `async_graphl::Error` but wanted a method that does this (including .extend), i think i've added a few other downstream, happy to change to something better)