### PR TITLE
726 response requisition and line service

### DIFF
--- a/repository/src/mock/test_requisition_service.rs
+++ b/repository/src/mock/test_requisition_service.rs
@@ -1,14 +1,16 @@
 use chrono::NaiveDate;
 
 use crate::schema::{
+    InvoiceLineRow, InvoiceLineRowType, InvoiceRow, InvoiceRowStatus, InvoiceRowType,
     MasterListLineRow, MasterListNameJoinRow, MasterListRow, RequisitionLineRow, RequisitionRow,
     RequisitionRowStatus, RequisitionRowType,
 };
 
 use super::{
-    common::{FullMockMasterList, FullMockRequisition},
+    common::{FullMockInvoice, FullMockInvoiceLine, FullMockMasterList, FullMockRequisition},
     mock_item_a, mock_item_b, mock_item_c, mock_item_d, mock_item_stats_item1,
-    mock_item_stats_item2, mock_name_a, mock_name_store_a, mock_store_a, MockData,
+    mock_item_stats_item2, mock_name_a, mock_name_store_a, mock_stock_line_a, mock_store_a,
+    MockData,
 };
 
 pub fn mock_test_requisition_service() -> MockData {
@@ -21,21 +23,38 @@ pub fn mock_test_requisition_service() -> MockData {
         .requisition_lines
         .push(mock_draft_response_requisition_for_update_test_line());
     result
+        .requisition_lines
+        .push(mock_finalised_request_requisition_line());
+    result
         .requisitions
         .push(mock_draft_request_requisition_for_update_test());
     result
         .requisitions
         .push(mock_draft_response_requisition_for_update_test());
+    result
+        .requisitions
+        .push(mock_finalised_response_requisition());
+    result.requisitions.push(mock_new_response_requisition());
     result.requisitions.push(mock_sent_request_requisition());
     result
         .full_requisitions
         .push(mock_request_draft_requisition_calculation_test());
+    result
+        .full_requisitions
+        .push(mock_new_response_requisition_test());
     result
         .full_master_lists
         .push(mock_test_add_from_master_list());
     result
         .full_master_lists
         .push(mock_test_not_store_a_master_list());
+
+    result.full_invoices = vec![(
+        "mock_new_response_requisition_test_invoice".to_owned(),
+        mock_new_response_requisition_test_invoice(),
+    )]
+    .into_iter()
+    .collect();
 
     result
 }
@@ -113,6 +132,39 @@ pub fn mock_sent_request_requisition_line() -> RequisitionLineRow {
     }
 }
 
+pub fn mock_finalised_response_requisition() -> RequisitionRow {
+    RequisitionRow {
+        id: "mock_finalised_response_requisition".to_owned(),
+        requisition_number: 3,
+        name_id: "name_a".to_owned(),
+        store_id: mock_store_a().id,
+        r#type: RequisitionRowType::Response,
+        status: RequisitionRowStatus::Finalised,
+        created_datetime: NaiveDate::from_ymd(2021, 01, 01).and_hms(0, 0, 0),
+        sent_datetime: None,
+        finalised_datetime: None,
+        colour: None,
+        comment: None,
+        their_reference: None,
+        max_months_of_stock: 1.0,
+        threshold_months_of_stock: 0.9,
+        linked_requisition_id: None,
+    }
+}
+
+pub fn mock_finalised_request_requisition_line() -> RequisitionLineRow {
+    RequisitionLineRow {
+        id: "mock_finalised_request_requisition_line".to_owned(),
+        requisition_id: mock_finalised_response_requisition().id,
+        item_id: mock_item_a().id,
+        requested_quantity: 10,
+        calculated_quantity: 5,
+        supply_quantity: 0,
+        stock_on_hand: 1,
+        average_monthly_consumption: 1,
+    }
+}
+
 pub fn mock_draft_response_requisition_for_update_test() -> RequisitionRow {
     RequisitionRow {
         id: "mock_draft_response_requisition_for_update_test".to_owned(),
@@ -121,6 +173,26 @@ pub fn mock_draft_response_requisition_for_update_test() -> RequisitionRow {
         store_id: mock_store_a().id,
         r#type: RequisitionRowType::Response,
         status: RequisitionRowStatus::Draft,
+        created_datetime: NaiveDate::from_ymd(2021, 01, 01).and_hms(0, 0, 0),
+        sent_datetime: None,
+        finalised_datetime: None,
+        colour: None,
+        comment: None,
+        their_reference: None,
+        max_months_of_stock: 1.0,
+        threshold_months_of_stock: 0.9,
+        linked_requisition_id: None,
+    }
+}
+
+pub fn mock_new_response_requisition() -> RequisitionRow {
+    RequisitionRow {
+        id: "mock_new_response_requisition".to_owned(),
+        requisition_number: 3,
+        name_id: "name_a".to_owned(),
+        store_id: mock_store_a().id,
+        r#type: RequisitionRowType::Response,
+        status: RequisitionRowStatus::New,
         created_datetime: NaiveDate::from_ymd(2021, 01, 01).and_hms(0, 0, 0),
         sent_datetime: None,
         finalised_datetime: None,
@@ -264,6 +336,131 @@ pub fn mock_test_add_from_master_list() -> FullMockMasterList {
                 id: line3.clone(),
                 item_id: mock_item_stats_item2().id,
                 master_list_id: id.clone(),
+            },
+        ],
+    }
+}
+
+pub fn mock_new_response_requisition_test() -> FullMockRequisition {
+    let requisition_id = "mock_new_response_requisition_test".to_owned();
+    let line1_id = format!("{}1", requisition_id);
+    let line2_id = format!("{}2", requisition_id);
+    FullMockRequisition {
+        requisition: RequisitionRow {
+            id: requisition_id.clone(),
+            requisition_number: 3,
+            name_id: mock_name_a().id,
+            store_id: mock_store_a().id,
+            r#type: RequisitionRowType::Response,
+            status: RequisitionRowStatus::New,
+            created_datetime: NaiveDate::from_ymd(2021, 01, 01).and_hms(0, 0, 0),
+            sent_datetime: None,
+            finalised_datetime: None,
+            colour: None,
+            comment: None,
+            their_reference: None,
+            max_months_of_stock: 10.0,
+            threshold_months_of_stock: 5.0,
+            linked_requisition_id: None,
+        },
+        lines: vec![
+            RequisitionLineRow {
+                id: line1_id,
+                requisition_id: requisition_id.clone(),
+                item_id: mock_item_a().id,
+                requested_quantity: 10,
+                calculated_quantity: 5,
+                supply_quantity: 50,
+                stock_on_hand: 1,
+                average_monthly_consumption: 1,
+            },
+            RequisitionLineRow {
+                id: line2_id,
+                requisition_id: requisition_id.clone(),
+                item_id: mock_item_b().id,
+                requested_quantity: 11,
+                calculated_quantity: 5,
+                supply_quantity: 100,
+                stock_on_hand: 1,
+                average_monthly_consumption: 0,
+            },
+        ],
+    }
+}
+
+pub fn mock_new_response_requisition_test_invoice() -> FullMockInvoice {
+    let invoice_id = "mock_new_response_requisition_test_invoice".to_owned();
+    let line1_id = format!("{}1", invoice_id);
+    let line2_id = format!("{}2", invoice_id);
+
+    FullMockInvoice {
+        invoice: InvoiceRow {
+            id: invoice_id.clone(),
+            name_id: mock_name_a().id,
+            store_id: "store_a".to_owned(),
+            invoice_number: 20,
+            requisition_id: Some(mock_new_response_requisition_test().requisition.id),
+            r#type: InvoiceRowType::OutboundShipment,
+            status: InvoiceRowStatus::New,
+            on_hold: false,
+            name_store_id: None,
+            comment: None,
+            their_reference: None,
+            created_datetime: NaiveDate::from_ymd(1970, 1, 1).and_hms_milli(12, 30, 0, 0),
+            allocated_datetime: None,
+            shipped_datetime: None,
+            colour: None,
+            linked_invoice_id: None,
+            picked_datetime: None,
+            delivered_datetime: None,
+            verified_datetime: None,
+        },
+        lines: vec![
+            FullMockInvoiceLine {
+                line: InvoiceLineRow {
+                    id: line1_id.clone(),
+                    invoice_id: invoice_id.clone(),
+                    r#type: InvoiceLineRowType::StockOut,
+                    pack_size: 2,
+                    number_of_packs: 2,
+                    item_id: mock_item_a().id,
+                    item_name: mock_item_a().name,
+                    item_code: mock_item_a().code,
+                    cost_price_per_pack: 0.0,
+                    sell_price_per_pack: 0.0,
+                    total_before_tax: 0.0,
+                    total_after_tax: 0.0,
+                    tax: Some(0.0),
+                    batch: None,
+                    expiry_date: None,
+                    note: None,
+                    location_id: None,
+                    stock_line_id: None,
+                },
+                stock_line: mock_stock_line_a(),
+            },
+            FullMockInvoiceLine {
+                line: InvoiceLineRow {
+                    id: line2_id.clone(),
+                    invoice_id: invoice_id.clone(),
+                    r#type: InvoiceLineRowType::UnallocatedStock,
+                    pack_size: 1,
+                    number_of_packs: 2,
+                    item_id: mock_item_a().id,
+                    item_name: mock_item_a().name,
+                    item_code: mock_item_a().code,
+                    cost_price_per_pack: 0.0,
+                    sell_price_per_pack: 0.0,
+                    total_before_tax: 0.0,
+                    total_after_tax: 0.0,
+                    tax: Some(0.0),
+                    batch: None,
+                    expiry_date: None,
+                    note: None,
+                    location_id: None,
+                    stock_line_id: None,
+                },
+                stock_line: mock_stock_line_a(),
             },
         ],
     }

--- a/service/src/requisition/mod.rs
+++ b/service/src/requisition/mod.rs
@@ -7,11 +7,16 @@ use self::{
         InsertRequestRequisition, InsertRequestRequisitionError, UpdateRequestRequisition,
         UpdateRequestRequisitionError, UseCalculatedQuantity, UseCalculatedQuantityError,
     },
+    response_requisition::{
+        create_requisition_shipment, supply_requested_quantity, update_response_requisition,
+        CreateRequisitionShipment, CreateRequisitionShipmentError, SupplyRequestedQuantity,
+        SupplyRequestedQuantityError, UpdateResponseRequisition, UpdateResponseRequisitionError,
+    },
 };
 
 use super::{ListError, ListResult};
 use crate::service_provider::ServiceContext;
-use domain::PaginationOption;
+use domain::{PaginationOption, invoice::Invoice};
 use repository::{
     schema::RequisitionRowType, RepositoryError, Requisition, RequisitionFilter, RequisitionLine,
     RequisitionSort,
@@ -20,6 +25,7 @@ use repository::{
 pub mod common;
 pub mod query;
 pub mod request_requisition;
+pub mod response_requisition;
 
 pub trait RequisitionServiceTrait: Sync + Send {
     fn get_requisitions(
@@ -95,6 +101,33 @@ pub trait RequisitionServiceTrait: Sync + Send {
         input: AddFromMasterList,
     ) -> Result<Vec<RequisitionLine>, AddFromMasterListError> {
         add_from_master_list(ctx, store_id, input)
+    }
+
+    fn update_response_requisition(
+        &self,
+        ctx: &ServiceContext,
+        store_id: &str,
+        input: UpdateResponseRequisition,
+    ) -> Result<Requisition, UpdateResponseRequisitionError> {
+        update_response_requisition(ctx, store_id, input)
+    }
+
+    fn supply_requested_quantity(
+        &self,
+        ctx: &ServiceContext,
+        store_id: &str,
+        input: SupplyRequestedQuantity,
+    ) -> Result<Vec<RequisitionLine>, SupplyRequestedQuantityError> {
+        supply_requested_quantity(ctx, store_id, input)
+    }
+
+    fn create_requisition_shipment(
+        &self,
+        ctx: &ServiceContext,
+        store_id: &str,
+        input: CreateRequisitionShipment,
+    ) -> Result<Invoice, CreateRequisitionShipmentError> {
+        create_requisition_shipment(ctx, store_id, input)
     }
 }
 

--- a/service/src/requisition/request_requisition/update/test.rs
+++ b/service/src/requisition/request_requisition/update/test.rs
@@ -136,7 +136,6 @@ mod test_update {
         let RequisitionRow {
             id,
             status,
-            created_datetime,
             sent_datetime,
             colour,
             comment,
@@ -154,7 +153,7 @@ mod test_update {
         assert_eq!(status, RequisitionRowStatus::Sent);
 
         let sent_datetime = sent_datetime.unwrap();
-        assert!(sent_datetime > before_update && created_datetime < after_update);
+        assert!(sent_datetime > before_update && sent_datetime < after_update);
 
         // Recalculate stock
 

--- a/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
+++ b/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
@@ -1,0 +1,87 @@
+use super::{ItemFulFillment, OutError};
+use crate::{invoice::check_other_party_id, number::next_number};
+use chrono::Utc;
+use repository::{
+    schema::{
+        InvoiceLineRow, InvoiceLineRowType, InvoiceRow, InvoiceRowStatus, InvoiceRowType,
+        NumberRowType, RequisitionRow,
+    },
+    ItemRepository, StorageConnection,
+};
+use util::uuid::uuid;
+
+pub fn generate(
+    connection: &StorageConnection,
+    store_id: &str,
+    requisition_row: RequisitionRow,
+    fullfilments: Vec<ItemFulFillment>,
+) -> Result<(InvoiceRow, Vec<InvoiceLineRow>), OutError> {
+    let other_party = check_other_party_id(connection, &requisition_row.name_id)?
+        .ok_or(OutError::ProblemGettingOtherParty)?;
+
+    let new_invoice = InvoiceRow {
+        id: uuid(),
+        name_id: requisition_row.name_id,
+        name_store_id: other_party.store_id,
+        store_id: store_id.to_owned(),
+        invoice_number: next_number(connection, &NumberRowType::OutboundShipment, &store_id)?,
+        r#type: InvoiceRowType::OutboundShipment,
+        status: InvoiceRowStatus::New,
+        created_datetime: Utc::now().naive_utc(),
+        requisition_id: Some(requisition_row.id),
+
+        // Default
+        on_hold: false,
+        comment: None,
+        their_reference: None,
+        allocated_datetime: None,
+        picked_datetime: None,
+        shipped_datetime: None,
+        delivered_datetime: None,
+        verified_datetime: None,
+        colour: None,
+        linked_invoice_id: None,
+    };
+
+    let invoice_line_rows = generate_invoice_lines(connection, &new_invoice.id, fullfilments)?;
+    Ok((new_invoice, invoice_line_rows))
+}
+
+pub fn generate_invoice_lines(
+    connection: &StorageConnection,
+    invoice_id: &str,
+    fullfilments: Vec<ItemFulFillment>,
+) -> Result<Vec<InvoiceLineRow>, OutError> {
+    let mut invoice_line_rows = vec![];
+
+    for ItemFulFillment { item_id, quantity } in fullfilments.into_iter() {
+        let item_row = ItemRepository::new(connection)
+            .find_one_by_id(&item_id)?
+            .ok_or(OutError::ProblemFindingItem)?;
+
+        invoice_line_rows.push(InvoiceLineRow {
+            id: uuid(),
+            invoice_id: invoice_id.to_owned(),
+            pack_size: 1,
+            number_of_packs: quantity,
+            item_id,
+            item_code: item_row.code,
+            item_name: item_row.name,
+            r#type: InvoiceLineRowType::UnallocatedStock,
+
+            // Default
+            total_before_tax: 0.0,
+            total_after_tax: 0.0,
+            tax: None,
+            note: None,
+            location_id: None,
+            batch: None,
+            expiry_date: None,
+            sell_price_per_pack: 0.0,
+            cost_price_per_pack: 0.0,
+            stock_line_id: None,
+        });
+    }
+
+    Ok(invoice_line_rows)
+}

--- a/service/src/requisition/response_requisition/create_requisition_shipment/mod.rs
+++ b/service/src/requisition/response_requisition/create_requisition_shipment/mod.rs
@@ -1,0 +1,75 @@
+use crate::service_provider::ServiceContext;
+use domain::{
+    invoice::{Invoice, InvoiceFilter},
+    EqualFilter,
+};
+use repository::{
+    InvoiceLineRowRepository, InvoiceQueryRepository, InvoiceRepository, RepositoryError,
+};
+
+mod generate;
+mod test;
+mod validate;
+
+use generate::*;
+use validate::*;
+
+pub struct CreateRequisitionShipment {
+    pub response_requisition_id: String,
+}
+
+pub struct ItemFulFillment {
+    pub item_id: String,
+    pub quantity: i32,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum CreateRequisitionShipmentError {
+    RequistionDoesNotExist,
+    NotThisStoreRequisition,
+    CannotEditRequisition,
+    NotAResponseRequisition,
+    NothingRemainingToSupply,
+    CreatedInvoiceDoesNotExist,
+    ProblemGettingOtherParty,
+    ProblemFindingItem,
+    DatabaseError(RepositoryError),
+}
+
+type OutError = CreateRequisitionShipmentError;
+
+pub fn create_requisition_shipment(
+    ctx: &ServiceContext,
+    store_id: &str,
+    input: CreateRequisitionShipment,
+) -> Result<Invoice, OutError> {
+    let invoice = ctx
+        .connection
+        .transaction_sync(|connection| {
+            let (requisition_row, fullfilments) = validate(connection, store_id, &input)?;
+            let (invoice_row, invoice_line_rows) =
+                generate(connection, store_id, requisition_row, fullfilments)?;
+
+            InvoiceRepository::new(&connection).upsert_one(&invoice_row)?;
+
+            let invoice_line_repository = InvoiceLineRowRepository::new(&connection);
+            for row in invoice_line_rows {
+                invoice_line_repository.upsert_one(&row)?;
+            }
+
+            // TODO use invoice service if it accepts ctx
+            let mut result = InvoiceQueryRepository::new(&connection)
+                .query_by_filter(InvoiceFilter::new().id(EqualFilter::equal_to(&invoice_row.id)))?;
+
+            result.pop().ok_or(OutError::CreatedInvoiceDoesNotExist)
+        })
+        .map_err(|error| error.to_inner_error())?;
+
+    Ok(invoice)
+}
+
+impl From<RepositoryError> for CreateRequisitionShipmentError {
+    fn from(error: RepositoryError) -> Self {
+        CreateRequisitionShipmentError::DatabaseError(error)
+    }
+}

--- a/service/src/requisition/response_requisition/create_requisition_shipment/test.rs
+++ b/service/src/requisition/response_requisition/create_requisition_shipment/test.rs
@@ -1,0 +1,180 @@
+#[cfg(test)]
+mod test_update {
+    use domain::EqualFilter;
+    use repository::{
+        mock::{
+            mock_draft_response_requisition_for_update_test, mock_finalised_response_requisition,
+            mock_new_response_requisition_test, mock_sent_request_requisition, MockDataInserts,
+        },
+        test_db::setup_all,
+        InvoiceLineFilter, InvoiceLineRepository, InvoiceRepository,
+    };
+
+    use crate::{
+        requisition::response_requisition::{
+            CreateRequisitionShipment, CreateRequisitionShipmentError as ServiceError,
+        },
+        requisition_line::response_requisition_line::UpdateResponseRequisitionLine,
+        service_provider::ServiceProvider,
+    };
+
+    #[actix_rt::test]
+    async fn create_requisition_shipment_errors() {
+        let (_, _, connection_manager, _) =
+            setup_all("create_requisition_shipment_errors", MockDataInserts::all()).await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider.context().unwrap();
+        let service = service_provider.requisition_service;
+
+        // RequistionDoesNotExist
+        assert_eq!(
+            service.create_requisition_shipment(
+                &context,
+                "store_a",
+                CreateRequisitionShipment {
+                    response_requisition_id: "invalid".to_owned(),
+                },
+            ),
+            Err(ServiceError::RequistionDoesNotExist)
+        );
+
+        // NotThisStoreRequisition
+        assert_eq!(
+            service.create_requisition_shipment(
+                &context,
+                "store_b",
+                CreateRequisitionShipment {
+                    response_requisition_id: mock_draft_response_requisition_for_update_test().id,
+                },
+            ),
+            Err(ServiceError::NotThisStoreRequisition)
+        );
+
+        // CannotEditRequisition
+        assert_eq!(
+            service.create_requisition_shipment(
+                &context,
+                "store_a",
+                CreateRequisitionShipment {
+                    response_requisition_id: mock_finalised_response_requisition().id,
+                },
+            ),
+            Err(ServiceError::CannotEditRequisition)
+        );
+
+        // NotAResponseRequisition
+        assert_eq!(
+            service.create_requisition_shipment(
+                &context,
+                "store_a",
+                CreateRequisitionShipment {
+                    response_requisition_id: mock_sent_request_requisition().id,
+                },
+            ),
+            Err(ServiceError::NotAResponseRequisition)
+        );
+    }
+
+    #[actix_rt::test]
+    async fn create_requisition_shipment_success() {
+        let (_, connection, connection_manager, _) = setup_all(
+            "create_requisition_shipment_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider.context().unwrap();
+        let service = service_provider.requisition_service;
+
+        // Check existing invoice is accounted for
+        let invoice = service
+            .create_requisition_shipment(
+                &context,
+                "store_a",
+                CreateRequisitionShipment {
+                    response_requisition_id: mock_new_response_requisition_test().requisition.id,
+                },
+            )
+            .unwrap();
+
+        let invoice = InvoiceRepository::new(&connection)
+            .find_one_by_id(&invoice.id)
+            .unwrap();
+
+        assert_eq!(
+            invoice.requisition_id,
+            Some(mock_new_response_requisition_test().requisition.id)
+        );
+
+        let mut invoice_lines = InvoiceLineRepository::new(&connection)
+            .query_by_filter(
+                InvoiceLineFilter::new().invoice_id(EqualFilter::equal_to(&invoice.id)),
+            )
+            .unwrap();
+
+        invoice_lines.sort_by(|a, b| a.item_id.cmp(&b.item_id));
+
+        assert_eq!(invoice_lines.len(), 2);
+
+        assert_eq!(invoice_lines[0].number_of_packs, 44);
+        assert_eq!(invoice_lines[1].number_of_packs, 100);
+
+        // NothingRemainingToSupply
+        assert_eq!(
+            service.create_requisition_shipment(
+                &context,
+                "store_a",
+                CreateRequisitionShipment {
+                    response_requisition_id: mock_new_response_requisition_test().requisition.id,
+                },
+            ),
+            Err(ServiceError::NothingRemainingToSupply)
+        );
+
+        // Supply some more
+        service_provider
+            .requisition_line_service
+            .update_response_requisition_line(
+                &context,
+                "store_a",
+                UpdateResponseRequisitionLine {
+                    id: mock_new_response_requisition_test().lines[0].id.clone(),
+                    supply_quantity: Some(100),
+                },
+            )
+            .unwrap();
+
+        let invoice = service
+            .create_requisition_shipment(
+                &context,
+                "store_a",
+                CreateRequisitionShipment {
+                    response_requisition_id: mock_new_response_requisition_test().requisition.id,
+                },
+            )
+            .unwrap();
+
+        let invoice = InvoiceRepository::new(&connection)
+            .find_one_by_id(&invoice.id)
+            .unwrap();
+
+        assert_eq!(
+            invoice.requisition_id,
+            Some(mock_new_response_requisition_test().requisition.id)
+        );
+
+        let mut invoice_lines = InvoiceLineRepository::new(&connection)
+            .query_by_filter(
+                InvoiceLineFilter::new().invoice_id(EqualFilter::equal_to(&invoice.id)),
+            )
+            .unwrap();
+
+        invoice_lines.sort_by(|a, b| a.item_id.cmp(&b.item_id));
+
+        assert_eq!(invoice_lines.len(), 1);
+
+        assert_eq!(invoice_lines[0].number_of_packs, 50);
+    }
+}

--- a/service/src/requisition/response_requisition/create_requisition_shipment/validate.rs
+++ b/service/src/requisition/response_requisition/create_requisition_shipment/validate.rs
@@ -1,0 +1,73 @@
+use std::collections::HashMap;
+
+use domain::EqualFilter;
+use repository::{
+    schema::{RequisitionRowStatus, RequisitionRowType, RequisitionRow},
+    InvoiceLineFilter, InvoiceLineRepository, RepositoryError, StorageConnection,
+};
+
+use crate::requisition::common::{check_requisition_exists, get_lines_for_requisition};
+
+use super::{CreateRequisitionShipment, ItemFulFillment, OutError};
+
+pub fn validate(
+    connection: &StorageConnection,
+    store_id: &str,
+    input: &CreateRequisitionShipment,
+) -> Result<(RequisitionRow, Vec<ItemFulFillment>), OutError> {
+    let requisition_row = check_requisition_exists(connection, &input.response_requisition_id)?
+        .ok_or(OutError::RequistionDoesNotExist)?;
+
+    if requisition_row.store_id != store_id {
+        return Err(OutError::NotThisStoreRequisition);
+    }
+
+    if requisition_row.r#type != RequisitionRowType::Response {
+        return Err(OutError::NotAResponseRequisition);
+    }
+
+    if requisition_row.status != RequisitionRowStatus::New {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    let filfulments = get_remaining_fulfilments(connection, &requisition_row.id)?;
+    if filfulments.len() == 0 {
+        return Err(OutError::NothingRemainingToSupply);
+    }
+
+    Ok((requisition_row, filfulments))
+}
+
+pub fn get_remaining_fulfilments(
+    connection: &StorageConnection,
+    requisition_id: &str,
+) -> Result<Vec<ItemFulFillment>, RepositoryError> {
+    let existing_invoice_lines = InvoiceLineRepository::new(connection).query_by_filter(
+        InvoiceLineFilter::new().requisition_id(EqualFilter::equal_to(requisition_id)),
+    )?;
+
+    let requisition_lines = get_lines_for_requisition(connection, requisition_id)?;
+
+    let mut fulfilments_map: HashMap<String, i32> = requisition_lines
+        .into_iter()
+        .map(|line| {
+            (
+                line.requisition_line_row.item_id,
+                line.requisition_line_row.supply_quantity,
+            )
+        })
+        .collect();
+
+    for line in existing_invoice_lines {
+        let map_value = fulfilments_map.entry(line.item_id.clone()).or_insert(0);
+        *map_value -= line.pack_size * line.number_of_packs;
+    }
+
+    let result = fulfilments_map
+        .into_iter()
+        .filter(|(_, quantity)| *quantity > 0)
+        .map(|(item_id, quantity)| ItemFulFillment { item_id, quantity })
+        .collect();
+
+    Ok(result)
+}

--- a/service/src/requisition/response_requisition/mod.rs
+++ b/service/src/requisition/response_requisition/mod.rs
@@ -1,0 +1,8 @@
+mod update;
+pub use self::update::*;
+
+mod supply_requested_quantity;
+pub use supply_requested_quantity::*;
+
+mod create_requisition_shipment;
+pub use create_requisition_shipment::*;

--- a/service/src/requisition/response_requisition/supply_requested_quantity.rs
+++ b/service/src/requisition/response_requisition/supply_requested_quantity.rs
@@ -1,0 +1,222 @@
+use crate::{
+    requisition::common::{check_requisition_exists, get_lines_for_requisition},
+    service_provider::ServiceContext,
+};
+use domain::EqualFilter;
+use repository::{
+    schema::{RequisitionLineRow, RequisitionRowStatus, RequisitionRowType},
+    RepositoryError, RequisitionLine, RequisitionLineFilter, RequisitionLineRepository,
+    RequisitionLineRowRepository, StorageConnection,
+};
+
+pub struct SupplyRequestedQuantity {
+    pub response_requisition_id: String,
+}
+
+#[derive(Debug, PartialEq)]
+
+pub enum SupplyRequestedQuantityError {
+    RequistionDoesNotExist,
+    NotThisStoreRequisition,
+    CannotEditRequisition,
+    NotAResponseRequisition,
+    DatabaseError(RepositoryError),
+}
+
+type OutError = SupplyRequestedQuantityError;
+
+pub fn supply_requested_quantity(
+    ctx: &ServiceContext,
+    store_id: &str,
+    input: SupplyRequestedQuantity,
+) -> Result<Vec<RequisitionLine>, OutError> {
+    let requisition_lines = ctx
+        .connection
+        .transaction_sync(|connection| {
+            validate(connection, store_id, &input)?;
+            let update_requisition_line_rows =
+                generate(connection, &input.response_requisition_id)?;
+
+            let requisition_line_row_repository = RequisitionLineRowRepository::new(&connection);
+
+            for requisition_line_row in update_requisition_line_rows {
+                requisition_line_row_repository.upsert_one(&requisition_line_row)?;
+            }
+
+            match RequisitionLineRepository::new(connection).query_by_filter(
+                RequisitionLineFilter::new()
+                    .requisition_id(EqualFilter::equal_to(&input.response_requisition_id)),
+            ) {
+                Ok(lines) => Ok(lines),
+                Err(error) => Err(OutError::DatabaseError(error)),
+            }
+        })
+        .map_err(|error| error.to_inner_error())?;
+    Ok(requisition_lines)
+}
+
+fn validate(
+    connection: &StorageConnection,
+    store_id: &str,
+    input: &SupplyRequestedQuantity,
+) -> Result<(), OutError> {
+    let requisition_row = check_requisition_exists(connection, &input.response_requisition_id)?
+        .ok_or(OutError::RequistionDoesNotExist)?;
+
+    if requisition_row.store_id != store_id {
+        return Err(OutError::NotThisStoreRequisition);
+    }
+
+    if requisition_row.r#type != RequisitionRowType::Response {
+        return Err(OutError::NotAResponseRequisition);
+    }
+
+    if requisition_row.status != RequisitionRowStatus::New {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    Ok(())
+}
+
+fn generate(
+    connection: &StorageConnection,
+    requisition_id: &str,
+) -> Result<Vec<RequisitionLineRow>, RepositoryError> {
+    let lines = get_lines_for_requisition(connection, requisition_id)?;
+
+    let result = lines
+        .into_iter()
+        .map(
+            |RequisitionLine {
+                 mut requisition_line_row,
+                 ..
+             }| {
+                requisition_line_row.supply_quantity = requisition_line_row.requested_quantity;
+
+                requisition_line_row
+            },
+        )
+        .collect();
+
+    Ok(result)
+}
+
+impl From<RepositoryError> for SupplyRequestedQuantityError {
+    fn from(error: RepositoryError) -> Self {
+        SupplyRequestedQuantityError::DatabaseError(error)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use repository::{
+        mock::{
+            mock_draft_response_requisition_for_update_test, mock_finalised_response_requisition,
+            mock_new_response_requisition_test, mock_sent_request_requisition, MockDataInserts,
+        },
+        test_db::setup_all,
+    };
+
+    use crate::{
+        requisition::{
+            common::get_lines_for_requisition,
+            response_requisition::{
+                SupplyRequestedQuantity, SupplyRequestedQuantityError as ServiceError,
+            },
+        },
+        service_provider::ServiceProvider,
+    };
+
+    #[actix_rt::test]
+    async fn supply_requested_quantity_errors() {
+        let (_, _, connection_manager, _) =
+            setup_all("supply_requested_quantity_errors", MockDataInserts::all()).await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider.context().unwrap();
+        let service = service_provider.requisition_service;
+
+        // RequistionDoesNotExist
+        assert_eq!(
+            service.supply_requested_quantity(
+                &context,
+                "store_a",
+                SupplyRequestedQuantity {
+                    response_requisition_id: "invalid".to_owned(),
+                }
+            ),
+            Err(ServiceError::RequistionDoesNotExist)
+        );
+
+        // NotThisStoreRequisition
+        assert_eq!(
+            service.supply_requested_quantity(
+                &context,
+                "store_b",
+                SupplyRequestedQuantity {
+                    response_requisition_id: mock_draft_response_requisition_for_update_test().id,
+                },
+            ),
+            Err(ServiceError::NotThisStoreRequisition)
+        );
+
+        // CannotEditRequisition
+        assert_eq!(
+            service.supply_requested_quantity(
+                &context,
+                "store_a",
+                SupplyRequestedQuantity {
+                    response_requisition_id: mock_finalised_response_requisition().id,
+                },
+            ),
+            Err(ServiceError::CannotEditRequisition)
+        );
+
+        // NotAResponseRequisition
+        assert_eq!(
+            service.supply_requested_quantity(
+                &context,
+                "store_a",
+                SupplyRequestedQuantity {
+                    response_requisition_id: mock_sent_request_requisition().id,
+                },
+            ),
+            Err(ServiceError::NotAResponseRequisition)
+        );
+    }
+
+    #[actix_rt::test]
+    async fn supply_requested_quantity_success() {
+        let (_, connection, connection_manager, _) =
+            setup_all("supply_requested_quantity_success", MockDataInserts::all()).await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider.context().unwrap();
+        let service = service_provider.requisition_service;
+
+        let result = service
+            .supply_requested_quantity(
+                &context,
+                "store_a",
+                SupplyRequestedQuantity {
+                    response_requisition_id: mock_new_response_requisition_test().requisition.id,
+                },
+            )
+            .unwrap();
+
+        let lines = get_lines_for_requisition(
+            &connection,
+            &mock_new_response_requisition_test().requisition.id,
+        )
+        .unwrap();
+
+        assert_eq!(result, lines);
+
+        for requisition_line in lines {
+            assert_eq!(
+                requisition_line.requisition_line_row.supply_quantity,
+                requisition_line.requisition_line_row.requested_quantity
+            )
+        }
+    }
+}

--- a/service/src/requisition/response_requisition/update.rs
+++ b/service/src/requisition/response_requisition/update.rs
@@ -1,0 +1,288 @@
+use crate::{
+    requisition::{common::check_requisition_exists, query::get_requisition},
+    service_provider::ServiceContext,
+};
+use chrono::Utc;
+use repository::{
+    schema::{RequisitionRow, RequisitionRowStatus, RequisitionRowType},
+    RepositoryError, Requisition, RequisitionRowRepository, StorageConnection,
+};
+
+pub enum UpdateResponseRequstionStatus {
+    Finalised,
+}
+pub struct UpdateResponseRequisition {
+    pub id: String,
+    pub colour: Option<String>,
+    pub their_reference: Option<String>,
+    pub comment: Option<String>,
+    pub status: Option<UpdateResponseRequstionStatus>,
+}
+
+#[derive(Debug, PartialEq)]
+
+pub enum UpdateResponseRequisitionError {
+    RequistionDoesNotExist,
+    NotThisStoreRequisition,
+    CannotEditRequisition,
+    NotAResponseRequisition,
+    UpdatedRequisitionDoesNotExist,
+    DatabaseError(RepositoryError),
+}
+
+type OutError = UpdateResponseRequisitionError;
+
+pub fn update_response_requisition(
+    ctx: &ServiceContext,
+    store_id: &str,
+    input: UpdateResponseRequisition,
+) -> Result<Requisition, OutError> {
+    let requisition = ctx
+        .connection
+        .transaction_sync(|connection| {
+            let requisition_row = validate(connection, store_id, &input)?;
+            let updated_requisition = generate(requisition_row, input);
+            RequisitionRowRepository::new(&connection).upsert_one(&updated_requisition)?;
+
+            get_requisition(ctx, None, &updated_requisition.id)
+                .map_err(|error| OutError::DatabaseError(error))?
+                .ok_or(OutError::UpdatedRequisitionDoesNotExist)
+        })
+        .map_err(|error| error.to_inner_error())?;
+
+    // TODO trigger request requisition
+    Ok(requisition)
+}
+
+pub fn validate(
+    connection: &StorageConnection,
+    store_id: &str,
+    input: &UpdateResponseRequisition,
+) -> Result<RequisitionRow, OutError> {
+    let requisition_row =
+        check_requisition_exists(connection, &input.id)?.ok_or(OutError::RequistionDoesNotExist)?;
+
+    if requisition_row.store_id != store_id {
+        return Err(OutError::NotThisStoreRequisition);
+    }
+
+    if requisition_row.r#type != RequisitionRowType::Response {
+        return Err(OutError::NotAResponseRequisition);
+    }
+
+    if requisition_row.status != RequisitionRowStatus::New {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    Ok(requisition_row)
+}
+
+pub fn generate(
+    RequisitionRow {
+        id,
+        requisition_number,
+        name_id,
+        store_id,
+        r#type,
+        status,
+        created_datetime,
+        sent_datetime,
+        finalised_datetime,
+        colour,
+        comment,
+        their_reference,
+        max_months_of_stock,
+        threshold_months_of_stock,
+        linked_requisition_id,
+    }: RequisitionRow,
+    UpdateResponseRequisition {
+        id: _,
+        colour: update_colour,
+        status: update_status,
+        comment: update_comment,
+        their_reference: update_their_reference,
+    }: UpdateResponseRequisition,
+) -> RequisitionRow {
+    RequisitionRow {
+        status: if update_status.is_some() {
+            RequisitionRowStatus::Finalised
+        } else {
+            status
+        },
+        finalised_datetime: if update_status.is_some() {
+            Some(Utc::now().naive_utc())
+        } else {
+            finalised_datetime
+        },
+        colour: update_colour.or(colour),
+        comment: update_comment.or(comment),
+        their_reference: update_their_reference.or(their_reference),
+
+        // not changed
+        id,
+        requisition_number,
+        name_id,
+        store_id,
+        r#type,
+        created_datetime,
+        sent_datetime,
+        linked_requisition_id,
+        threshold_months_of_stock,
+        max_months_of_stock,
+    }
+}
+
+impl From<RepositoryError> for UpdateResponseRequisitionError {
+    fn from(error: RepositoryError) -> Self {
+        UpdateResponseRequisitionError::DatabaseError(error)
+    }
+}
+
+#[cfg(test)]
+mod test_update {
+    use chrono::Utc;
+    use repository::{
+        mock::{
+            mock_draft_response_requisition_for_update_test, mock_finalised_response_requisition,
+            mock_new_response_requisition, mock_sent_request_requisition, MockDataInserts,
+        },
+        schema::{RequisitionRow, RequisitionRowStatus},
+        test_db::setup_all,
+        RequisitionRowRepository,
+    };
+
+    use crate::{
+        requisition::response_requisition::{
+            UpdateResponseRequisition, UpdateResponseRequisitionError as ServiceError,
+            UpdateResponseRequstionStatus,
+        },
+        service_provider::ServiceProvider,
+    };
+
+    #[actix_rt::test]
+    async fn update_response_requisition_errors() {
+        let (_, _, connection_manager, _) =
+            setup_all("update_response_requisition_errors", MockDataInserts::all()).await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider.context().unwrap();
+        let service = service_provider.requisition_service;
+
+        // RequistionDoesNotExist
+        assert_eq!(
+            service.update_response_requisition(
+                &context,
+                "store_a",
+                UpdateResponseRequisition {
+                    id: "invalid".to_owned(),
+                    colour: None,
+                    status: None,
+                    their_reference: None,
+                    comment: None,
+                },
+            ),
+            Err(ServiceError::RequistionDoesNotExist)
+        );
+
+        // NotThisStoreRequisition
+        assert_eq!(
+            service.update_response_requisition(
+                &context,
+                "store_b",
+                UpdateResponseRequisition {
+                    id: mock_draft_response_requisition_for_update_test().id,
+                    colour: None,
+                    status: None,
+                    their_reference: None,
+                    comment: None,
+                },
+            ),
+            Err(ServiceError::NotThisStoreRequisition)
+        );
+
+        // CannotEditRequisition
+        assert_eq!(
+            service.update_response_requisition(
+                &context,
+                "store_a",
+                UpdateResponseRequisition {
+                    id: mock_finalised_response_requisition().id,
+                    colour: None,
+                    status: None,
+                    their_reference: None,
+                    comment: None,
+                },
+            ),
+            Err(ServiceError::CannotEditRequisition)
+        );
+
+        // NotAResponseRequisition
+        assert_eq!(
+            service.update_response_requisition(
+                &context,
+                "store_a",
+                UpdateResponseRequisition {
+                    id: mock_sent_request_requisition().id,
+                    colour: None,
+                    status: None,
+                    their_reference: None,
+                    comment: None,
+                },
+            ),
+            Err(ServiceError::NotAResponseRequisition)
+        );
+    }
+
+    #[actix_rt::test]
+    async fn update_response_requisition_success() {
+        let (_, connection, connection_manager, _) = setup_all(
+            "update_response_requisition_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider.context().unwrap();
+        let service = service_provider.requisition_service;
+
+        let before_update = Utc::now().naive_utc();
+
+        let result = service
+            .update_response_requisition(
+                &context,
+                "store_a",
+                UpdateResponseRequisition {
+                    id: mock_new_response_requisition().id,
+                    colour: Some("new colour".to_owned()),
+                    status: Some(UpdateResponseRequstionStatus::Finalised),
+                    their_reference: Some("new their_reference".to_owned()),
+                    comment: Some("new comment".to_owned()),
+                },
+            )
+            .unwrap();
+
+        let after_update = Utc::now().naive_utc();
+
+        let RequisitionRow {
+            id,
+            status,
+            finalised_datetime,
+            colour,
+            comment,
+            their_reference,
+            ..
+        } = RequisitionRowRepository::new(&connection)
+            .find_one_by_id(&result.requisition_row.id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(id, mock_new_response_requisition().id);
+        assert_eq!(colour, Some("new colour".to_owned()));
+        assert_eq!(their_reference, Some("new their_reference".to_owned()));
+        assert_eq!(comment, Some("new comment".to_owned()));
+        assert_eq!(status, RequisitionRowStatus::Finalised);
+
+        let finalised_datetime = finalised_datetime.unwrap();
+        assert!(finalised_datetime > before_update && finalised_datetime < after_update);
+    }
+}

--- a/service/src/requisition_line/mod.rs
+++ b/service/src/requisition_line/mod.rs
@@ -2,10 +2,11 @@ use self::{
     query::get_requisition_lines,
     request_requisition_line::{
         delete_request_requisition_line, insert_request_requisition_line,
-        update_request_requisition_line, InsertRequestRequisitionLine,
+        update_request_requisition_line, DeleteRequestRequisitionLine,
+        DeleteRequestRequisitionLineError, InsertRequestRequisitionLine,
         InsertRequestRequisitionLineError, UpdateRequestRequisitionLine,
-        UpdateRequestRequisitionLineError, DeleteRequestRequisitionLine, DeleteRequestRequisitionLineError,
-    },
+        UpdateRequestRequisitionLineError,
+    }, response_requisition_line::{update_response_requisition_line, UpdateResponseRequisitionLine, UpdateResponseRequisitionLineError},
 };
 
 use super::{ListError, ListResult};
@@ -17,6 +18,7 @@ use repository::{RequisitionLine, RequisitionLineFilter};
 pub mod common;
 pub mod query;
 pub mod request_requisition_line;
+pub mod response_requisition_line;
 
 pub trait RequisitionLineServiceTrait: Sync + Send {
     fn get_requisition_lines(
@@ -53,6 +55,15 @@ pub trait RequisitionLineServiceTrait: Sync + Send {
         input: DeleteRequestRequisitionLine,
     ) -> Result<String, DeleteRequestRequisitionLineError> {
         delete_request_requisition_line(ctx, store_id, input)
+    }
+
+    fn update_response_requisition_line(
+        &self,
+        ctx: &ServiceContext,
+        store_id: &str,
+        input: UpdateResponseRequisitionLine,
+    ) -> Result<RequisitionLine, UpdateResponseRequisitionLineError> {
+        update_response_requisition_line(ctx, store_id, input)
     }
 }
 

--- a/service/src/requisition_line/response_requisition_line/mod.rs
+++ b/service/src/requisition_line/response_requisition_line/mod.rs
@@ -1,0 +1,2 @@
+mod update;
+pub use update::*;

--- a/service/src/requisition_line/response_requisition_line/update.rs
+++ b/service/src/requisition_line/response_requisition_line/update.rs
@@ -1,0 +1,232 @@
+use crate::{
+    requisition::common::check_requisition_exists,
+    requisition_line::{common::check_requisition_line_exists, query::get_requisition_line},
+    service_provider::ServiceContext,
+};
+
+use repository::{
+    schema::{RequisitionLineRow, RequisitionRowStatus, RequisitionRowType},
+    RepositoryError, RequisitionLine, RequisitionLineRowRepository, StorageConnection,
+};
+
+pub struct UpdateResponseRequisitionLine {
+    pub id: String,
+    pub supply_quantity: Option<u32>,
+}
+
+#[derive(Debug, PartialEq)]
+
+pub enum UpdateResponseRequisitionLineError {
+    RequisitionLineDoesNotExist,
+    NotThisStoreRequisition,
+    CannotEditRequisition,
+    NotAResponseRequisition,
+    UpdatedRequisitionLineDoesNotExist,
+    RequistionDoesNotExist,
+    DatabaseError(RepositoryError),
+}
+
+type OutError = UpdateResponseRequisitionLineError;
+
+pub fn update_response_requisition_line(
+    ctx: &ServiceContext,
+    store_id: &str,
+    input: UpdateResponseRequisitionLine,
+) -> Result<RequisitionLine, OutError> {
+    let requisition_line = ctx
+        .connection
+        .transaction_sync(|connection| {
+            let requisition_row = validate(connection, store_id, &input)?;
+            let updated_requisition_line_row = generate(requisition_row, input);
+
+            RequisitionLineRowRepository::new(&connection)
+                .upsert_one(&updated_requisition_line_row)?;
+
+            get_requisition_line(ctx, &updated_requisition_line_row.id)
+                .map_err(|error| OutError::DatabaseError(error))?
+                .ok_or(OutError::UpdatedRequisitionLineDoesNotExist)
+        })
+        .map_err(|error| error.to_inner_error())?;
+    Ok(requisition_line)
+}
+
+fn validate(
+    connection: &StorageConnection,
+    store_id: &str,
+    input: &UpdateResponseRequisitionLine,
+) -> Result<RequisitionLineRow, OutError> {
+    let requisition_line_row = check_requisition_line_exists(connection, &input.id)?
+        .ok_or(OutError::RequisitionLineDoesNotExist)?;
+
+    let requisition_row =
+        check_requisition_exists(connection, &requisition_line_row.requisition_id)?
+            .ok_or(OutError::RequistionDoesNotExist)?;
+
+    if requisition_row.store_id != store_id {
+        return Err(OutError::NotThisStoreRequisition);
+    }
+
+    if requisition_row.r#type != RequisitionRowType::Response {
+        return Err(OutError::NotAResponseRequisition);
+    }
+
+    if requisition_row.status != RequisitionRowStatus::New {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    Ok(requisition_line_row)
+}
+
+fn generate(
+    RequisitionLineRow {
+        id,
+        requisition_id,
+        item_id,
+        requested_quantity,
+        calculated_quantity,
+        supply_quantity,
+        stock_on_hand,
+        average_monthly_consumption,
+    }: RequisitionLineRow,
+    UpdateResponseRequisitionLine {
+        id: _,
+        supply_quantity: updated_supply_quantity,
+    }: UpdateResponseRequisitionLine,
+) -> RequisitionLineRow {
+    RequisitionLineRow {
+        supply_quantity: updated_supply_quantity.unwrap_or(supply_quantity as u32) as i32,
+        // not changed
+        id,
+        requisition_id,
+        item_id,
+        calculated_quantity,
+        requested_quantity,
+        stock_on_hand,
+        average_monthly_consumption,
+    }
+}
+
+impl From<RepositoryError> for UpdateResponseRequisitionLineError {
+    fn from(error: RepositoryError) -> Self {
+        UpdateResponseRequisitionLineError::DatabaseError(error)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use repository::{
+        mock::{
+            mock_finalised_request_requisition_line, mock_new_response_requisition_test,
+            mock_sent_request_requisition_line, MockDataInserts,
+        },
+        test_db::setup_all,
+        RequisitionLineRowRepository,
+    };
+
+    use crate::{
+        requisition_line::response_requisition_line::{
+            UpdateResponseRequisitionLine, UpdateResponseRequisitionLineError as ServiceError,
+        },
+        service_provider::ServiceProvider,
+    };
+
+    #[actix_rt::test]
+    async fn update_response_requisition_line_errors() {
+        let (_, _, connection_manager, _) = setup_all(
+            "update_response_requisition_line_errors",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider.context().unwrap();
+        let service = service_provider.requisition_line_service;
+
+        // RequisitionLineDoesNotExist
+        assert_eq!(
+            service.update_response_requisition_line(
+                &context,
+                "store_a",
+                UpdateResponseRequisitionLine {
+                    id: "invalid".to_owned(),
+                    supply_quantity: None,
+                },
+            ),
+            Err(ServiceError::RequisitionLineDoesNotExist)
+        );
+
+        // NotThisStoreRequisition
+        assert_eq!(
+            service.update_response_requisition_line(
+                &context,
+                "store_b",
+                UpdateResponseRequisitionLine {
+                    id: mock_new_response_requisition_test().lines[0].id.clone(),
+                    supply_quantity: None,
+                },
+            ),
+            Err(ServiceError::NotThisStoreRequisition)
+        );
+
+        // CannotEditRequisition
+        assert_eq!(
+            service.update_response_requisition_line(
+                &context,
+                "store_a",
+                UpdateResponseRequisitionLine {
+                    id: mock_finalised_request_requisition_line().id,
+                    supply_quantity: None,
+                },
+            ),
+            Err(ServiceError::CannotEditRequisition)
+        );
+
+        // NotAResponseRequisition
+        assert_eq!(
+            service.update_response_requisition_line(
+                &context,
+                "store_a",
+                UpdateResponseRequisitionLine {
+                    id: mock_sent_request_requisition_line().id,
+                    supply_quantity: None,
+                },
+            ),
+            Err(ServiceError::NotAResponseRequisition)
+        );
+    }
+
+    #[actix_rt::test]
+    async fn update_response_requisition_line_success() {
+        let (_, connection, connection_manager, _) = setup_all(
+            "update_response_requisition_line_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider.context().unwrap();
+        let service = service_provider.requisition_line_service;
+
+        let mut test_line = mock_new_response_requisition_test().lines[0].clone();
+
+        service
+            .update_response_requisition_line(
+                &context,
+                "store_a",
+                UpdateResponseRequisitionLine {
+                    id: test_line.id.clone(),
+                    supply_quantity: Some(99),
+                },
+            )
+            .unwrap();
+
+        let line = RequisitionLineRowRepository::new(&connection)
+            .find_one_by_id(&test_line.id)
+            .unwrap()
+            .unwrap();
+
+        test_line.supply_quantity = 99;
+
+        assert_eq!(test_line, line);
+    }
+}


### PR DESCRIPTION
closes https://github.com/openmsupply/remote-server/issues/726

Mock data is getting a bit messy, as per comment in earlier PR, might need to refactor the final mock data for all requisitions tests.

Added update response and update response line, create_requisition_shipment and supply requested quantity.

Only tricky bit is generation of invoice_lines and validation that some quantities still to be supplied, used ItemFullFilments struct which is populated in validate, which is technically not validate task but is needed there first so it's passed along to generate.
