### PR TITLE
769 stocktake by number

### DIFF
--- a/graphql/src/schema/queries/mod.rs
+++ b/graphql/src/schema/queries/mod.rs
@@ -201,6 +201,15 @@ impl Queries {
         stocktake(ctx, &store_id, &id)
     }
 
+    pub async fn stocktake_by_number(
+        &self,
+        ctx: &Context<'_>,
+        store_id: String,
+        stocktake_number: i64,
+    ) -> Result<StocktakeResponse> {
+        stocktake_by_number(ctx, &store_id, stocktake_number)
+    }
+
     pub async fn stocktakes(
         &self,
         ctx: &Context<'_>,

--- a/server/tests/graphql/mod.rs
+++ b/server/tests/graphql/mod.rs
@@ -181,7 +181,7 @@ macro_rules! assert_graphql_query {
         )
         .await;
 
-        match actual["errors"].as_array() {
+        match actual.get("errors").and_then(serde_json::Value::as_array) {
             Some(errors) => {
                 if !errors.is_empty() {
                     panic!("Request failed with standard error(s): {}",

--- a/server/tests/graphql/mod.rs
+++ b/server/tests/graphql/mod.rs
@@ -181,6 +181,15 @@ macro_rules! assert_graphql_query {
         )
         .await;
 
+        match actual["errors"].as_array() {
+            Some(errors) => {
+                if !errors.is_empty() {
+                    panic!("Request failed with standard error(s): {}",
+                        serde_json::to_string_pretty(errors).unwrap());
+                }
+            },
+            None => {}
+        }
         let expected = serde_json::json!(
             {
                 "data": $expected_inner,


### PR DESCRIPTION
I ended up to not introduce new methods in the stocktake service. After simplifying the `stocktake` endpoint the code was actually so simple that I didn't see the need for a special service method, i.e. the service only has one query method. 

Somehow I ran into a std error while adding stocktake tests and the output was a bit misleading. I now print the std error in the assert_graphql_query macro.