### PR TITLE
Requisition-PR-changes-branched-from-737

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2978,6 +2978,7 @@ dependencies = [
  "serde 1.0.130",
  "serde_json",
  "thiserror",
+ "util",
  "uuid",
 ]
 

--- a/graphql/src/loader/invoice_line_query.rs
+++ b/graphql/src/loader/invoice_line_query.rs
@@ -8,7 +8,7 @@ use service::ListError;
 
 use crate::standard_graphql_error::StandardGraphqlError;
 
-use super::{extract_unique_requisition_and_item_id, RequisitionAndItemId};
+use super::{extract_unique_requisition_and_item_ids, RequisitionAndItemId};
 
 pub struct InvoiceLineQueryLoader {
     pub connection_manager: StorageConnectionManager,
@@ -60,7 +60,7 @@ impl Loader<RequisitionAndItemId> for InvoiceLineForRequisitionLine {
         let repo = InvoiceLineRepository::new(&connection);
 
         let (requisition_ids, item_ids) =
-            extract_unique_requisition_and_item_id(requisition_and_item_id);
+            extract_unique_requisition_and_item_ids(requisition_and_item_id);
 
         let all_invoice_lines = repo
             .query_by_filter(

--- a/graphql/src/loader/mod.rs
+++ b/graphql/src/loader/mod.rs
@@ -39,7 +39,7 @@ pub struct RequisitionAndItemId {
     pub item_id: String,
 }
 
-fn extract_unique_requisition_and_item_id(
+fn extract_unique_requisition_and_item_ids(
     requisition_and_item_ids: &[RequisitionAndItemId],
 ) -> (Vec<String>, Vec<String>) {
     let mut requisition_ids: HashSet<String> = HashSet::new();

--- a/graphql/src/loader/requisition_line.rs
+++ b/graphql/src/loader/requisition_line.rs
@@ -8,7 +8,7 @@ use service::service_provider::ServiceProvider;
 
 use crate::standard_graphql_error::StandardGraphqlError;
 
-use super::{extract_unique_requisition_and_item_id, RequisitionAndItemId};
+use super::{extract_unique_requisition_and_item_ids, RequisitionAndItemId};
 
 pub struct RequisitionLinesByRequisitionIdLoader {
     pub service_provider: Data<ServiceProvider>,
@@ -62,7 +62,7 @@ impl Loader<RequisitionAndItemId> for LinkedRequisitionLineLoader {
         let service_context = self.service_provider.context()?;
 
         let (requisition_ids, item_ids) =
-            extract_unique_requisition_and_item_id(requisition_and_item_id);
+            extract_unique_requisition_and_item_ids(requisition_and_item_id);
 
         let filter = RequisitionLineFilter::new()
             .requisition_id(EqualFilter::equal_any(requisition_ids))

--- a/graphql/src/schema/mutations/requisition/request_requisition/line/insert.rs
+++ b/graphql/src/schema/mutations/requisition/request_requisition/line/insert.rs
@@ -116,7 +116,7 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
         ServiceError::NotThisStoreRequisition => BadUserInput(formatted_error),
         ServiceError::NotARequestRequisition => BadUserInput(formatted_error),
         ServiceError::ItemDoesNotExist => BadUserInput(formatted_error),
-        ServiceError::ProblemCreatingRequisitionLine => InternalError(formatted_error),
+        ServiceError::CannotFindItemStatusForRequisitionLine => InternalError(formatted_error),
         ServiceError::NewlyCreatedRequisitionLineDoesNotExist => InternalError(formatted_error),
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
     };

--- a/graphql/src/schema/types/requisition.rs
+++ b/graphql/src/schema/types/requisition.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use self::dataloader::DataLoader;
 use crate::{
     loader::{
@@ -12,7 +10,7 @@ use crate::{
 use async_graphql::*;
 use chrono::{DateTime, Utc};
 use repository::{
-    schema::{RequisitionRow, RequisitionRowStatus, RequisitionRowType},
+    schema::{NameRow, RequisitionRow, RequisitionRowStatus, RequisitionRowType},
     Requisition,
 };
 use service::ListResult;
@@ -55,48 +53,48 @@ pub struct RequisitionConnector {
 #[Object]
 impl RequisitionNode {
     pub async fn id(&self) -> &str {
-        &self.id
+        &self.row().id
     }
 
     pub async fn r#type(&self) -> RequisitionNodeType {
-        RequisitionNodeType::from_domain(&self.r#type)
+        RequisitionNodeType::from_domain(&self.row().r#type)
     }
 
     pub async fn status(&self) -> RequisitionNodeStatus {
-        RequisitionNodeStatus::from_domain(&self.status)
+        RequisitionNodeStatus::from_domain(&self.row().status)
     }
 
     pub async fn created_datetime(&self) -> DateTime<Utc> {
-        DateTime::<Utc>::from_utc(*&self.created_datetime.clone(), Utc)
+        DateTime::<Utc>::from_utc(self.row().created_datetime.clone(), Utc)
     }
 
     /// Applicable to request requisition only
     pub async fn sent_datetime(&self) -> Option<DateTime<Utc>> {
-        let sent_datetime = *&self.sent_datetime.clone();
+        let sent_datetime = self.row().sent_datetime.clone();
         sent_datetime.map(|v| DateTime::<Utc>::from_utc(v, Utc))
     }
 
     pub async fn finalised_datetime(&self) -> Option<DateTime<Utc>> {
-        let finalised_datetime = *&self.finalised_datetime.clone();
+        let finalised_datetime = self.row().finalised_datetime.clone();
         finalised_datetime.map(|v| DateTime::<Utc>::from_utc(v, Utc))
     }
 
     pub async fn requisition_number(&self) -> &i64 {
-        &self.requisition_number
+        &self.row().requisition_number
     }
 
     pub async fn colour(&self) -> &Option<String> {
-        &self.colour
+        &self.row().colour
     }
 
     pub async fn their_reference(&self) -> &Option<String> {
-        &self.their_reference
+        &self.row().their_reference
     }
 
     // TODO our reference ? How does their reference reflect in other half of requisition ?
 
     pub async fn comment(&self) -> &Option<String> {
-        &self.comment
+        &self.row().comment
     }
 
     /// Request Requisition: Supplying store (store that is supplying stock)
@@ -104,38 +102,39 @@ impl RequisitionNode {
     pub async fn other_party(&self, ctx: &Context<'_>) -> Result<NameNode> {
         let loader = ctx.get_loader::<DataLoader<NameByIdLoader>>();
 
-        let response_option = loader.load_one(self.name_id.clone()).await?;
+        let response_option = loader.load_one(self.row().name_id.clone()).await?;
 
         response_option.map(NameNode::from).ok_or(
             InternalError(format!(
                 "Cannot find name ({}) linked to requisition ({})",
-                &self.name_id, &self.id
+                &self.row().name_id,
+                &self.row().id
             ))
             .extend(),
         )
     }
 
     pub async fn other_party_name(&self) -> &str {
-        &self.requisition.name_row.name
+        &self.name_row().name
     }
 
     pub async fn other_party_id(&self) -> &str {
-        &self.name_id
+        &self.row().name_id
     }
 
     /// Maximum calculated quantity, used to deduce calculated quantity for each line, see calculated in requisition line
     pub async fn max_months_of_stock(&self) -> &f64 {
-        &self.max_months_of_stock
+        &self.row().max_months_of_stock
     }
 
     /// Minimum quantity to have for stock to be ordered, used to deduce calculated quantity for each line, see calculated in requisition line
     pub async fn threshold_months_of_stock(&self) -> &f64 {
-        &self.threshold_months_of_stock
+        &self.row().threshold_months_of_stock
     }
 
     pub async fn lines(&self, ctx: &Context<'_>) -> Result<RequisitionLineConnector> {
         let loader = ctx.get_loader::<DataLoader<RequisitionLinesByRequisitionIdLoader>>();
-        let result_option = loader.load_one((&self.id).to_owned()).await?;
+        let result_option = loader.load_one(self.row().id.clone()).await?;
 
         let result = result_option.unwrap_or(vec![]);
 
@@ -144,11 +143,11 @@ impl RequisitionNode {
 
     /// Link to request requisition
     pub async fn request_requisition(&self, ctx: &Context<'_>) -> Result<Option<RequisitionNode>> {
-        if &self.r#type == &RequisitionRowType::Request {
+        if &self.row().r#type == &RequisitionRowType::Request {
             return Ok(None);
         }
 
-        let request_requisition_id = if let Some(id) = &self.linked_requisition_id {
+        let request_requisition_id = if let Some(id) = &self.row().linked_requisition_id {
             id
         } else {
             return Ok(None);
@@ -166,7 +165,7 @@ impl RequisitionNode {
     /// Request Requisition: Inbound Shipments linked to requisition
     pub async fn shipments(&self, ctx: &Context<'_>) -> Result<Connector<InvoiceNode>> {
         let loader = ctx.get_loader::<DataLoader<InvoiceByRequisitionIdLoader>>();
-        let result_option = loader.load_one((&self.id).to_owned()).await?;
+        let result_option = loader.load_one(self.row().id.clone()).await?;
 
         let list_result = result_option.unwrap_or(vec![]);
 
@@ -176,14 +175,6 @@ impl RequisitionNode {
     // % allocated ?
     // % shipped ?
     // lead time ?
-}
-
-impl Deref for RequisitionNode {
-    type Target = RequisitionRow;
-
-    fn deref(&self) -> &Self::Target {
-        &self.requisition.requisition_row
-    }
 }
 
 impl RequisitionNode {
@@ -242,5 +233,15 @@ impl RequisitionNodeStatus {
             Sent => RequisitionNodeStatus::Sent,
             Finalised => RequisitionNodeStatus::Finalised,
         }
+    }
+}
+
+impl RequisitionNode {
+    pub fn row(&self) -> &RequisitionRow {
+        &self.requisition.requisition_row
+    }
+
+    pub fn name_row(&self) -> &NameRow {
+        &self.requisition.name_row
     }
 }

--- a/graphql/src/schema/types/requisition_line.rs
+++ b/graphql/src/schema/types/requisition_line.rs
@@ -1,9 +1,7 @@
-use std::ops::Deref;
-
 use async_graphql::*;
 use dataloader::DataLoader;
 use repository::{
-    schema::{RequisitionLineRow, RequisitionRowType},
+    schema::{RequisitionLineRow, RequisitionRow, RequisitionRowType},
     RequisitionLine,
 };
 use service::{usize_to_u32, ListResult};
@@ -33,20 +31,21 @@ pub struct RequisitionLineConnector {
 #[Object]
 impl RequisitionLineNode {
     pub async fn id(&self) -> &str {
-        &self.id
+        &self.row().id
     }
 
     pub async fn item_id(&self) -> &str {
-        &self.item_id
+        &self.row().item_id
     }
 
     pub async fn item(&self, ctx: &Context<'_>) -> Result<ItemNode> {
         let loader = ctx.get_loader::<DataLoader<ItemLoader>>();
-        let item_option = loader.load_one((&self.item_id).to_owned()).await?;
+        let item_option = loader.load_one(self.row().item_id.clone()).await?;
         let item = item_option.ok_or(
             StandardGraphqlError::InternalError(format!(
                 "Cannot find item_id {} for requisition_line_id {}",
-                &self.item_id, &self.id
+                &self.row().item_id,
+                &self.row().id
             ))
             .extend(),
         )?;
@@ -56,18 +55,18 @@ impl RequisitionLineNode {
 
     /// Quantity requested
     pub async fn requested_quantity(&self) -> &i32 {
-        &self.requested_quantity
+        &self.row().requested_quantity
     }
 
     /// Quantity to be supplied in the next shipment, only used in response requisition
     pub async fn supply_quantity(&self) -> &i32 {
-        &self.supply_quantity
+        &self.row().supply_quantity
     }
 
     /// Calculated quantity
     /// When months_of_stock < requisition.threshold_months_of_stock, calculated = average_monthy_consumption * requisition.max_months_of_stock - months_of_stock
     pub async fn calculated_quantity(&self) -> &i32 {
-        &self.calculated_quantity
+        &self.row().calculated_quantity
     }
 
     /// OutboundShipment lines linked to requisitions line
@@ -83,14 +82,14 @@ impl RequisitionLineNode {
                 Some(linked_requisition_id) => linked_requisition_id,
                 None => return Ok(Connector::empty()),
             },
-            _ => &self.requisition_id,
+            _ => &self.row().requisition_id,
         };
 
         let loader = ctx.get_loader::<DataLoader<InvoiceLineForRequisitionLine>>();
         let result_option = loader
             .load_one(RequisitionAndItemId {
                 requisition_id: requisition_id.clone(),
-                item_id: (&self.item_id).clone(),
+                item_id: self.row().item_id.clone(),
             })
             .await?;
 
@@ -112,14 +111,14 @@ impl RequisitionLineNode {
                 Some(linked_requisition_id) => linked_requisition_id,
                 None => return Ok(Connector::empty()),
             },
-            _ => &self.requisition_id,
+            _ => &self.row().requisition_id,
         };
 
         let loader = ctx.get_loader::<DataLoader<InvoiceLineForRequisitionLine>>();
         let result_option = loader
             .load_one(RequisitionAndItemId {
                 requisition_id: requisition_id.clone(),
-                item_id: (&self.item_id).clone(),
+                item_id: self.row().item_id.clone(),
             })
             .await?;
 
@@ -131,8 +130,8 @@ impl RequisitionLineNode {
     /// Snapshot Stats (when requisition was created)
     pub async fn item_stats(&self) -> ItemStatsNode {
         ItemStatsNode {
-            average_monthly_consumption: *&self.average_monthly_consumption,
-            stock_on_hand: *&self.stock_on_hand,
+            average_monthly_consumption: self.row().average_monthly_consumption,
+            stock_on_hand: self.row().stock_on_hand,
         }
     }
 
@@ -140,31 +139,22 @@ impl RequisitionLineNode {
         &self,
         ctx: &Context<'_>,
     ) -> Result<Option<RequisitionLineNode>> {
-        let linked_requisition_id = if let Some(linked_requisition_id) =
-            &self.requisition_line.requisition_row.linked_requisition_id
-        {
-            linked_requisition_id
-        } else {
-            return Ok(None);
-        };
+        let linked_requisition_id =
+            if let Some(linked_requisition_id) = &self.requisition_row().linked_requisition_id {
+                linked_requisition_id
+            } else {
+                return Ok(None);
+            };
 
         let loader = ctx.get_loader::<DataLoader<LinkedRequisitionLineLoader>>();
         let result_option = loader
             .load_one(RequisitionAndItemId {
                 requisition_id: linked_requisition_id.clone(),
-                item_id: (&self.item_id).clone(),
+                item_id: self.row().item_id.clone(),
             })
             .await?;
 
         Ok(result_option.map(RequisitionLineNode::from_domain))
-    }
-}
-
-impl Deref for RequisitionLineNode {
-    type Target = RequisitionLineRow;
-
-    fn deref(&self) -> &Self::Target {
-        &self.requisition_line.requisition_line_row
     }
 }
 
@@ -194,5 +184,14 @@ impl RequisitionLineConnector {
                 .map(RequisitionLineNode::from_domain)
                 .collect(),
         }
+    }
+}
+
+impl RequisitionLineNode {
+    pub fn row(&self) -> &RequisitionLineRow {
+        &self.requisition_line.requisition_line_row
+    }
+    pub fn requisition_row(&self) -> &RequisitionRow {
+        &self.requisition_line.requisition_row
     }
 }

--- a/repository/Cargo.toml
+++ b/repository/Cargo.toml
@@ -8,6 +8,7 @@ path = "src/lib.rs"
 
 [dependencies]
 domain = { path = "../domain" }
+util = { path = "../util" }
 
 chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "1.4.7", default-features = false, features = ["r2d2", "numeric", "chrono", "32-column-tables"] }

--- a/repository/src/db_diesel/item_stats.rs
+++ b/repository/src/db_diesel/item_stats.rs
@@ -97,7 +97,6 @@ pub fn to_domain(
                 stock_info_row.item_id.clone(),
                 ItemStats {
                     consumption_rows: Vec::new(),
-
                     item_id: stock_info_row.item_id.clone(),
                     stock_info_row,
                     look_back_datetime,
@@ -108,6 +107,8 @@ pub fn to_domain(
 
     for consumption_row in consumption_rows.into_iter() {
         map.entry(consumption_row.item_id.clone())
+            // Technicallly, there will always be matching record already in the HashMap
+            // since stock_info view should return same item/stores as consumption view
             .or_insert(ItemStats {
                 consumption_rows: Vec::new(),
                 item_id: consumption_row.item_id.clone(),

--- a/repository/src/db_diesel/item_stats.rs
+++ b/repository/src/db_diesel/item_stats.rs
@@ -11,6 +11,7 @@ use diesel::prelude::*;
 use diesel::{QueryDsl, RunQueryDsl};
 use domain::EqualFilter;
 use std::collections::HashMap;
+use util::constants::NUMBER_OF_DAYS_IN_A_MONTH;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ItemStatsFilter {
@@ -150,7 +151,8 @@ impl ItemStats {
             total_consumption += row.consumption_quantity
         }
 
-        (total_consumption as f64 / number_of_days_since_look_back as f64 * 30 as f64) as i32
+        (total_consumption as f64 / number_of_days_since_look_back as f64
+            * NUMBER_OF_DAYS_IN_A_MONTH) as i32
     }
 
     pub fn stock_on_hand(&self) -> i32 {

--- a/repository/src/tests.rs
+++ b/repository/src/tests.rs
@@ -350,6 +350,7 @@ mod repository_test {
         stock_line::StockLineFilter,
         DateFilter, EqualFilter, Pagination, SimpleStringFilter,
     };
+    use util::constants::NUMBER_OF_DAYS_IN_A_MONTH;
 
     #[actix_rt::test]
     async fn test_name_repository() {
@@ -1218,11 +1219,11 @@ mod repository_test {
 
         assert_eq!(
             item_stats[0].average_monthly_consumption(),
-            ((40 + 4 + 3) as f64 / (3 * 30) as f64 * 30 as f64) as i32
+            ((40 + 4 + 3) as f64 / (3 * 30) as f64 * NUMBER_OF_DAYS_IN_A_MONTH) as i32
         );
         assert_eq!(
             item_stats[1].average_monthly_consumption(),
-            ((15) as f64 / (3 * 30) as f64 * 30 as f64) as i32
+            ((15) as f64 / (3 * 30) as f64 * NUMBER_OF_DAYS_IN_A_MONTH) as i32
         );
 
         // Reduce to looking back 10 days
@@ -1241,7 +1242,7 @@ mod repository_test {
 
         assert_eq!(
             item_stats[0].average_monthly_consumption(),
-            ((40 + 4) as f64 / (10) as f64 * 30 as f64) as i32
+            ((40 + 4) as f64 / (10) as f64 * NUMBER_OF_DAYS_IN_A_MONTH) as i32
         );
         // No invoice lines check
         assert_eq!(item_stats[1].average_monthly_consumption(), 0);
@@ -1257,11 +1258,11 @@ mod repository_test {
 
         assert_eq!(
             item_stats[0].average_monthly_consumption(),
-            ((20000) as f64 / (3 * 30) as f64 * 30 as f64) as i32
+            ((20000) as f64 / (3 * 30) as f64 * NUMBER_OF_DAYS_IN_A_MONTH) as i32
         );
         assert_eq!(
             item_stats[1].average_monthly_consumption(),
-            ((300) as f64 / (3 * 30) as f64 * 30 as f64) as i32
+            ((300) as f64 / (3 * 30) as f64 * NUMBER_OF_DAYS_IN_A_MONTH) as i32
         );
     }
 }

--- a/server/tests/graphql/requisition/request_requisition_line/insert.rs
+++ b/server/tests/graphql/requisition/request_requisition_line/insert.rs
@@ -187,9 +187,9 @@ mod graphql {
             Some(service_provider(test_service, &connection_manager))
         );
 
-        // ProblemCreatingRequisitionLine
+        // CannotFindItemStatusForRequisitionLine
         let test_service = TestService(Box::new(|_, _| {
-            Err(ServiceError::ProblemCreatingRequisitionLine)
+            Err(ServiceError::CannotFindItemStatusForRequisitionLine)
         }));
         let expected_message = "Internal error";
         assert_standard_graphql_error!(

--- a/service/src/requisition/request_requisition/update/generate.rs
+++ b/service/src/requisition/request_requisition/update/generate.rs
@@ -47,6 +47,7 @@ pub fn generate(
         || update_max_months_of_stock != max_months_of_stock;
 
     let updated_requisition_row = RequisitionRow {
+        // Only sent status is available in UpdateRequestRequstionStatus
         status: if update_status.is_some() {
             RequisitionRowStatus::Sent
         } else {

--- a/service/src/requisition/response_requisition/create_requisition_shipment/validate.rs
+++ b/service/src/requisition/response_requisition/create_requisition_shipment/validate.rs
@@ -30,12 +30,12 @@ pub fn validate(
         return Err(OutError::CannotEditRequisition);
     }
 
-    let filfulments = get_remaining_fulfilments(connection, &requisition_row.id)?;
-    if filfulments.len() == 0 {
+    let fulfilment = get_remaining_fulfilments(connection, &requisition_row.id)?;
+    if fulfilment.len() == 0 {
         return Err(OutError::NothingRemainingToSupply);
     }
 
-    Ok((requisition_row, filfulments))
+    Ok((requisition_row, fulfilment))
 }
 
 pub fn get_remaining_fulfilments(

--- a/service/src/requisition/response_requisition/update.rs
+++ b/service/src/requisition/response_requisition/update.rs
@@ -106,6 +106,7 @@ pub fn generate(
     }: UpdateResponseRequisition,
 ) -> RequisitionRow {
     RequisitionRow {
+        // Only finalised status is available in UpdateResponseRequstionStatus
         status: if update_status.is_some() {
             RequisitionRowStatus::Finalised
         } else {

--- a/service/src/requisition/response_requisition/update.rs
+++ b/service/src/requisition/response_requisition/update.rs
@@ -29,6 +29,7 @@ pub enum UpdateResponseRequisitionError {
     CannotEditRequisition,
     NotAResponseRequisition,
     UpdatedRequisitionDoesNotExist,
+    // TODO https://github.com/openmsupply/remote-server/issues/760
     DatabaseError(RepositoryError),
 }
 

--- a/service/src/requisition_line/request_requisition_line/insert.rs
+++ b/service/src/requisition_line/request_requisition_line/insert.rs
@@ -34,10 +34,10 @@ pub enum InsertRequestRequisitionLineError {
     NotThisStoreRequisition,
     CannotEditRequisition,
     NotARequestRequisition,
+    DatabaseError(RepositoryError),
     // Should never happen
     CannotFindItemStatusForRequisitionLine,
     NewlyCreatedRequisitionLineDoesNotExist,
-    DatabaseError(RepositoryError),
 }
 
 type OutError = InsertRequestRequisitionLineError;

--- a/service/src/requisition_line/request_requisition_line/insert.rs
+++ b/service/src/requisition_line/request_requisition_line/insert.rs
@@ -34,6 +34,7 @@ pub enum InsertRequestRequisitionLineError {
     NotThisStoreRequisition,
     CannotEditRequisition,
     NotARequestRequisition,
+    // Should never happen
     CannotFindItemStatusForRequisitionLine,
     NewlyCreatedRequisitionLineDoesNotExist,
     DatabaseError(RepositoryError),

--- a/service/src/requisition_line/request_requisition_line/insert.rs
+++ b/service/src/requisition_line/request_requisition_line/insert.rs
@@ -34,7 +34,7 @@ pub enum InsertRequestRequisitionLineError {
     NotThisStoreRequisition,
     CannotEditRequisition,
     NotARequestRequisition,
-    ProblemCreatingRequisitionLine,
+    CannotFindItemStatusForRequisitionLine,
     NewlyCreatedRequisitionLineDoesNotExist,
     DatabaseError(RepositoryError),
 }
@@ -111,7 +111,7 @@ fn generate(
     let mut new_requisition_line =
         generate_requisition_lines(connection, store_id, &requisition_row, vec![item_id])?
             .pop()
-            .ok_or(OutError::ProblemCreatingRequisitionLine)?;
+            .ok_or(OutError::CannotFindItemStatusForRequisitionLine)?;
 
     new_requisition_line.requested_quantity = requested_quantity.unwrap_or(0) as i32;
     new_requisition_line.id = id;

--- a/util/src/constants.rs
+++ b/util/src/constants.rs
@@ -1,2 +1,4 @@
 /// Code for the special inventory adjustment name
 pub const INVENTORY_ADJUSTMENT_NAME_CODE: &str = "invad";
+/// Number of days in a month (used in AMC calculation)
+pub const NUMBER_OF_DAYS_IN_A_MONTH: f64 = 30.0;


### PR DESCRIPTION
Changes to avoid conflicts and propagating changes from branches branches. Branched from 737 so that it can be merged before store_id changes