### PR TITLE
728 request requisition service to graphql mapping

### DIFF
--- a/graphql/src/schema/mutations/mod.rs
+++ b/graphql/src/schema/mutations/mod.rs
@@ -372,53 +372,53 @@ impl Mutations {
     async fn insert_request_requisition(
         &self,
         ctx: &Context<'_>,
-        store_id: Option<String>,
+        store_id: String,
         input: request_requisition::InsertInput,
     ) -> Result<request_requisition::InsertResponse> {
         // TODO remove and make store_id parameter required
-        request_requisition::insert(ctx, store_id, input)
+        request_requisition::insert(ctx, &store_id, input)
     }
 
     async fn update_request_requisition(
         &self,
         ctx: &Context<'_>,
-        store_id: Option<String>,
+        store_id: String,
         input: request_requisition::UpdateInput,
     ) -> Result<request_requisition::UpdateResponse> {
         // TODO remove and make store_id parameter required
-        request_requisition::update(ctx, store_id, input)
+        request_requisition::update(ctx, &store_id, input)
     }
 
     async fn delete_request_requisition(
         &self,
         ctx: &Context<'_>,
-        store_id: Option<String>,
+        store_id: String,
         input: request_requisition::DeleteInput,
     ) -> Result<request_requisition::DeleteResponse> {
         // TODO remove and make store_id parameter required
-        request_requisition::delete(ctx, store_id, input)
+        request_requisition::delete(ctx, &store_id, input)
     }
 
     /// Set requested for each line in request requisition to calculated
     async fn use_calculated_quantity(
         &self,
         ctx: &Context<'_>,
-        store_id: Option<String>,
+        store_id: String,
         input: request_requisition::UseCalculatedQuantityInput,
     ) -> Result<request_requisition::UseCalculatedQuantityResponse> {
         // TODO remove and make store_id parameter required
-        request_requisition::use_calculated_quantity(ctx, store_id, input)
+        request_requisition::use_calculated_quantity(ctx, &store_id, input)
     }
 
     /// Add requisition lines from master item master list
     async fn add_from_master_list(
         &self,
         ctx: &Context<'_>,
-        store_id: Option<String>,
+        store_id: String,
         input: request_requisition::AddFromMasterListInput,
     ) -> Result<request_requisition::AddFromMasterListResponse> {
         // TODO remove and make store_id parameter required
-        request_requisition::add_from_master_list(ctx, store_id, input)
+        request_requisition::add_from_master_list(ctx, &store_id, input)
     }
 
     async fn insert_request_requisition_line(

--- a/graphql/src/schema/mutations/requisition/errors.rs
+++ b/graphql/src/schema/mutations/requisition/errors.rs
@@ -1,16 +1,10 @@
 use async_graphql::*;
 
-use crate::schema::types::RequisitionLineConnector;
-
-pub struct CannotDeleteRequisitionWithLines(pub RequisitionLineConnector);
+pub struct CannotDeleteRequisitionWithLines;
 #[Object]
 impl CannotDeleteRequisitionWithLines {
     pub async fn description(&self) -> &'static str {
         "Cannot delete requisitions with existing lines"
-    }
-
-    pub async fn lines(&self) -> &RequisitionLineConnector {
-        &self.0
     }
 }
 

--- a/graphql/src/schema/mutations/requisition/request_requisition/delete.rs
+++ b/graphql/src/schema/mutations/requisition/request_requisition/delete.rs
@@ -1,8 +1,18 @@
-use crate::schema::mutations::{
-    requisition::errors::{CannotDeleteRequisitionWithLines, CannotEditRequisition},
-    DeleteResponse as GenericDeleteResponse, RecordDoesNotExist,
+use crate::{
+    schema::mutations::{
+        requisition::errors::{CannotDeleteRequisitionWithLines, CannotEditRequisition},
+        DeleteResponse as GenericDeleteResponse, RecordDoesNotExist,
+    },
+    standard_graphql_error::{validate_auth, StandardGraphqlError},
+    ContextExt,
 };
 use async_graphql::*;
+use service::{
+    permission_validation::{Resource, ResourceAccessRequest},
+    requisition::request_requisition::{
+        DeleteRequestRequisition as ServiceInput, DeleteRequestRequisitionError as ServiceError,
+    },
+};
 
 #[derive(InputObject)]
 #[graphql(name = "DeleteRequestRequisitionInput")]
@@ -32,10 +42,64 @@ pub enum DeleteResponse {
     Response(GenericDeleteResponse),
 }
 
-pub fn delete(
-    _ctx: &Context<'_>,
-    _store_id: Option<String>,
-    _input: DeleteInput,
-) -> Result<DeleteResponse> {
-    todo!()
+pub fn delete(ctx: &Context<'_>, store_id: &str, input: DeleteInput) -> Result<DeleteResponse> {
+    validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::EditRequisition,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.context()?;
+
+    let response = match service_provider
+        .requisition_service
+        .delete_request_requisition(&service_context, store_id, input.to_domain())
+    {
+        Ok(deleted_id) => DeleteResponse::Response(GenericDeleteResponse(deleted_id)),
+        Err(error) => DeleteResponse::Error(DeleteError {
+            error: map_error(error)?,
+        }),
+    };
+
+    Ok(response)
+}
+
+impl DeleteInput {
+    fn to_domain(self) -> ServiceInput {
+        let DeleteInput { id } = self;
+        ServiceInput { id }
+    }
+}
+
+fn map_error(error: ServiceError) -> Result<DeleteErrorInterface> {
+    use StandardGraphqlError::*;
+    let formatted_error = format!("{:#?}", error);
+
+    let graphql_error = match error {
+        // Structured Errors
+        ServiceError::RequisitionDoesNotExist => {
+            return Ok(DeleteErrorInterface::RecordDoesNotExist(
+                RecordDoesNotExist {},
+            ))
+        }
+        ServiceError::CannotEditRequisition => {
+            return Ok(DeleteErrorInterface::CannotEditRequisition(
+                CannotEditRequisition {},
+            ))
+        }
+        ServiceError::CannotDeleteRequisitionWithLines => {
+            return Ok(DeleteErrorInterface::CannotDeleteRequisitionWithLines(
+                CannotDeleteRequisitionWithLines {},
+            ))
+        }
+        // Standard Graphql Errors
+        ServiceError::NotThisStoreRequisition => BadUserInput(formatted_error),
+        ServiceError::NotARequestRequisition => BadUserInput(formatted_error),
+        ServiceError::DatabaseError(_) => InternalError(formatted_error),
+    };
+
+    Err(graphql_error.extend())
 }

--- a/graphql/src/schema/mutations/requisition/request_requisition/update.rs
+++ b/graphql/src/schema/mutations/requisition/request_requisition/update.rs
@@ -1,8 +1,18 @@
+use crate::{
+    schema::{
+        mutations::{requisition::errors::CannotEditRequisition, RecordDoesNotExist},
+        types::RequisitionNode,
+    },
+    standard_graphql_error::{validate_auth, StandardGraphqlError},
+    ContextExt,
+};
 use async_graphql::*;
-
-use crate::schema::{
-    mutations::{requisition::errors::CannotEditRequisition, RecordDoesNotExist},
-    types::RequisitionNode,
+use service::{
+    permission_validation::{Resource, ResourceAccessRequest},
+    requisition::request_requisition::{
+        UpdateRequestRequisition as ServiceInput, UpdateRequestRequisitionError as ServiceError,
+        UpdateRequestRequstionStatus,
+    },
 };
 
 #[derive(InputObject)]
@@ -43,10 +53,86 @@ pub enum UpdateResponse {
     Response(RequisitionNode),
 }
 
-pub fn update(
-    _ctx: &Context<'_>,
-    _store_id: Option<String>,
-    _input: UpdateInput,
-) -> Result<UpdateResponse> {
-    todo!()
+pub fn update(ctx: &Context<'_>, store_id: &str, input: UpdateInput) -> Result<UpdateResponse> {
+    validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::EditRequisition,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.context()?;
+
+    let response = match service_provider
+        .requisition_service
+        .update_request_requisition(&service_context, store_id, input.to_domain())
+    {
+        Ok(requisition) => UpdateResponse::Response(RequisitionNode::from_domain(requisition)),
+        Err(error) => UpdateResponse::Error(UpdateError {
+            error: map_error(error)?,
+        }),
+    };
+
+    Ok(response)
+}
+
+impl UpdateInput {
+    fn to_domain(self) -> ServiceInput {
+        let UpdateInput {
+            id,
+            colour,
+            their_reference,
+            comment,
+            max_months_of_stock,
+            threshold_months_of_stock,
+            status,
+        } = self;
+
+        ServiceInput {
+            id,
+            colour,
+            their_reference,
+            comment,
+            max_months_of_stock,
+            threshold_months_of_stock,
+            status: status.map(|status| status.to_domain()),
+        }
+    }
+}
+
+fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
+    use StandardGraphqlError::*;
+    let formatted_error = format!("{:#?}", error);
+
+    let graphql_error = match error {
+        // Structured Errors
+        ServiceError::RequisitionDoesNotExist => {
+            return Ok(UpdateErrorInterface::RecordDoesNotExist(
+                RecordDoesNotExist {},
+            ))
+        }
+        ServiceError::CannotEditRequisition => {
+            return Ok(UpdateErrorInterface::CannotEditRequisition(
+                CannotEditRequisition {},
+            ))
+        }
+        // Standard Graphql Errors
+        ServiceError::NotThisStoreRequisition => BadUserInput(formatted_error),
+        ServiceError::NotARequestRequisition => BadUserInput(formatted_error),
+        ServiceError::UpdatedRequisitionDoesNotExist => InternalError(formatted_error),
+        ServiceError::DatabaseError(_) => InternalError(formatted_error),
+    };
+
+    Err(graphql_error.extend())
+}
+
+impl UpdateRequestRequisitionStatusInput {
+    pub fn to_domain(self) -> UpdateRequestRequstionStatus {
+        use UpdateRequestRequisitionStatusInput::*;
+        match self {
+            Sent => UpdateRequestRequstionStatus::Sent,
+        }
+    }
 }

--- a/graphql/src/schema/mutations/requisition/request_requisition/use_calculated_quantity.rs
+++ b/graphql/src/schema/mutations/requisition/request_requisition/use_calculated_quantity.rs
@@ -1,37 +1,108 @@
+use crate::{
+    schema::{
+        mutations::{requisition::errors::CannotEditRequisition, RecordDoesNotExist},
+        types::RequisitionLineConnector,
+    },
+    standard_graphql_error::{validate_auth, StandardGraphqlError},
+    ContextExt,
+};
 use async_graphql::*;
-
-use crate::schema::{
-    mutations::{requisition::errors::CannotEditRequisition, RecordDoesNotExist},
-    types::RequisitionNode,
+use service::{
+    permission_validation::{Resource, ResourceAccessRequest},
+    requisition::request_requisition::{
+        UseCalculatedQuantity as ServiceInput, UseCalculatedQuantityError as ServiceError,
+    },
 };
 
 #[derive(InputObject)]
 pub struct UseCalculatedQuantityInput {
-    pub response_requisition_id: String,
+    pub request_requisition_id: String,
 }
 
 #[derive(Interface)]
+#[graphql(name = "UseCalculatedQuantityErrorInterface")]
 #[graphql(field(name = "description", type = "String"))]
-pub enum UseCalculatedQuantityErrorInterface {
+pub enum DeleteErrorInterface {
     RecordDoesNotExist(RecordDoesNotExist),
     CannotEditRequisition(CannotEditRequisition),
 }
 
 #[derive(SimpleObject)]
-pub struct UseCalculatedQuantityError {
-    pub error: UseCalculatedQuantityErrorInterface,
+#[graphql(name = "UseCalculatedQuantityError")]
+pub struct DeleteError {
+    pub error: DeleteErrorInterface,
 }
 
 #[derive(Union)]
+#[graphql(name = "UseCalculatedQuantityResponse")]
 pub enum UseCalculatedQuantityResponse {
-    Error(UseCalculatedQuantityError),
-    Response(RequisitionNode),
+    Error(DeleteError),
+    Response(RequisitionLineConnector),
 }
 
 pub fn use_calculated_quantity(
-    _ctx: &Context<'_>,
-    _store_id: Option<String>,
-    _input: UseCalculatedQuantityInput,
+    ctx: &Context<'_>,
+    store_id: &str,
+    input: UseCalculatedQuantityInput,
 ) -> Result<UseCalculatedQuantityResponse> {
-    todo!()
+    validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::EditRequisition,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.context()?;
+
+    let response = match service_provider
+        .requisition_service
+        .use_calculated_quantity(&service_context, store_id, input.to_domain())
+    {
+        Ok(requisition_lines) => UseCalculatedQuantityResponse::Response(
+            RequisitionLineConnector::from_vec(requisition_lines),
+        ),
+        Err(error) => UseCalculatedQuantityResponse::Error(DeleteError {
+            error: map_error(error)?,
+        }),
+    };
+
+    Ok(response)
+}
+
+impl UseCalculatedQuantityInput {
+    fn to_domain(self) -> ServiceInput {
+        let UseCalculatedQuantityInput {
+            request_requisition_id,
+        } = self;
+        ServiceInput {
+            request_requisition_id,
+        }
+    }
+}
+
+fn map_error(error: ServiceError) -> Result<DeleteErrorInterface> {
+    use StandardGraphqlError::*;
+    let formatted_error = format!("{:#?}", error);
+
+    let graphql_error = match error {
+        // Structured Errors
+        ServiceError::RequisitionDoesNotExist => {
+            return Ok(DeleteErrorInterface::RecordDoesNotExist(
+                RecordDoesNotExist {},
+            ))
+        }
+        ServiceError::CannotEditRequisition => {
+            return Ok(DeleteErrorInterface::CannotEditRequisition(
+                CannotEditRequisition {},
+            ))
+        }
+        // Standard Graphql Errors
+        ServiceError::NotThisStoreRequisition => BadUserInput(formatted_error),
+        ServiceError::NotARequestRequisition => BadUserInput(formatted_error),
+        ServiceError::DatabaseError(_) => InternalError(formatted_error),
+    };
+
+    Err(graphql_error.extend())
 }

--- a/server/tests/graphql/requisition/mod.rs
+++ b/server/tests/graphql/requisition/mod.rs
@@ -1,3 +1,4 @@
+mod request_requisition;
 mod requisition;
 mod requisition_by_number;
 mod requisition_loaders;

--- a/server/tests/graphql/requisition/request_requisition/add_from_master_list.rs
+++ b/server/tests/graphql/requisition/request_requisition/add_from_master_list.rs
@@ -1,0 +1,226 @@
+mod graphql {
+    use crate::graphql::{assert_graphql_query, assert_standard_graphql_error};
+    use repository::{
+        mock::{
+            mock_request_draft_requisition, mock_sent_request_requisition_line, MockDataInserts,
+        },
+        RequisitionLine, StorageConnectionManager,
+    };
+    use serde_json::json;
+    use server::test_utils::setup_all;
+    use service::{
+        requisition::{
+            request_requisition::{
+                AddFromMasterList as ServiceInput, AddFromMasterListError as ServiceError,
+            },
+            RequisitionServiceTrait,
+        },
+        service_provider::{ServiceContext, ServiceProvider},
+    };
+
+    type DeleteLineMethod =
+        dyn Fn(&str, ServiceInput) -> Result<Vec<RequisitionLine>, ServiceError> + Sync + Send;
+
+    pub struct TestService(pub Box<DeleteLineMethod>);
+
+    impl RequisitionServiceTrait for TestService {
+        fn add_from_master_list(
+            &self,
+            _: &ServiceContext,
+            store_id: &str,
+            input: ServiceInput,
+        ) -> Result<Vec<RequisitionLine>, ServiceError> {
+            self.0(store_id, input)
+        }
+    }
+
+    fn service_provider(
+        test_service: TestService,
+        connection_manager: &StorageConnectionManager,
+    ) -> ServiceProvider {
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
+        service_provider.requisition_service = Box::new(test_service);
+        service_provider
+    }
+
+    fn empty_variables() -> serde_json::Value {
+        json!({
+          "input": {
+            "requestRequisitionId": "n/a",
+            "masterListId": "n/a",
+          },
+          "storeId": "n/a"
+        })
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_add_from_master_list_errors() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_add_from_master_list_structured_errors",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($input: AddFromMasterListInput!, $storeId: String) {
+            addFromMasterList(storeId: $storeId, input: $input) {
+              ... on AddFromMasterListError {
+                error {
+                  __typename
+                }
+              }
+            }
+          }
+        "#;
+
+        // RequisitionDoesNotExist
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::RequisitionDoesNotExist)));
+
+        let expected = json!({
+            "addFromMasterList": {
+              "error": {
+                "__typename": "RecordDoesNotExist"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // CannotEditRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::CannotEditRequisition)));
+
+        let expected = json!({
+            "addFromMasterList": {
+              "error": {
+                "__typename": "CannotEditRequisition"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // MasterListNotFoundForThisStore
+        let test_service = TestService(Box::new(|_, _| {
+            Err(ServiceError::MasterListNotFoundForThisStore)
+        }));
+
+        let expected = json!({
+            "addFromMasterList": {
+              "error": {
+                "__typename": "MasterListNotFoundForThisStore"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NotThisStoreRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::NotThisStoreRequisition)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NotARequestRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::NotARequestRequisition)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_add_from_master_list_success() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_add_from_master_list_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($storeId: String, $input: AddFromMasterListInput!) {
+            addFromMasterList(storeId: $storeId, input: $input) {
+                ... on RequisitionLineConnector{
+                  nodes {
+                    id
+                  }
+                }
+            }
+          }
+        "#;
+
+        // Success
+        let test_service = TestService(Box::new(|store_id, input| {
+            assert_eq!(store_id, "store_a");
+            assert_eq!(
+                input,
+                ServiceInput {
+                    request_requisition_id: "id input".to_string(),
+                    master_list_id: "master list id input".to_string(),
+                }
+            );
+            Ok(vec![RequisitionLine {
+                requisition_line_row: mock_sent_request_requisition_line(),
+                requisition_row: mock_request_draft_requisition(),
+            }])
+        }));
+
+        let variables = json!({
+          "input": {
+            "requestRequisitionId": "id input",
+            "masterListId": "master list id input"
+          },
+          "storeId": "store_a"
+        });
+
+        let expected = json!({
+            "addFromMasterList": {
+              "nodes": [
+                {
+                  "id": mock_sent_request_requisition_line().id
+                }
+              ]
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(variables),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+}

--- a/server/tests/graphql/requisition/request_requisition/delete.rs
+++ b/server/tests/graphql/requisition/request_requisition/delete.rs
@@ -1,0 +1,210 @@
+mod graphql {
+    use crate::graphql::{assert_graphql_query, assert_standard_graphql_error};
+    use repository::{mock::MockDataInserts, StorageConnectionManager};
+    use serde_json::json;
+    use server::test_utils::setup_all;
+    use service::{
+        requisition::{
+            request_requisition::{
+                DeleteRequestRequisition as ServiceInput,
+                DeleteRequestRequisitionError as ServiceError,
+            },
+            RequisitionServiceTrait,
+        },
+        service_provider::{ServiceContext, ServiceProvider},
+    };
+
+    type DeleteLineMethod =
+        dyn Fn(&str, ServiceInput) -> Result<String, ServiceError> + Sync + Send;
+
+    pub struct TestService(pub Box<DeleteLineMethod>);
+
+    impl RequisitionServiceTrait for TestService {
+        fn delete_request_requisition(
+            &self,
+            _: &ServiceContext,
+            store_id: &str,
+            input: ServiceInput,
+        ) -> Result<String, ServiceError> {
+            self.0(store_id, input)
+        }
+    }
+
+    fn service_provider(
+        test_service: TestService,
+        connection_manager: &StorageConnectionManager,
+    ) -> ServiceProvider {
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
+        service_provider.requisition_service = Box::new(test_service);
+        service_provider
+    }
+
+    fn empty_variables() -> serde_json::Value {
+        json!({
+          "input": {
+            "id": "n/a",
+          },
+          "storeId": "n/a"
+        })
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_delete_request_requisition_errors() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_delete_request_requisition_structured_errors",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($input: DeleteRequestRequisitionInput!, $storeId: String) {
+            deleteRequestRequisition(storeId: $storeId, input: $input) {
+              ... on DeleteRequestRequisitionError {
+                error {
+                  __typename
+                }
+              }
+            }
+          }
+        "#;
+
+        // RequisitionDoesNotExist
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::RequisitionDoesNotExist)));
+
+        let expected = json!({
+            "deleteRequestRequisition": {
+              "error": {
+                "__typename": "RecordDoesNotExist"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // CannotEditRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::CannotEditRequisition)));
+
+        let expected = json!({
+            "deleteRequestRequisition": {
+              "error": {
+                "__typename": "CannotEditRequisition"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // CannotDeleteRequisitionWithLines
+        let test_service = TestService(Box::new(|_, _| {
+            Err(ServiceError::CannotDeleteRequisitionWithLines)
+        }));
+
+        let expected = json!({
+            "deleteRequestRequisition": {
+              "error": {
+                "__typename": "CannotDeleteRequisitionWithLines"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NotThisStoreRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::NotThisStoreRequisition)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NotARequestRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::NotARequestRequisition)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_delete_request_requisition_success() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_delete_request_requisition_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($storeId: String, $input: DeleteRequestRequisitionInput!) {
+            deleteRequestRequisition(storeId: $storeId, input: $input) {
+                ... on DeleteResponse {
+                    id
+                }
+            }
+          }
+        "#;
+
+        // Success
+        let test_service = TestService(Box::new(|store_id, input| {
+            assert_eq!(store_id, "store_a");
+            assert_eq!(
+                input,
+                ServiceInput {
+                    id: "id input".to_string(),
+                }
+            );
+            Ok("deleted id".to_owned())
+        }));
+
+        let variables = json!({
+          "input": {
+            "id": "id input",
+          },
+          "storeId": "store_a"
+        });
+
+        let expected = json!({
+            "deleteRequestRequisition": {
+                "id": "deleted id"
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(variables),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+}

--- a/server/tests/graphql/requisition/request_requisition/insert.rs
+++ b/server/tests/graphql/requisition/request_requisition/insert.rs
@@ -1,0 +1,228 @@
+mod graphql {
+    use crate::graphql::{assert_graphql_query, assert_standard_graphql_error};
+    use repository::{
+        mock::{mock_name_a, mock_request_draft_requisition, MockDataInserts},
+        Requisition, StorageConnectionManager,
+    };
+    use serde_json::json;
+    use server::test_utils::setup_all;
+    use service::{
+        requisition::{
+            request_requisition::{
+                InsertRequestRequisition as ServiceInput,
+                InsertRequestRequisitionError as ServiceError,
+            },
+            RequisitionServiceTrait,
+        },
+        service_provider::{ServiceContext, ServiceProvider},
+    };
+
+    type InsertLineMethod =
+        dyn Fn(&str, ServiceInput) -> Result<Requisition, ServiceError> + Sync + Send;
+
+    pub struct TestService(pub Box<InsertLineMethod>);
+
+    impl RequisitionServiceTrait for TestService {
+        fn insert_request_requisition(
+            &self,
+            _: &ServiceContext,
+            store_id: &str,
+            input: ServiceInput,
+        ) -> Result<Requisition, ServiceError> {
+            self.0(store_id, input)
+        }
+    }
+
+    fn service_provider(
+        test_service: TestService,
+        connection_manager: &StorageConnectionManager,
+    ) -> ServiceProvider {
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
+        service_provider.requisition_service = Box::new(test_service);
+        service_provider
+    }
+
+    fn empty_variables() -> serde_json::Value {
+        json!({
+          "input": {
+            "id": "n/a",
+            "otherPartyId": "n/a",
+            "maxMonthsOfStock": 0,
+            "thresholdMonthsOfStock": 0
+          },
+          "storeId": "n/a"
+        })
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_insert_request_requisition_errors() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_insert_request_requisition_structured_errors",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($input: InsertRequestRequisitionInput!, $storeId: String) {
+            insertRequestRequisition(storeId: $storeId, input: $input) {
+              ... on InsertRequestRequisitionError {
+                error {
+                  __typename
+                }
+              }
+            }
+          }
+        "#;
+
+        // OtherPartyNotASupplier
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::OtherPartyNotASupplier)));
+
+        let expected = json!({
+            "insertRequestRequisition": {
+              "error": {
+                "__typename": "OtherPartyNotASupplier"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // RequisitionAlreadyExists
+        let test_service =
+            TestService(Box::new(|_, _| Err(ServiceError::RequisitionAlreadyExists)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // OtherPartyDoesNotExist
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::OtherPartyDoesNotExist)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // OtherPartyIsThisStore
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::OtherPartyIsThisStore)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // OtherPartyIsNotAStore
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::OtherPartyIsNotAStore)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // OtherPartyIsNotAStore
+        let test_service = TestService(Box::new(|_, _| {
+            Err(ServiceError::NewlyCreatedRequisitionDoesNotExist)
+        }));
+        let expected_message = "Internal error";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_insert_request_requisition_success() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_insert_request_requisition_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($storeId: String, $input: InsertRequestRequisitionInput!) {
+            insertRequestRequisition(storeId: $storeId, input: $input) {
+                ... on RequisitionNode {
+                    id
+                }
+            }
+          }
+        "#;
+
+        // Success
+        let test_service = TestService(Box::new(|store_id, input| {
+            assert_eq!(store_id, "store_a");
+            assert_eq!(
+                input,
+                ServiceInput {
+                    id: "id input".to_string(),
+                    other_party_id: "other party input".to_string(),
+                    colour: Some("colour input".to_string()),
+                    their_reference: Some("reference input".to_string()),
+                    comment: Some("comment input".to_string()),
+                    max_months_of_stock: 1.0,
+                    threshold_months_of_stock: 2.0
+                }
+            );
+            Ok(Requisition {
+                requisition_row: mock_request_draft_requisition(),
+                name_row: mock_name_a(),
+            })
+        }));
+
+        let variables = json!({
+          "input": {
+            "id": "id input",
+            "otherPartyId": "other party input",
+            "maxMonthsOfStock": 1,
+            "thresholdMonthsOfStock": 2,
+            "colour": "colour input",
+            "theirReference": "reference input",
+            "comment": "comment input",
+          },
+          "storeId": "store_a"
+        });
+
+        let expected = json!({
+            "insertRequestRequisition": {
+                "id": mock_request_draft_requisition().id
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(variables),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+}

--- a/server/tests/graphql/requisition/request_requisition/mod.rs
+++ b/server/tests/graphql/requisition/request_requisition/mod.rs
@@ -1,0 +1,5 @@
+mod add_from_master_list;
+mod delete;
+mod insert;
+mod update;
+mod use_calculated_quantity;

--- a/server/tests/graphql/requisition/request_requisition/update.rs
+++ b/server/tests/graphql/requisition/request_requisition/update.rs
@@ -1,0 +1,220 @@
+mod graphql {
+    use crate::graphql::{assert_graphql_query, assert_standard_graphql_error};
+    use repository::{
+        mock::{mock_name_a, mock_request_draft_requisition, MockDataInserts},
+        Requisition, StorageConnectionManager,
+    };
+    use serde_json::json;
+    use server::test_utils::setup_all;
+    use service::{
+        requisition::{
+            request_requisition::{
+                UpdateRequestRequisition as ServiceInput,
+                UpdateRequestRequisitionError as ServiceError, UpdateRequestRequstionStatus,
+            },
+            RequisitionServiceTrait,
+        },
+        service_provider::{ServiceContext, ServiceProvider},
+    };
+
+    type UpdateLineMethod =
+        dyn Fn(&str, ServiceInput) -> Result<Requisition, ServiceError> + Sync + Send;
+
+    pub struct TestService(pub Box<UpdateLineMethod>);
+
+    impl RequisitionServiceTrait for TestService {
+        fn update_request_requisition(
+            &self,
+            _: &ServiceContext,
+            store_id: &str,
+            input: ServiceInput,
+        ) -> Result<Requisition, ServiceError> {
+            self.0(store_id, input)
+        }
+    }
+
+    fn service_provider(
+        test_service: TestService,
+        connection_manager: &StorageConnectionManager,
+    ) -> ServiceProvider {
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
+        service_provider.requisition_service = Box::new(test_service);
+        service_provider
+    }
+
+    fn empty_variables() -> serde_json::Value {
+        json!({
+          "input": {
+            "id": "n/a",
+          },
+          "storeId": "n/a"
+        })
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_update_request_requisition_errors() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_update_request_requisition_structured_errors",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($input: UpdateRequestRequisitionInput!, $storeId: String) {
+            updateRequestRequisition(storeId: $storeId, input: $input) {
+              ... on UpdateRequestRequisitionError {
+                error {
+                  __typename
+                }
+              }
+            }
+          }
+        "#;
+
+        // RequisitionDoesNotExist
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::RequisitionDoesNotExist)));
+
+        let expected = json!({
+            "updateRequestRequisition": {
+              "error": {
+                "__typename": "RecordDoesNotExist"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // CannotEditRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::CannotEditRequisition)));
+
+        let expected = json!({
+            "updateRequestRequisition": {
+              "error": {
+                "__typename": "CannotEditRequisition"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NotThisStoreRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::NotThisStoreRequisition)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NotARequestRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::NotARequestRequisition)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // UpdatedRequisitionDoesNotExist
+        let test_service = TestService(Box::new(|_, _| {
+            Err(ServiceError::UpdatedRequisitionDoesNotExist)
+        }));
+        let expected_message = "Internal error";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_update_request_requisition_success() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_update_request_requisition_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($storeId: String, $input: UpdateRequestRequisitionInput!) {
+            updateRequestRequisition(storeId: $storeId, input: $input) {
+                ... on RequisitionNode {
+                    id
+                }
+            }
+          }
+        "#;
+
+        // Success
+        let test_service = TestService(Box::new(|store_id, input| {
+            assert_eq!(store_id, "store_a");
+            assert_eq!(
+                input,
+                ServiceInput {
+                    id: "id input".to_string(),
+                    colour: Some("colour input".to_string()),
+                    their_reference: Some("reference input".to_string()),
+                    comment: Some("comment input".to_string()),
+                    max_months_of_stock: Some(1.0),
+                    threshold_months_of_stock: Some(2.0),
+                    status: Some(UpdateRequestRequstionStatus::Sent)
+                }
+            );
+            Ok(Requisition {
+                requisition_row: mock_request_draft_requisition(),
+                name_row: mock_name_a(),
+            })
+        }));
+
+        let variables = json!({
+          "input": {
+            "id": "id input",
+            "maxMonthsOfStock": 1,
+            "thresholdMonthsOfStock": 2,
+            "colour": "colour input",
+            "theirReference": "reference input",
+            "comment": "comment input",
+            "status": "SENT"
+          },
+          "storeId": "store_a"
+        });
+
+        let expected = json!({
+            "updateRequestRequisition": {
+                "id": mock_request_draft_requisition().id
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(variables),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+}

--- a/server/tests/graphql/requisition/request_requisition/use_calculated_quantity.rs
+++ b/server/tests/graphql/requisition/request_requisition/use_calculated_quantity.rs
@@ -1,0 +1,201 @@
+mod graphql {
+    use crate::graphql::{assert_graphql_query, assert_standard_graphql_error};
+    use repository::{
+        mock::{
+            mock_request_draft_requisition, mock_sent_request_requisition_line, MockDataInserts,
+        },
+        RequisitionLine, StorageConnectionManager,
+    };
+    use serde_json::json;
+    use server::test_utils::setup_all;
+    use service::{
+        requisition::{
+            request_requisition::{
+                UseCalculatedQuantity as ServiceInput, UseCalculatedQuantityError as ServiceError,
+            },
+            RequisitionServiceTrait,
+        },
+        service_provider::{ServiceContext, ServiceProvider},
+    };
+
+    type DeleteLineMethod =
+        dyn Fn(&str, ServiceInput) -> Result<Vec<RequisitionLine>, ServiceError> + Sync + Send;
+
+    pub struct TestService(pub Box<DeleteLineMethod>);
+
+    impl RequisitionServiceTrait for TestService {
+        fn use_calculated_quantity(
+            &self,
+            _: &ServiceContext,
+            store_id: &str,
+            input: ServiceInput,
+        ) -> Result<Vec<RequisitionLine>, ServiceError> {
+            self.0(store_id, input)
+        }
+    }
+
+    fn service_provider(
+        test_service: TestService,
+        connection_manager: &StorageConnectionManager,
+    ) -> ServiceProvider {
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
+        service_provider.requisition_service = Box::new(test_service);
+        service_provider
+    }
+
+    fn empty_variables() -> serde_json::Value {
+        json!({
+          "input": {
+            "requestRequisitionId": "n/a"
+          },
+          "storeId": "n/a"
+        })
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_use_calculated_quantity_errors() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_use_calculated_quantity_structured_errors",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($input: UseCalculatedQuantityInput!, $storeId: String) {
+            useCalculatedQuantity(storeId: $storeId, input: $input) {
+              ... on UseCalculatedQuantityError {
+                error {
+                  __typename
+                }
+              }
+            }
+          }
+        "#;
+
+        // RequisitionDoesNotExist
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::RequisitionDoesNotExist)));
+
+        let expected = json!({
+            "useCalculatedQuantity": {
+              "error": {
+                "__typename": "RecordDoesNotExist"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // CannotEditRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::CannotEditRequisition)));
+
+        let expected = json!({
+            "useCalculatedQuantity": {
+              "error": {
+                "__typename": "CannotEditRequisition"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NotThisStoreRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::NotThisStoreRequisition)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NotARequestRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::NotARequestRequisition)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_use_calculated_quantity_success() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_use_calculated_quantity_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($storeId: String, $input: UseCalculatedQuantityInput!) {
+            useCalculatedQuantity(storeId: $storeId, input: $input) {
+                ... on RequisitionLineConnector{
+                  nodes {
+                    id
+                  }
+                }
+            }
+          }
+        "#;
+
+        // Success
+        let test_service = TestService(Box::new(|store_id, input| {
+            assert_eq!(store_id, "store_a");
+            assert_eq!(
+                input,
+                ServiceInput {
+                    request_requisition_id: "id input".to_string(),
+                }
+            );
+            Ok(vec![RequisitionLine {
+                requisition_line_row: mock_sent_request_requisition_line(),
+                requisition_row: mock_request_draft_requisition(),
+            }])
+        }));
+
+        let variables = json!({
+          "input": {
+            "requestRequisitionId": "id input"
+          },
+          "storeId": "store_a"
+        });
+
+        let expected = json!({
+            "useCalculatedQuantity": {
+              "nodes": [
+                {
+                  "id": mock_sent_request_requisition_line().id
+                }
+              ]
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(variables),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+}

--- a/service/src/permission_validation.rs
+++ b/service/src/permission_validation.rs
@@ -26,6 +26,7 @@ pub enum Resource {
     DeleteStockTake,
     // requisition
     QueryRequisition,
+    EditRequisition,
     // stock take line
     InsertStockTakeLine,
     UpdateStockTakeLine,
@@ -50,6 +51,7 @@ fn all_permissions() -> HashMap<Resource, PermissionDSL> {
     map.insert(Resource::DeleteStockTake, default());
     // requisition
     map.insert(Resource::QueryRequisition, default());
+    map.insert(Resource::EditRequisition, default());
     // stock take line
     map.insert(Resource::InsertStockTakeLine, default());
     map.insert(Resource::UpdateStockTakeLine, default());

--- a/service/src/requisition/request_requisition/add_from_master_list.rs
+++ b/service/src/requisition/request_requisition/add_from_master_list.rs
@@ -12,6 +12,7 @@ use repository::{
 
 use super::generate_requisition_lines;
 
+#[derive(Debug, PartialEq)]
 pub struct AddFromMasterList {
     pub request_requisition_id: String,
     pub master_list_id: String,
@@ -20,7 +21,7 @@ pub struct AddFromMasterList {
 #[derive(Debug, PartialEq)]
 
 pub enum AddFromMasterListError {
-    RequistionDoesNotExist,
+    RequisitionDoesNotExist,
     NotThisStoreRequisition,
     CannotEditRequisition,
     MasterListNotFoundForThisStore,
@@ -66,7 +67,7 @@ fn validate(
     input: &AddFromMasterList,
 ) -> Result<RequisitionRow, OutError> {
     let requisition_row = check_requisition_exists(connection, &input.request_requisition_id)?
-        .ok_or(OutError::RequistionDoesNotExist)?;
+        .ok_or(OutError::RequisitionDoesNotExist)?;
 
     if requisition_row.store_id != store_id {
         return Err(OutError::NotThisStoreRequisition);
@@ -89,7 +90,7 @@ fn validate(
 fn generate(
     connection: &StorageConnection,
     store_id: &str,
-    requistion_row: RequisitionRow,
+    requisition_row: RequisitionRow,
     input: &AddFromMasterList,
 ) -> Result<Vec<RequisitionLineRow>, RepositoryError> {
     let requisition_lines = get_lines_for_requisition(connection, &input.request_requisition_id)?;
@@ -114,7 +115,7 @@ fn generate(
     Ok(generate_requisition_lines(
         connection,
         store_id,
-        &requistion_row,
+        &requisition_row,
         items_ids_not_in_requisition,
     )?)
 }
@@ -168,7 +169,7 @@ mod test {
         let context = service_provider.context().unwrap();
         let service = service_provider.requisition_service;
 
-        // RequistionDoesNotExist
+        // RequisitionDoesNotExist
         assert_eq!(
             service.add_from_master_list(
                 &context,
@@ -178,7 +179,7 @@ mod test {
                     master_list_id: "n/a".to_owned()
                 },
             ),
-            Err(ServiceError::RequistionDoesNotExist)
+            Err(ServiceError::RequisitionDoesNotExist)
         );
 
         // NotThisStoreRequisition

--- a/service/src/requisition/request_requisition/delete.rs
+++ b/service/src/requisition/request_requisition/delete.rs
@@ -7,6 +7,7 @@ use repository::{
     RepositoryError, RequisitionRowRepository, StorageConnection,
 };
 
+#[derive(Debug, PartialEq)]
 pub struct DeleteRequestRequisition {
     pub id: String,
 }
@@ -14,10 +15,10 @@ pub struct DeleteRequestRequisition {
 #[derive(Debug, PartialEq)]
 
 pub enum DeleteRequestRequisitionError {
-    RequistionDoesNotExist,
+    RequisitionDoesNotExist,
     NotThisStoreRequisition,
     CannotEditRequisition,
-    CannotDeleteRequistionWithLines,
+    CannotDeleteRequisitionWithLines,
     NotARequestRequisition,
     DatabaseError(RepositoryError),
 }
@@ -48,8 +49,8 @@ fn validate(
     store_id: &str,
     input: &DeleteRequestRequisition,
 ) -> Result<(), OutError> {
-    let requisition_row =
-        check_requisition_exists(connection, &input.id)?.ok_or(OutError::RequistionDoesNotExist)?;
+    let requisition_row = check_requisition_exists(connection, &input.id)?
+        .ok_or(OutError::RequisitionDoesNotExist)?;
 
     if requisition_row.store_id != store_id {
         return Err(OutError::NotThisStoreRequisition);
@@ -64,7 +65,7 @@ fn validate(
     }
 
     if !get_lines_for_requisition(connection, &input.id)?.is_empty() {
-        return Err(OutError::CannotDeleteRequistionWithLines);
+        return Err(OutError::CannotDeleteRequisitionWithLines);
     }
 
     Ok(())
@@ -106,7 +107,7 @@ mod test_delete {
         let context = service_provider.context().unwrap();
         let service = service_provider.requisition_service;
 
-        // RequistionDoesNotExist
+        // RequisitionDoesNotExist
         assert_eq!(
             service.delete_request_requisition(
                 &context,
@@ -115,7 +116,7 @@ mod test_delete {
                     id: "invalid".to_owned(),
                 },
             ),
-            Err(ServiceError::RequistionDoesNotExist)
+            Err(ServiceError::RequisitionDoesNotExist)
         );
 
         // NotThisStoreRequisition
@@ -154,7 +155,7 @@ mod test_delete {
             Err(ServiceError::NotARequestRequisition)
         );
 
-        // CannotDeleteRequistionWithLines
+        // CannotDeleteRequisitionWithLines
         assert_eq!(
             service.delete_request_requisition(
                 &context,
@@ -165,7 +166,7 @@ mod test_delete {
                         .id,
                 },
             ),
-            Err(ServiceError::CannotDeleteRequistionWithLines)
+            Err(ServiceError::CannotDeleteRequisitionWithLines)
         );
     }
 

--- a/service/src/requisition/request_requisition/insert.rs
+++ b/service/src/requisition/request_requisition/insert.rs
@@ -13,6 +13,7 @@ use repository::{
     NameQueryRepository, RepositoryError, Requisition, RequisitionRowRepository, StorageConnection,
 };
 
+#[derive(Debug, PartialEq)]
 pub struct InsertRequestRequisition {
     pub id: String,
     pub other_party_id: String,

--- a/service/src/requisition/request_requisition/update/mod.rs
+++ b/service/src/requisition/request_requisition/update/mod.rs
@@ -10,10 +10,12 @@ mod validate;
 use generate::generate;
 use validate::validate;
 
+#[derive(Debug, PartialEq)]
 pub enum UpdateRequestRequstionStatus {
     Sent,
 }
 
+#[derive(Debug, PartialEq)]
 pub struct UpdateRequestRequisition {
     pub id: String,
     pub colour: Option<String>,
@@ -27,7 +29,7 @@ pub struct UpdateRequestRequisition {
 #[derive(Debug, PartialEq)]
 
 pub enum UpdateRequestRequisitionError {
-    RequistionDoesNotExist,
+    RequisitionDoesNotExist,
     NotThisStoreRequisition,
     CannotEditRequisition,
     NotARequestRequisition,

--- a/service/src/requisition/request_requisition/update/test.rs
+++ b/service/src/requisition/request_requisition/update/test.rs
@@ -30,7 +30,7 @@ mod test_update {
         let context = service_provider.context().unwrap();
         let service = service_provider.requisition_service;
 
-        // RequistionDoesNotExist
+        // RequisitionDoesNotExist
         assert_eq!(
             service.update_request_requisition(
                 &context,
@@ -45,7 +45,7 @@ mod test_update {
                     threshold_months_of_stock: None,
                 },
             ),
-            Err(ServiceError::RequistionDoesNotExist)
+            Err(ServiceError::RequisitionDoesNotExist)
         );
 
         // NotThisStoreRequisition

--- a/service/src/requisition/request_requisition/update/validate.rs
+++ b/service/src/requisition/request_requisition/update/validate.rs
@@ -10,8 +10,8 @@ pub fn validate(
     store_id: &str,
     input: &UpdateRequestRequisition,
 ) -> Result<RequisitionRow, OutError> {
-    let requisition_row =
-        check_requisition_exists(connection, &input.id)?.ok_or(OutError::RequistionDoesNotExist)?;
+    let requisition_row = check_requisition_exists(connection, &input.id)?
+        .ok_or(OutError::RequisitionDoesNotExist)?;
 
     if requisition_row.store_id != store_id {
         return Err(OutError::NotThisStoreRequisition);

--- a/service/src/requisition/request_requisition/use_calculated_quantity.rs
+++ b/service/src/requisition/request_requisition/use_calculated_quantity.rs
@@ -16,7 +16,7 @@ pub struct UseCalculatedQuantity {
 #[derive(Debug, PartialEq)]
 
 pub enum UseCalculatedQuantityError {
-    RequistionDoesNotExist,
+    RequisitionDoesNotExist,
     NotThisStoreRequisition,
     CannotEditRequisition,
     NotARequestRequisition,
@@ -60,7 +60,7 @@ fn validate(
     input: &UseCalculatedQuantity,
 ) -> Result<(), OutError> {
     let requisition_row = check_requisition_exists(connection, &input.request_requisition_id)?
-        .ok_or(OutError::RequistionDoesNotExist)?;
+        .ok_or(OutError::RequisitionDoesNotExist)?;
 
     if requisition_row.store_id != store_id {
         return Err(OutError::NotThisStoreRequisition);
@@ -136,7 +136,7 @@ mod test {
         let context = service_provider.context().unwrap();
         let service = service_provider.requisition_service;
 
-        // RequistionDoesNotExist
+        // RequisitionDoesNotExist
         assert_eq!(
             service.use_calculated_quantity(
                 &context,
@@ -145,7 +145,7 @@ mod test {
                     request_requisition_id: "invalid".to_owned(),
                 },
             ),
-            Err(ServiceError::RequistionDoesNotExist)
+            Err(ServiceError::RequisitionDoesNotExist)
         );
 
         // NotThisStoreRequisition

--- a/service/src/requisition/request_requisition/use_calculated_quantity.rs
+++ b/service/src/requisition/request_requisition/use_calculated_quantity.rs
@@ -9,6 +9,7 @@ use repository::{
     RequisitionLineRowRepository, StorageConnection,
 };
 
+#[derive(Debug, PartialEq)]
 pub struct UseCalculatedQuantity {
     pub request_requisition_id: String,
 }

--- a/service/src/requisition/response_requisition/create_requisition_shipment/mod.rs
+++ b/service/src/requisition/response_requisition/create_requisition_shipment/mod.rs
@@ -25,7 +25,7 @@ pub struct ItemFulFillment {
 
 #[derive(Debug, PartialEq)]
 pub enum CreateRequisitionShipmentError {
-    RequistionDoesNotExist,
+    RequisitionDoesNotExist,
     NotThisStoreRequisition,
     CannotEditRequisition,
     NotAResponseRequisition,

--- a/service/src/requisition/response_requisition/create_requisition_shipment/test.rs
+++ b/service/src/requisition/response_requisition/create_requisition_shipment/test.rs
@@ -27,7 +27,7 @@ mod test_update {
         let context = service_provider.context().unwrap();
         let service = service_provider.requisition_service;
 
-        // RequistionDoesNotExist
+        // RequisitionDoesNotExist
         assert_eq!(
             service.create_requisition_shipment(
                 &context,
@@ -36,7 +36,7 @@ mod test_update {
                     response_requisition_id: "invalid".to_owned(),
                 },
             ),
-            Err(ServiceError::RequistionDoesNotExist)
+            Err(ServiceError::RequisitionDoesNotExist)
         );
 
         // NotThisStoreRequisition

--- a/service/src/requisition/response_requisition/create_requisition_shipment/validate.rs
+++ b/service/src/requisition/response_requisition/create_requisition_shipment/validate.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use domain::EqualFilter;
 use repository::{
-    schema::{RequisitionRowStatus, RequisitionRowType, RequisitionRow},
+    schema::{RequisitionRow, RequisitionRowStatus, RequisitionRowType},
     InvoiceLineFilter, InvoiceLineRepository, RepositoryError, StorageConnection,
 };
 
@@ -16,7 +16,7 @@ pub fn validate(
     input: &CreateRequisitionShipment,
 ) -> Result<(RequisitionRow, Vec<ItemFulFillment>), OutError> {
     let requisition_row = check_requisition_exists(connection, &input.response_requisition_id)?
-        .ok_or(OutError::RequistionDoesNotExist)?;
+        .ok_or(OutError::RequisitionDoesNotExist)?;
 
     if requisition_row.store_id != store_id {
         return Err(OutError::NotThisStoreRequisition);

--- a/service/src/requisition/response_requisition/supply_requested_quantity.rs
+++ b/service/src/requisition/response_requisition/supply_requested_quantity.rs
@@ -16,7 +16,7 @@ pub struct SupplyRequestedQuantity {
 #[derive(Debug, PartialEq)]
 
 pub enum SupplyRequestedQuantityError {
-    RequistionDoesNotExist,
+    RequisitionDoesNotExist,
     NotThisStoreRequisition,
     CannotEditRequisition,
     NotAResponseRequisition,
@@ -61,7 +61,7 @@ fn validate(
     input: &SupplyRequestedQuantity,
 ) -> Result<(), OutError> {
     let requisition_row = check_requisition_exists(connection, &input.response_requisition_id)?
-        .ok_or(OutError::RequistionDoesNotExist)?;
+        .ok_or(OutError::RequisitionDoesNotExist)?;
 
     if requisition_row.store_id != store_id {
         return Err(OutError::NotThisStoreRequisition);
@@ -136,7 +136,7 @@ mod test {
         let context = service_provider.context().unwrap();
         let service = service_provider.requisition_service;
 
-        // RequistionDoesNotExist
+        // RequisitionDoesNotExist
         assert_eq!(
             service.supply_requested_quantity(
                 &context,
@@ -145,7 +145,7 @@ mod test {
                     response_requisition_id: "invalid".to_owned(),
                 }
             ),
-            Err(ServiceError::RequistionDoesNotExist)
+            Err(ServiceError::RequisitionDoesNotExist)
         );
 
         // NotThisStoreRequisition

--- a/service/src/requisition/response_requisition/update.rs
+++ b/service/src/requisition/response_requisition/update.rs
@@ -22,7 +22,7 @@ pub struct UpdateResponseRequisition {
 #[derive(Debug, PartialEq)]
 
 pub enum UpdateResponseRequisitionError {
-    RequistionDoesNotExist,
+    RequisitionDoesNotExist,
     NotThisStoreRequisition,
     CannotEditRequisition,
     NotAResponseRequisition,
@@ -59,8 +59,8 @@ pub fn validate(
     store_id: &str,
     input: &UpdateResponseRequisition,
 ) -> Result<RequisitionRow, OutError> {
-    let requisition_row =
-        check_requisition_exists(connection, &input.id)?.ok_or(OutError::RequistionDoesNotExist)?;
+    let requisition_row = check_requisition_exists(connection, &input.id)?
+        .ok_or(OutError::RequisitionDoesNotExist)?;
 
     if requisition_row.store_id != store_id {
         return Err(OutError::NotThisStoreRequisition);
@@ -168,7 +168,7 @@ mod test_update {
         let context = service_provider.context().unwrap();
         let service = service_provider.requisition_service;
 
-        // RequistionDoesNotExist
+        // RequisitionDoesNotExist
         assert_eq!(
             service.update_response_requisition(
                 &context,
@@ -181,7 +181,7 @@ mod test_update {
                     comment: None,
                 },
             ),
-            Err(ServiceError::RequistionDoesNotExist)
+            Err(ServiceError::RequisitionDoesNotExist)
         );
 
         // NotThisStoreRequisition

--- a/service/src/requisition_line/request_requisition_line/delete.rs
+++ b/service/src/requisition_line/request_requisition_line/delete.rs
@@ -18,7 +18,7 @@ pub enum DeleteRequestRequisitionLineError {
     NotThisStoreRequisition,
     CannotEditRequisition,
     NotARequestRequisition,
-    RequistionDoesNotExist,
+    RequisitionDoesNotExist,
     DatabaseError(RepositoryError),
 }
 
@@ -51,7 +51,7 @@ fn validate(
 
     let requisition_row =
         check_requisition_exists(connection, &requisition_line_row.requisition_id)?
-            .ok_or(OutError::RequistionDoesNotExist)?;
+            .ok_or(OutError::RequisitionDoesNotExist)?;
 
     if requisition_row.store_id != store_id {
         return Err(OutError::NotThisStoreRequisition);

--- a/service/src/requisition_line/request_requisition_line/insert.rs
+++ b/service/src/requisition_line/request_requisition_line/insert.rs
@@ -26,7 +26,7 @@ pub struct InsertRequestRequisitionLine {
 pub enum InsertRequestRequisitionLineError {
     RequisitionLineAlreadyExists,
     ItemAlreadyExistInRequisition,
-    RequistionDoesNotExist,
+    RequisitionDoesNotExist,
     NotThisStoreRequisition,
     CannotEditRequisition,
     NotARequestRequisition,
@@ -68,7 +68,7 @@ fn validate(
     }
 
     let requisition_row = check_requisition_exists(connection, &input.requisition_id)?
-        .ok_or(OutError::RequistionDoesNotExist)?;
+        .ok_or(OutError::RequisitionDoesNotExist)?;
 
     if requisition_row.store_id != store_id {
         return Err(OutError::NotThisStoreRequisition);
@@ -92,7 +92,7 @@ fn validate(
 fn generate(
     connection: &StorageConnection,
     store_id: &str,
-    requistion_row: RequisitionRow,
+    requisition_row: RequisitionRow,
     InsertRequestRequisitionLine {
         id,
         requisition_id: _,
@@ -101,7 +101,7 @@ fn generate(
     }: InsertRequestRequisitionLine,
 ) -> Result<RequisitionLineRow, OutError> {
     let mut new_requisition_line =
-        generate_requisition_lines(connection, store_id, &requistion_row, vec![item_id])?
+        generate_requisition_lines(connection, store_id, &requisition_row, vec![item_id])?
             .pop()
             .ok_or(OutError::ProblemCreatingRequisitionLine)?;
 
@@ -185,7 +185,7 @@ mod test {
             Err(ServiceError::ItemAlreadyExistInRequisition)
         );
 
-        // RequistionDoesNotExist
+        // RequisitionDoesNotExist
         assert_eq!(
             service.insert_request_requisition_line(
                 &context,
@@ -197,7 +197,7 @@ mod test {
                     requested_quantity: None,
                 },
             ),
-            Err(ServiceError::RequistionDoesNotExist)
+            Err(ServiceError::RequisitionDoesNotExist)
         );
 
         // NotThisStoreRequisition

--- a/service/src/requisition_line/request_requisition_line/update.rs
+++ b/service/src/requisition_line/request_requisition_line/update.rs
@@ -22,7 +22,7 @@ pub enum UpdateRequestRequisitionLineError {
     CannotEditRequisition,
     NotARequestRequisition,
     UpdatedRequisitionLineDoesNotExist,
-    RequistionDoesNotExist,
+    RequisitionDoesNotExist,
     DatabaseError(RepositoryError),
 }
 
@@ -60,7 +60,7 @@ fn validate(
 
     let requisition_row =
         check_requisition_exists(connection, &requisition_line_row.requisition_id)?
-            .ok_or(OutError::RequistionDoesNotExist)?;
+            .ok_or(OutError::RequisitionDoesNotExist)?;
 
     if requisition_row.store_id != store_id {
         return Err(OutError::NotThisStoreRequisition);

--- a/service/src/requisition_line/response_requisition_line/update.rs
+++ b/service/src/requisition_line/response_requisition_line/update.rs
@@ -22,7 +22,7 @@ pub enum UpdateResponseRequisitionLineError {
     CannotEditRequisition,
     NotAResponseRequisition,
     UpdatedRequisitionLineDoesNotExist,
-    RequistionDoesNotExist,
+    RequisitionDoesNotExist,
     DatabaseError(RepositoryError),
 }
 
@@ -60,7 +60,7 @@ fn validate(
 
     let requisition_row =
         check_requisition_exists(connection, &requisition_line_row.requisition_id)?
-            .ok_or(OutError::RequistionDoesNotExist)?;
+            .ok_or(OutError::RequisitionDoesNotExist)?;
 
     if requisition_row.store_id != store_id {
         return Err(OutError::NotThisStoreRequisition);


### PR DESCRIPTION
closes https://github.com/openmsupply/remote-server/issues/728

* store_id not optional
* add EditRequisition to permissions
* changed add from master list to return lines (would be easier for FE ?)