### PR TITLE
Remove deref in favour of more direct .row() methods

### DIFF
--- a/graphql/src/schema/types/requisition.rs
+++ b/graphql/src/schema/types/requisition.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use self::dataloader::DataLoader;
 use crate::{
     loader::{
@@ -12,7 +10,7 @@ use crate::{
 use async_graphql::*;
 use chrono::{DateTime, Utc};
 use repository::{
-    schema::{RequisitionRow, RequisitionRowStatus, RequisitionRowType},
+    schema::{NameRow, RequisitionRow, RequisitionRowStatus, RequisitionRowType},
     Requisition,
 };
 use service::ListResult;
@@ -55,48 +53,48 @@ pub struct RequisitionConnector {
 #[Object]
 impl RequisitionNode {
     pub async fn id(&self) -> &str {
-        &self.id
+        &self.row().id
     }
 
     pub async fn r#type(&self) -> RequisitionNodeType {
-        RequisitionNodeType::from_domain(&self.r#type)
+        RequisitionNodeType::from_domain(&self.row().r#type)
     }
 
     pub async fn status(&self) -> RequisitionNodeStatus {
-        RequisitionNodeStatus::from_domain(&self.status)
+        RequisitionNodeStatus::from_domain(&self.row().status)
     }
 
     pub async fn created_datetime(&self) -> DateTime<Utc> {
-        DateTime::<Utc>::from_utc(*&self.created_datetime.clone(), Utc)
+        DateTime::<Utc>::from_utc(self.row().created_datetime.clone(), Utc)
     }
 
     /// Applicable to request requisition only
     pub async fn sent_datetime(&self) -> Option<DateTime<Utc>> {
-        let sent_datetime = *&self.sent_datetime.clone();
+        let sent_datetime = self.row().sent_datetime.clone();
         sent_datetime.map(|v| DateTime::<Utc>::from_utc(v, Utc))
     }
 
     pub async fn finalised_datetime(&self) -> Option<DateTime<Utc>> {
-        let finalised_datetime = *&self.finalised_datetime.clone();
+        let finalised_datetime = self.row().finalised_datetime.clone();
         finalised_datetime.map(|v| DateTime::<Utc>::from_utc(v, Utc))
     }
 
     pub async fn requisition_number(&self) -> &i64 {
-        &self.requisition_number
+        &self.row().requisition_number
     }
 
     pub async fn colour(&self) -> &Option<String> {
-        &self.colour
+        &self.row().colour
     }
 
     pub async fn their_reference(&self) -> &Option<String> {
-        &self.their_reference
+        &self.row().their_reference
     }
 
     // TODO our reference ? How does their reference reflect in other half of requisition ?
 
     pub async fn comment(&self) -> &Option<String> {
-        &self.comment
+        &self.row().comment
     }
 
     /// Request Requisition: Supplying store (store that is supplying stock)
@@ -104,38 +102,39 @@ impl RequisitionNode {
     pub async fn other_party(&self, ctx: &Context<'_>) -> Result<NameNode> {
         let loader = ctx.get_loader::<DataLoader<NameByIdLoader>>();
 
-        let response_option = loader.load_one(self.name_id.clone()).await?;
+        let response_option = loader.load_one(self.row().name_id.clone()).await?;
 
         response_option.map(NameNode::from).ok_or(
             InternalError(format!(
                 "Cannot find name ({}) linked to requisition ({})",
-                &self.name_id, &self.id
+                &self.row().name_id,
+                &self.row().id
             ))
             .extend(),
         )
     }
 
     pub async fn other_party_name(&self) -> &str {
-        &self.requisition.name_row.name
+        &self.name_row().name
     }
 
     pub async fn other_party_id(&self) -> &str {
-        &self.name_id
+        &self.row().name_id
     }
 
     /// Maximum calculated quantity, used to deduce calculated quantity for each line, see calculated in requisition line
     pub async fn max_months_of_stock(&self) -> &f64 {
-        &self.max_months_of_stock
+        &self.row().max_months_of_stock
     }
 
     /// Minimum quantity to have for stock to be ordered, used to deduce calculated quantity for each line, see calculated in requisition line
     pub async fn threshold_months_of_stock(&self) -> &f64 {
-        &self.threshold_months_of_stock
+        &self.row().threshold_months_of_stock
     }
 
     pub async fn lines(&self, ctx: &Context<'_>) -> Result<RequisitionLineConnector> {
         let loader = ctx.get_loader::<DataLoader<RequisitionLinesByRequisitionIdLoader>>();
-        let result_option = loader.load_one((&self.id).to_owned()).await?;
+        let result_option = loader.load_one(self.row().id.clone()).await?;
 
         let result = result_option.unwrap_or(vec![]);
 
@@ -144,11 +143,11 @@ impl RequisitionNode {
 
     /// Link to request requisition
     pub async fn request_requisition(&self, ctx: &Context<'_>) -> Result<Option<RequisitionNode>> {
-        if &self.r#type == &RequisitionRowType::Request {
+        if &self.row().r#type == &RequisitionRowType::Request {
             return Ok(None);
         }
 
-        let request_requisition_id = if let Some(id) = &self.linked_requisition_id {
+        let request_requisition_id = if let Some(id) = &self.row().linked_requisition_id {
             id
         } else {
             return Ok(None);
@@ -166,7 +165,7 @@ impl RequisitionNode {
     /// Request Requisition: Inbound Shipments linked to requisition
     pub async fn shipments(&self, ctx: &Context<'_>) -> Result<Connector<InvoiceNode>> {
         let loader = ctx.get_loader::<DataLoader<InvoiceByRequisitionIdLoader>>();
-        let result_option = loader.load_one((&self.id).to_owned()).await?;
+        let result_option = loader.load_one(self.row().id.clone()).await?;
 
         let list_result = result_option.unwrap_or(vec![]);
 
@@ -176,14 +175,6 @@ impl RequisitionNode {
     // % allocated ?
     // % shipped ?
     // lead time ?
-}
-
-impl Deref for RequisitionNode {
-    type Target = RequisitionRow;
-
-    fn deref(&self) -> &Self::Target {
-        &self.requisition.requisition_row
-    }
 }
 
 impl RequisitionNode {
@@ -242,5 +233,15 @@ impl RequisitionNodeStatus {
             Sent => RequisitionNodeStatus::Sent,
             Finalised => RequisitionNodeStatus::Finalised,
         }
+    }
+}
+
+impl RequisitionNode {
+    pub fn row(&self) -> &RequisitionRow {
+        &self.requisition.requisition_row
+    }
+
+    pub fn name_row(&self) -> &NameRow {
+        &self.requisition.name_row
     }
 }

--- a/graphql/src/schema/types/requisition_line.rs
+++ b/graphql/src/schema/types/requisition_line.rs
@@ -1,9 +1,7 @@
-use std::ops::Deref;
-
 use async_graphql::*;
 use dataloader::DataLoader;
 use repository::{
-    schema::{RequisitionLineRow, RequisitionRowType},
+    schema::{RequisitionLineRow, RequisitionRow, RequisitionRowType},
     RequisitionLine,
 };
 use service::{usize_to_u32, ListResult};
@@ -33,20 +31,21 @@ pub struct RequisitionLineConnector {
 #[Object]
 impl RequisitionLineNode {
     pub async fn id(&self) -> &str {
-        &self.id
+        &self.row().id
     }
 
     pub async fn item_id(&self) -> &str {
-        &self.item_id
+        &self.row().item_id
     }
 
     pub async fn item(&self, ctx: &Context<'_>) -> Result<ItemNode> {
         let loader = ctx.get_loader::<DataLoader<ItemLoader>>();
-        let item_option = loader.load_one((&self.item_id).to_owned()).await?;
+        let item_option = loader.load_one(self.row().item_id.clone()).await?;
         let item = item_option.ok_or(
             StandardGraphqlError::InternalError(format!(
                 "Cannot find item_id {} for requisition_line_id {}",
-                &self.item_id, &self.id
+                &self.row().item_id,
+                &self.row().id
             ))
             .extend(),
         )?;
@@ -56,18 +55,18 @@ impl RequisitionLineNode {
 
     /// Quantity requested
     pub async fn requested_quantity(&self) -> &i32 {
-        &self.requested_quantity
+        &self.row().requested_quantity
     }
 
     /// Quantity to be supplied in the next shipment, only used in response requisition
     pub async fn supply_quantity(&self) -> &i32 {
-        &self.supply_quantity
+        &self.row().supply_quantity
     }
 
     /// Calculated quantity
     /// When months_of_stock < requisition.threshold_months_of_stock, calculated = average_monthy_consumption * requisition.max_months_of_stock - months_of_stock
     pub async fn calculated_quantity(&self) -> &i32 {
-        &self.calculated_quantity
+        &self.row().calculated_quantity
     }
 
     /// OutboundShipment lines linked to requisitions line
@@ -83,14 +82,14 @@ impl RequisitionLineNode {
                 Some(linked_requisition_id) => linked_requisition_id,
                 None => return Ok(Connector::empty()),
             },
-            _ => &self.requisition_id,
+            _ => &self.row().requisition_id,
         };
 
         let loader = ctx.get_loader::<DataLoader<InvoiceLineForRequisitionLine>>();
         let result_option = loader
             .load_one(RequisitionAndItemId {
                 requisition_id: requisition_id.clone(),
-                item_id: (&self.item_id).clone(),
+                item_id: self.row().item_id.clone(),
             })
             .await?;
 
@@ -112,14 +111,14 @@ impl RequisitionLineNode {
                 Some(linked_requisition_id) => linked_requisition_id,
                 None => return Ok(Connector::empty()),
             },
-            _ => &self.requisition_id,
+            _ => &self.row().requisition_id,
         };
 
         let loader = ctx.get_loader::<DataLoader<InvoiceLineForRequisitionLine>>();
         let result_option = loader
             .load_one(RequisitionAndItemId {
                 requisition_id: requisition_id.clone(),
-                item_id: (&self.item_id).clone(),
+                item_id: self.row().item_id.clone(),
             })
             .await?;
 
@@ -131,8 +130,8 @@ impl RequisitionLineNode {
     /// Snapshot Stats (when requisition was created)
     pub async fn item_stats(&self) -> ItemStatsNode {
         ItemStatsNode {
-            average_monthly_consumption: *&self.average_monthly_consumption,
-            stock_on_hand: *&self.stock_on_hand,
+            average_monthly_consumption: self.row().average_monthly_consumption,
+            stock_on_hand: self.row().stock_on_hand,
         }
     }
 
@@ -140,31 +139,22 @@ impl RequisitionLineNode {
         &self,
         ctx: &Context<'_>,
     ) -> Result<Option<RequisitionLineNode>> {
-        let linked_requisition_id = if let Some(linked_requisition_id) =
-            &self.requisition_line.requisition_row.linked_requisition_id
-        {
-            linked_requisition_id
-        } else {
-            return Ok(None);
-        };
+        let linked_requisition_id =
+            if let Some(linked_requisition_id) = &self.requisition_row().linked_requisition_id {
+                linked_requisition_id
+            } else {
+                return Ok(None);
+            };
 
         let loader = ctx.get_loader::<DataLoader<LinkedRequisitionLineLoader>>();
         let result_option = loader
             .load_one(RequisitionAndItemId {
                 requisition_id: linked_requisition_id.clone(),
-                item_id: (&self.item_id).clone(),
+                item_id: self.row().item_id.clone(),
             })
             .await?;
 
         Ok(result_option.map(RequisitionLineNode::from_domain))
-    }
-}
-
-impl Deref for RequisitionLineNode {
-    type Target = RequisitionLineRow;
-
-    fn deref(&self) -> &Self::Target {
-        &self.requisition_line.requisition_line_row
     }
 }
 
@@ -194,5 +184,14 @@ impl RequisitionLineConnector {
                 .map(RequisitionLineNode::from_domain)
                 .collect(),
         }
+    }
+}
+
+impl RequisitionLineNode {
+    pub fn row(&self) -> &RequisitionLineRow {
+        &self.requisition_line.requisition_line_row
+    }
+    pub fn requisition_row(&self) -> &RequisitionRow {
+        &self.requisition_line.requisition_row
     }
 }


### PR DESCRIPTION
Changes to avoid conflicts since a lot of branches are branched from each other