### PR TITLE
730 response requisition service to graphql mapping

### DIFF
--- a/graphql/src/schema/mutations/mod.rs
+++ b/graphql/src/schema/mutations/mod.rs
@@ -454,11 +454,11 @@ impl Mutations {
     async fn update_response_requisition(
         &self,
         ctx: &Context<'_>,
-        store_id: Option<String>,
+        store_id: String,
         input: response_requisition::UpdateInput,
     ) -> Result<response_requisition::UpdateResponse> {
         // TODO remove and make store_id parameter required
-        response_requisition::update(ctx, store_id, input)
+        response_requisition::update(ctx, &store_id, input)
     }
 
     async fn update_response_requisition_line(
@@ -475,11 +475,11 @@ impl Mutations {
     async fn supply_requested_quantity(
         &self,
         ctx: &Context<'_>,
-        store_id: Option<String>,
+        store_id: String,
         input: response_requisition::SupplyRequestedQuantityInput,
     ) -> Result<response_requisition::SupplyRequestedQuantityResponse> {
         // TODO remove and make store_id parameter required
-        response_requisition::supply_requested_quantity(ctx, store_id, input)
+        response_requisition::supply_requested_quantity(ctx, &store_id, input)
     }
 
     /// Create shipment for response requisition
@@ -489,11 +489,11 @@ impl Mutations {
     async fn create_requisition_shipment(
         &self,
         ctx: &Context<'_>,
-        store_id: Option<String>,
+        store_id: String,
         input: response_requisition::CreateRequisitionShipmentInput,
     ) -> Result<response_requisition::CreateRequisitionShipmentResponse> {
         // TODO remove and make store_id parameter required
-        response_requisition::create_requisition_shipment(ctx, store_id, input)
+        response_requisition::create_requisition_shipment(ctx, &store_id, input)
     }
 }
 

--- a/graphql/src/schema/mutations/requisition/response_requisition/create_requisition_shipment.rs
+++ b/graphql/src/schema/mutations/requisition/response_requisition/create_requisition_shipment.rs
@@ -1,7 +1,18 @@
+use crate::{
+    schema::{
+        mutations::{requisition::errors::CannotEditRequisition, RecordDoesNotExist},
+        types::InvoiceNode,
+    },
+    standard_graphql_error::{validate_auth, StandardGraphqlError},
+    ContextExt,
+};
 use async_graphql::*;
 
-use crate::schema::{
-    mutations::requisition::errors::CannotEditRequisition, types::RequisitionNode,
+use service::{
+    permission_validation::{Resource, ResourceAccessRequest},
+    requisition::response_requisition::{
+        CreateRequisitionShipment as ServiceInput, CreateRequisitionShipmentError as ServiceError,
+    },
 };
 
 #[derive(InputObject)]
@@ -10,26 +21,104 @@ pub struct CreateRequisitionShipmentInput {
 }
 
 #[derive(Interface)]
+#[graphql(name = "CreateRequisitionShipmentErrorInterface")]
 #[graphql(field(name = "description", type = "String"))]
-pub enum CreateRequisitionShipmentErrorInterface {
+pub enum DeleteErrorInterface {
+    RecordDoesNotExist(RecordDoesNotExist),
+    NothingRemainingToSupply(NothingRemainingToSupply),
     CannotEditRequisition(CannotEditRequisition),
 }
 
 #[derive(SimpleObject)]
-pub struct CreateRequisitionShipmentError {
-    pub error: CreateRequisitionShipmentErrorInterface,
+#[graphql(name = "CreateRequisitionShipmentError")]
+pub struct DeleteError {
+    pub error: DeleteErrorInterface,
 }
 
 #[derive(Union)]
+#[graphql(name = "CreateRequisitionShipmentResponse")]
 pub enum CreateRequisitionShipmentResponse {
-    Error(CreateRequisitionShipmentError),
-    Response(RequisitionNode),
+    Error(DeleteError),
+    Response(InvoiceNode),
 }
 
 pub fn create_requisition_shipment(
-    _ctx: &Context<'_>,
-    _store_id: Option<String>,
-    _input: CreateRequisitionShipmentInput,
+    ctx: &Context<'_>,
+    store_id: &str,
+    input: CreateRequisitionShipmentInput,
 ) -> Result<CreateRequisitionShipmentResponse> {
-    todo!()
+    validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::EditRequisition,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.context()?;
+
+    let response = match service_provider
+        .requisition_service
+        .create_requisition_shipment(&service_context, store_id, input.to_domain())
+    {
+        Ok(invoice) => CreateRequisitionShipmentResponse::Response(invoice.into()),
+        Err(error) => CreateRequisitionShipmentResponse::Error(DeleteError {
+            error: map_error(error)?,
+        }),
+    };
+
+    Ok(response)
+}
+
+impl CreateRequisitionShipmentInput {
+    fn to_domain(self) -> ServiceInput {
+        let CreateRequisitionShipmentInput {
+            response_requisition_id,
+        } = self;
+        ServiceInput {
+            response_requisition_id,
+        }
+    }
+}
+
+fn map_error(error: ServiceError) -> Result<DeleteErrorInterface> {
+    use StandardGraphqlError::*;
+    let formatted_error = format!("{:#?}", error);
+
+    let graphql_error = match error {
+        // Structured Errors
+        ServiceError::RequisitionDoesNotExist => {
+            return Ok(DeleteErrorInterface::RecordDoesNotExist(
+                RecordDoesNotExist {},
+            ))
+        }
+        ServiceError::CannotEditRequisition => {
+            return Ok(DeleteErrorInterface::CannotEditRequisition(
+                CannotEditRequisition {},
+            ))
+        }
+        ServiceError::NothingRemainingToSupply => {
+            return Ok(DeleteErrorInterface::NothingRemainingToSupply(
+                NothingRemainingToSupply {},
+            ))
+        }
+        // Standard Graphql Errors
+        ServiceError::NotThisStoreRequisition => BadUserInput(formatted_error),
+        ServiceError::NotAResponseRequisition => BadUserInput(formatted_error),
+        ServiceError::CreatedInvoiceDoesNotExist => InternalError(formatted_error),
+        ServiceError::ProblemGettingOtherParty => InternalError(formatted_error),
+        ServiceError::ProblemFindingItem => InternalError(formatted_error),
+        ServiceError::DatabaseError(_) => InternalError(formatted_error),
+    };
+
+    Err(graphql_error.extend())
+}
+
+pub struct NothingRemainingToSupply;
+#[Object]
+impl NothingRemainingToSupply {
+    pub async fn description(&self) -> &'static str {
+        "Requisition is fulfilled, check associated invoices and supply quantity"
+    }
 }

--- a/graphql/src/schema/mutations/requisition/response_requisition/supply_requested_quantity.rs
+++ b/graphql/src/schema/mutations/requisition/response_requisition/supply_requested_quantity.rs
@@ -1,7 +1,17 @@
+use crate::{
+    schema::{
+        mutations::{requisition::errors::CannotEditRequisition, RecordDoesNotExist},
+        types::RequisitionLineConnector,
+    },
+    standard_graphql_error::{validate_auth, StandardGraphqlError},
+    ContextExt,
+};
 use async_graphql::*;
-
-use crate::schema::{
-    mutations::requisition::errors::CannotEditRequisition, types::RequisitionNode,
+use service::{
+    permission_validation::{Resource, ResourceAccessRequest},
+    requisition::response_requisition::{
+        SupplyRequestedQuantity as ServiceInput, SupplyRequestedQuantityError as ServiceError,
+    },
 };
 
 #[derive(InputObject)]
@@ -10,26 +20,89 @@ pub struct SupplyRequestedQuantityInput {
 }
 
 #[derive(Interface)]
+#[graphql(name = "SupplyRequestedQuantityErrorInterface")]
 #[graphql(field(name = "description", type = "String"))]
-pub enum SupplyRequestedQuantityErrorInterface {
+pub enum DeleteErrorInterface {
+    RecordDoesNotExist(RecordDoesNotExist),
     CannotEditRequisition(CannotEditRequisition),
 }
 
 #[derive(SimpleObject)]
-pub struct SupplyRequestedQuantityError {
-    pub error: SupplyRequestedQuantityErrorInterface,
+#[graphql(name = "SupplyRequestedQuantityError")]
+pub struct DeleteError {
+    pub error: DeleteErrorInterface,
 }
 
 #[derive(Union)]
+#[graphql(name = "SupplyRequestedQuantityResponse")]
 pub enum SupplyRequestedQuantityResponse {
-    Error(SupplyRequestedQuantityError),
-    Response(RequisitionNode),
+    Error(DeleteError),
+    Response(RequisitionLineConnector),
 }
 
 pub fn supply_requested_quantity(
-    _ctx: &Context<'_>,
-    _store_id: Option<String>,
-    _input: SupplyRequestedQuantityInput,
+    ctx: &Context<'_>,
+    store_id: &str,
+    input: SupplyRequestedQuantityInput,
 ) -> Result<SupplyRequestedQuantityResponse> {
-    todo!()
+    validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::EditRequisition,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.context()?;
+
+    let response = match service_provider
+        .requisition_service
+        .supply_requested_quantity(&service_context, store_id, input.to_domain())
+    {
+        Ok(requisition_lines) => SupplyRequestedQuantityResponse::Response(
+            RequisitionLineConnector::from_vec(requisition_lines),
+        ),
+        Err(error) => SupplyRequestedQuantityResponse::Error(DeleteError {
+            error: map_error(error)?,
+        }),
+    };
+
+    Ok(response)
+}
+
+impl SupplyRequestedQuantityInput {
+    fn to_domain(self) -> ServiceInput {
+        let SupplyRequestedQuantityInput {
+            response_requisition_id,
+        } = self;
+        ServiceInput {
+            response_requisition_id,
+        }
+    }
+}
+
+fn map_error(error: ServiceError) -> Result<DeleteErrorInterface> {
+    use StandardGraphqlError::*;
+    let formatted_error = format!("{:#?}", error);
+
+    let graphql_error = match error {
+        // Structured Errors
+        ServiceError::RequisitionDoesNotExist => {
+            return Ok(DeleteErrorInterface::RecordDoesNotExist(
+                RecordDoesNotExist {},
+            ))
+        }
+        ServiceError::CannotEditRequisition => {
+            return Ok(DeleteErrorInterface::CannotEditRequisition(
+                CannotEditRequisition {},
+            ))
+        }
+        // Standard Graphql Errors
+        ServiceError::NotThisStoreRequisition => BadUserInput(formatted_error),
+        ServiceError::NotAResponseRequisition => BadUserInput(formatted_error),
+        ServiceError::DatabaseError(_) => InternalError(formatted_error),
+    };
+
+    Err(graphql_error.extend())
 }

--- a/graphql/src/schema/mutations/requisition/response_requisition/update.rs
+++ b/graphql/src/schema/mutations/requisition/response_requisition/update.rs
@@ -1,7 +1,18 @@
+use crate::{
+    schema::{
+        mutations::{requisition::errors::CannotEditRequisition, RecordDoesNotExist},
+        types::RequisitionNode,
+    },
+    standard_graphql_error::{validate_auth, StandardGraphqlError},
+    ContextExt,
+};
 use async_graphql::*;
-
-use crate::schema::{
-    mutations::requisition::errors::CannotEditRequisition, types::RequisitionNode,
+use service::{
+    permission_validation::{Resource, ResourceAccessRequest},
+    requisition::response_requisition::{
+        UpdateResponseRequisition as ServiceInput, UpdateResponseRequisitionError as ServiceError,
+        UpdateResponseRequstionStatus,
+    },
 };
 
 #[derive(InputObject)]
@@ -23,6 +34,7 @@ pub enum UpdateResponseRequisitionStatusInput {
 #[graphql(name = "UpdateResponseRequisitionErrorInterface")]
 #[graphql(field(name = "description", type = "String"))]
 pub enum UpdateErrorInterface {
+    RecordDoesNotExist(RecordDoesNotExist),
     CannotEditRequisition(CannotEditRequisition),
 }
 
@@ -39,10 +51,82 @@ pub enum UpdateResponse {
     Response(RequisitionNode),
 }
 
-pub fn update(
-    _ctx: &Context<'_>,
-    _store_id: Option<String>,
-    _input: UpdateInput,
-) -> Result<UpdateResponse> {
-    todo!()
+pub fn update(ctx: &Context<'_>, store_id: &str, input: UpdateInput) -> Result<UpdateResponse> {
+    validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::EditRequisition,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.context()?;
+
+    let response = match service_provider
+        .requisition_service
+        .update_response_requisition(&service_context, store_id, input.to_domain())
+    {
+        Ok(requisition) => UpdateResponse::Response(RequisitionNode::from_domain(requisition)),
+        Err(error) => UpdateResponse::Error(UpdateError {
+            error: map_error(error)?,
+        }),
+    };
+
+    Ok(response)
+}
+
+impl UpdateInput {
+    fn to_domain(self) -> ServiceInput {
+        let UpdateInput {
+            id,
+            colour,
+            their_reference,
+            comment,
+            status,
+        } = self;
+
+        ServiceInput {
+            id,
+            colour,
+            their_reference,
+            comment,
+            status: status.map(|status| status.to_domain()),
+        }
+    }
+}
+
+fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
+    use StandardGraphqlError::*;
+    let formatted_error = format!("{:#?}", error);
+
+    let graphql_error = match error {
+        // Structured Errors
+        ServiceError::RequisitionDoesNotExist => {
+            return Ok(UpdateErrorInterface::RecordDoesNotExist(
+                RecordDoesNotExist {},
+            ))
+        }
+        ServiceError::CannotEditRequisition => {
+            return Ok(UpdateErrorInterface::CannotEditRequisition(
+                CannotEditRequisition {},
+            ))
+        }
+        // Standard Graphql Errors
+        ServiceError::NotThisStoreRequisition => BadUserInput(formatted_error),
+        ServiceError::NotAResponseRequisition => BadUserInput(formatted_error),
+        ServiceError::UpdatedRequisitionDoesNotExist => InternalError(formatted_error),
+        ServiceError::DatabaseError(_) => InternalError(formatted_error),
+    };
+
+    Err(graphql_error.extend())
+}
+
+impl UpdateResponseRequisitionStatusInput {
+    pub fn to_domain(self) -> UpdateResponseRequstionStatus {
+        use UpdateResponseRequisitionStatusInput::*;
+        match self {
+            Finalised => UpdateResponseRequstionStatus::Finalised,
+        }
+    }
 }

--- a/server/tests/graphql/requisition/mod.rs
+++ b/server/tests/graphql/requisition/mod.rs
@@ -3,3 +3,4 @@ mod requisition;
 mod requisition_by_number;
 mod requisition_loaders;
 mod requisitions;
+mod response_requisition;

--- a/server/tests/graphql/requisition/response_requisition/create_requisition_shipment.rs
+++ b/server/tests/graphql/requisition/response_requisition/create_requisition_shipment.rs
@@ -1,0 +1,269 @@
+mod graphql {
+    use crate::graphql::{assert_graphql_query, assert_standard_graphql_error};
+    use chrono::Utc;
+    use domain::invoice::{Invoice, InvoiceStatus, InvoiceType};
+    use repository::{mock::MockDataInserts, StorageConnectionManager};
+    use serde_json::json;
+    use server::test_utils::setup_all;
+    use service::{
+        requisition::{
+            response_requisition::{
+                CreateRequisitionShipment as ServiceInput,
+                CreateRequisitionShipmentError as ServiceError,
+            },
+            RequisitionServiceTrait,
+        },
+        service_provider::{ServiceContext, ServiceProvider},
+    };
+
+    type DeleteLineMethod =
+        dyn Fn(&str, ServiceInput) -> Result<Invoice, ServiceError> + Sync + Send;
+
+    pub struct TestService(pub Box<DeleteLineMethod>);
+
+    impl RequisitionServiceTrait for TestService {
+        fn create_requisition_shipment(
+            &self,
+            _: &ServiceContext,
+            store_id: &str,
+            input: ServiceInput,
+        ) -> Result<Invoice, ServiceError> {
+            self.0(store_id, input)
+        }
+    }
+
+    fn service_provider(
+        test_service: TestService,
+        connection_manager: &StorageConnectionManager,
+    ) -> ServiceProvider {
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
+        service_provider.requisition_service = Box::new(test_service);
+        service_provider
+    }
+
+    fn empty_variables() -> serde_json::Value {
+        json!({
+          "input": {
+            "responseRequisitionId": "n/a"
+          },
+          "storeId": "n/a"
+        })
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_create_requisition_shipment_errors() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_create_requisition_shipment_structured_errors",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($input: CreateRequisitionShipmentInput!, $storeId: String) {
+            createRequisitionShipment(storeId: $storeId, input: $input) {
+              ... on CreateRequisitionShipmentError {
+                error {
+                  __typename
+                }
+              }
+            }
+          }
+        "#;
+
+        // RequisitionDoesNotExist
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::RequisitionDoesNotExist)));
+
+        let expected = json!({
+            "createRequisitionShipment": {
+              "error": {
+                "__typename": "RecordDoesNotExist"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // CannotEditRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::CannotEditRequisition)));
+
+        let expected = json!({
+            "createRequisitionShipment": {
+              "error": {
+                "__typename": "CannotEditRequisition"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NothingRemainingToSupply
+        let test_service =
+            TestService(Box::new(|_, _| Err(ServiceError::NothingRemainingToSupply)));
+
+        let expected = json!({
+            "createRequisitionShipment": {
+              "error": {
+                "__typename": "NothingRemainingToSupply"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NotThisStoreRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::NotThisStoreRequisition)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NotAResponseRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::NotAResponseRequisition)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // ProblemGettingOtherParty
+        let test_service =
+            TestService(Box::new(|_, _| Err(ServiceError::ProblemGettingOtherParty)));
+        let expected_message = "Internal error";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // ProblemFindingItem
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::ProblemFindingItem)));
+        let expected_message = "Internal error";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // CreatedInvoiceDoesNotExist
+        let test_service = TestService(Box::new(|_, _| {
+            Err(ServiceError::CreatedInvoiceDoesNotExist)
+        }));
+        let expected_message = "Internal error";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_create_requisition_shipment_success() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_create_requisition_shipment_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($storeId: String, $input: CreateRequisitionShipmentInput!) {
+            createRequisitionShipment(storeId: $storeId, input: $input) {
+                ... on InvoiceNode{
+                  id
+                }
+            }
+          }
+        "#;
+
+        // Success
+        let test_service = TestService(Box::new(|store_id, input| {
+            assert_eq!(store_id, "store_a");
+            assert_eq!(
+                input,
+                ServiceInput {
+                    response_requisition_id: "id input".to_string(),
+                }
+            );
+            Ok(Invoice {
+                id: "new invoice id".to_string(),
+                other_party_name: "n/a".to_string(),
+                other_party_id: "n/a".to_string(),
+                other_party_store_id: None,
+                status: InvoiceStatus::New,
+                on_hold: false,
+                r#type: InvoiceType::OutboundShipment,
+                invoice_number: 1,
+                their_reference: None,
+                comment: None,
+                created_datetime: Utc::now().naive_utc(),
+                allocated_datetime: None,
+                picked_datetime: None,
+                shipped_datetime: None,
+                delivered_datetime: None,
+                verified_datetime: None,
+                colour: None,
+                requisition_id: None,
+            })
+        }));
+
+        let variables = json!({
+          "input": {
+            "responseRequisitionId": "id input"
+          },
+          "storeId": "store_a"
+        });
+
+        let expected = json!({
+            "createRequisitionShipment": {
+              "id": "new invoice id"
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(variables),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+}

--- a/server/tests/graphql/requisition/response_requisition/mod.rs
+++ b/server/tests/graphql/requisition/response_requisition/mod.rs
@@ -1,0 +1,3 @@
+mod create_requisition_shipment;
+mod supply_requested_quantity;
+mod update;

--- a/server/tests/graphql/requisition/response_requisition/supply_requested_quantity.rs
+++ b/server/tests/graphql/requisition/response_requisition/supply_requested_quantity.rs
@@ -1,0 +1,202 @@
+mod graphql {
+    use crate::graphql::{assert_graphql_query, assert_standard_graphql_error};
+    use repository::{
+        mock::{
+            mock_request_draft_requisition, mock_sent_request_requisition_line, MockDataInserts,
+        },
+        RequisitionLine, StorageConnectionManager,
+    };
+    use serde_json::json;
+    use server::test_utils::setup_all;
+    use service::{
+        requisition::{
+            response_requisition::{
+                SupplyRequestedQuantity as ServiceInput,
+                SupplyRequestedQuantityError as ServiceError,
+            },
+            RequisitionServiceTrait,
+        },
+        service_provider::{ServiceContext, ServiceProvider},
+    };
+
+    type DeleteLineMethod =
+        dyn Fn(&str, ServiceInput) -> Result<Vec<RequisitionLine>, ServiceError> + Sync + Send;
+
+    pub struct TestService(pub Box<DeleteLineMethod>);
+
+    impl RequisitionServiceTrait for TestService {
+        fn supply_requested_quantity(
+            &self,
+            _: &ServiceContext,
+            store_id: &str,
+            input: ServiceInput,
+        ) -> Result<Vec<RequisitionLine>, ServiceError> {
+            self.0(store_id, input)
+        }
+    }
+
+    fn service_provider(
+        test_service: TestService,
+        connection_manager: &StorageConnectionManager,
+    ) -> ServiceProvider {
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
+        service_provider.requisition_service = Box::new(test_service);
+        service_provider
+    }
+
+    fn empty_variables() -> serde_json::Value {
+        json!({
+          "input": {
+            "responseRequisitionId": "n/a"
+          },
+          "storeId": "n/a"
+        })
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_supply_requested_quantity_errors() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_supply_requested_quantity_structured_errors",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($input: SupplyRequestedQuantityInput!, $storeId: String) {
+            supplyRequestedQuantity(storeId: $storeId, input: $input) {
+              ... on SupplyRequestedQuantityError {
+                error {
+                  __typename
+                }
+              }
+            }
+          }
+        "#;
+
+        // RequisitionDoesNotExist
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::RequisitionDoesNotExist)));
+
+        let expected = json!({
+            "supplyRequestedQuantity": {
+              "error": {
+                "__typename": "RecordDoesNotExist"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // CannotEditRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::CannotEditRequisition)));
+
+        let expected = json!({
+            "supplyRequestedQuantity": {
+              "error": {
+                "__typename": "CannotEditRequisition"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NotThisStoreRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::NotThisStoreRequisition)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NotAResponseRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::NotAResponseRequisition)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_supply_requested_quantity_success() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_supply_requested_quantity_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($storeId: String, $input: SupplyRequestedQuantityInput!) {
+            supplyRequestedQuantity(storeId: $storeId, input: $input) {
+                ... on RequisitionLineConnector{
+                  nodes {
+                    id
+                  }
+                }
+            }
+          }
+        "#;
+
+        // Success
+        let test_service = TestService(Box::new(|store_id, input| {
+            assert_eq!(store_id, "store_a");
+            assert_eq!(
+                input,
+                ServiceInput {
+                    response_requisition_id: "id input".to_string(),
+                }
+            );
+            Ok(vec![RequisitionLine {
+                requisition_line_row: mock_sent_request_requisition_line(),
+                requisition_row: mock_request_draft_requisition(),
+            }])
+        }));
+
+        let variables = json!({
+          "input": {
+            "responseRequisitionId": "id input"
+          },
+          "storeId": "store_a"
+        });
+
+        let expected = json!({
+            "supplyRequestedQuantity": {
+              "nodes": [
+                {
+                  "id": mock_sent_request_requisition_line().id
+                }
+              ]
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(variables),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+}

--- a/server/tests/graphql/requisition/response_requisition/update.rs
+++ b/server/tests/graphql/requisition/response_requisition/update.rs
@@ -1,0 +1,217 @@
+mod graphql {
+    use crate::graphql::{assert_graphql_query, assert_standard_graphql_error};
+    use repository::{
+        mock::{mock_name_a, mock_request_draft_requisition, MockDataInserts},
+        Requisition, StorageConnectionManager,
+    };
+    use serde_json::json;
+    use server::test_utils::setup_all;
+    use service::{
+        requisition::{
+            response_requisition::{
+                UpdateResponseRequisition as ServiceInput,
+                UpdateResponseRequisitionError as ServiceError, UpdateResponseRequstionStatus,
+            },
+            RequisitionServiceTrait,
+        },
+        service_provider::{ServiceContext, ServiceProvider},
+    };
+
+    type UpdateLineMethod =
+        dyn Fn(&str, ServiceInput) -> Result<Requisition, ServiceError> + Sync + Send;
+
+    pub struct TestService(pub Box<UpdateLineMethod>);
+
+    impl RequisitionServiceTrait for TestService {
+        fn update_response_requisition(
+            &self,
+            _: &ServiceContext,
+            store_id: &str,
+            input: ServiceInput,
+        ) -> Result<Requisition, ServiceError> {
+            self.0(store_id, input)
+        }
+    }
+
+    fn service_provider(
+        test_service: TestService,
+        connection_manager: &StorageConnectionManager,
+    ) -> ServiceProvider {
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
+        service_provider.requisition_service = Box::new(test_service);
+        service_provider
+    }
+
+    fn empty_variables() -> serde_json::Value {
+        json!({
+          "input": {
+            "id": "n/a",
+          },
+          "storeId": "n/a"
+        })
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_update_response_requisition_errors() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_update_response_requisition_structured_errors",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($input: UpdateResponseRequisitionInput!, $storeId: String) {
+            updateResponseRequisition(storeId: $storeId, input: $input) {
+              ... on UpdateResponseRequisitionError {
+                error {
+                  __typename
+                }
+              }
+            }
+          }
+        "#;
+
+        // RequisitionDoesNotExist
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::RequisitionDoesNotExist)));
+
+        let expected = json!({
+            "updateResponseRequisition": {
+              "error": {
+                "__typename": "RecordDoesNotExist"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // CannotEditRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::CannotEditRequisition)));
+
+        let expected = json!({
+            "updateResponseRequisition": {
+              "error": {
+                "__typename": "CannotEditRequisition"
+              }
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(empty_variables()),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NotThisStoreRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::NotThisStoreRequisition)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NotAResponseRequisition
+        let test_service = TestService(Box::new(|_, _| Err(ServiceError::NotAResponseRequisition)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // UpdatedRequisitionDoesNotExist
+        let test_service = TestService(Box::new(|_, _| {
+            Err(ServiceError::UpdatedRequisitionDoesNotExist)
+        }));
+        let expected_message = "Internal error";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_update_response_requisition_success() {
+        let (_, _, connection_manager, settings) = setup_all(
+            "test_graphql_update_response_requisition_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($storeId: String, $input: UpdateResponseRequisitionInput!) {
+            updateResponseRequisition(storeId: $storeId, input: $input) {
+                ... on RequisitionNode {
+                    id
+                }
+            }
+          }
+        "#;
+
+        // Success
+        let test_service = TestService(Box::new(|store_id, input| {
+            assert_eq!(store_id, "store_a");
+            assert_eq!(
+                input,
+                ServiceInput {
+                    id: "id input".to_string(),
+                    colour: Some("colour input".to_string()),
+                    their_reference: Some("reference input".to_string()),
+                    comment: Some("comment input".to_string()),
+                    status: Some(UpdateResponseRequstionStatus::Finalised)
+                }
+            );
+            Ok(Requisition {
+                requisition_row: mock_request_draft_requisition(),
+                name_row: mock_name_a(),
+            })
+        }));
+
+        let variables = json!({
+          "input": {
+            "id": "id input",
+
+            "colour": "colour input",
+            "theirReference": "reference input",
+            "comment": "comment input",
+            "status": "FINALISED"
+          },
+          "storeId": "store_a"
+        });
+
+        let expected = json!({
+            "updateResponseRequisition": {
+                "id": mock_request_draft_requisition().id
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(variables),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+}

--- a/service/src/requisition/response_requisition/create_requisition_shipment/mod.rs
+++ b/service/src/requisition/response_requisition/create_requisition_shipment/mod.rs
@@ -14,6 +14,7 @@ mod validate;
 use generate::*;
 use validate::*;
 
+#[derive(Debug, PartialEq)]
 pub struct CreateRequisitionShipment {
     pub response_requisition_id: String,
 }

--- a/service/src/requisition/response_requisition/supply_requested_quantity.rs
+++ b/service/src/requisition/response_requisition/supply_requested_quantity.rs
@@ -9,6 +9,7 @@ use repository::{
     RequisitionLineRowRepository, StorageConnection,
 };
 
+#[derive(Debug, PartialEq)]
 pub struct SupplyRequestedQuantity {
     pub response_requisition_id: String,
 }

--- a/service/src/requisition/response_requisition/update.rs
+++ b/service/src/requisition/response_requisition/update.rs
@@ -8,9 +8,11 @@ use repository::{
     RepositoryError, Requisition, RequisitionRowRepository, StorageConnection,
 };
 
+#[derive(Debug, PartialEq)]
 pub enum UpdateResponseRequstionStatus {
     Finalised,
 }
+#[derive(Debug, PartialEq)]
 pub struct UpdateResponseRequisition {
     pub id: String,
     pub colour: Option<String>,


### PR DESCRIPTION
closes #730 

* Removed store_id from 
* Added some extra structured errors

Btw in the structured errors in requisition end points, I would like to see more info being returned, but wanted to implement as much functionality without those details (i.e. NothingRemainigToSupply can return shipments etc..)

