### PR TITLE
768 change batch mutations to use input object

### DIFF
--- a/graphql/src/schema/mutations/inbound_shipment/batch.rs
+++ b/graphql/src/schema/mutations/inbound_shipment/batch.rs
@@ -31,14 +31,19 @@ pub struct BatchInboundShipmentResponse {
     delete_inbound_shipments: Option<Vec<MutationWithId<DeleteInboundShipmentResponse>>>,
 }
 
+#[derive(InputObject)]
+pub struct BatchInboundShipmentInput {
+    pub insert_inbound_shipments: Option<Vec<InsertInboundShipmentInput>>,
+    pub insert_inbound_shipment_lines: Option<Vec<InsertInboundShipmentLineInput>>,
+    pub update_inbound_shipment_lines: Option<Vec<UpdateInboundShipmentLineInput>>,
+    pub delete_inbound_shipment_lines: Option<Vec<DeleteInboundShipmentLineInput>>,
+    pub update_inbound_shipments: Option<Vec<UpdateInboundShipmentInput>>,
+    pub delete_inbound_shipments: Option<Vec<DeleteInboundShipmentInput>>,
+}
+
 pub fn get_batch_inbound_shipment_response(
     connection_manager: &StorageConnectionManager,
-    insert_inbound_shipments: Option<Vec<InsertInboundShipmentInput>>,
-    insert_inbound_shipment_lines: Option<Vec<InsertInboundShipmentLineInput>>,
-    update_inbound_shipment_lines: Option<Vec<UpdateInboundShipmentLineInput>>,
-    delete_inbound_shipment_lines: Option<Vec<DeleteInboundShipmentLineInput>>,
-    update_inbound_shipments: Option<Vec<UpdateInboundShipmentInput>>,
-    delete_inbound_shipments: Option<Vec<DeleteInboundShipmentInput>>,
+    input: BatchInboundShipmentInput,
 ) -> BatchInboundShipmentResponse {
     let mut result = BatchInboundShipmentResponse {
         insert_inbound_shipments: None,
@@ -49,7 +54,7 @@ pub fn get_batch_inbound_shipment_response(
         delete_inbound_shipments: None,
     };
 
-    if let Some(inputs) = insert_inbound_shipments {
+    if let Some(inputs) = input.insert_inbound_shipments {
         let (has_errors, responses) = do_insert_inbound_shipments(connection_manager, inputs);
         result.insert_inbound_shipments = Some(responses);
         if has_errors {
@@ -57,7 +62,7 @@ pub fn get_batch_inbound_shipment_response(
         }
     }
 
-    if let Some(inputs) = insert_inbound_shipment_lines {
+    if let Some(inputs) = input.insert_inbound_shipment_lines {
         let (has_errors, responses) = do_insert_inbound_shipment_lines(connection_manager, inputs);
         result.insert_inbound_shipment_lines = Some(responses);
         if has_errors {
@@ -65,7 +70,7 @@ pub fn get_batch_inbound_shipment_response(
         }
     }
 
-    if let Some(inputs) = update_inbound_shipment_lines {
+    if let Some(inputs) = input.update_inbound_shipment_lines {
         let (has_errors, responses) = do_update_inbound_shipment_lines(connection_manager, inputs);
         result.update_inbound_shipment_lines = Some(responses);
         if has_errors {
@@ -73,7 +78,7 @@ pub fn get_batch_inbound_shipment_response(
         }
     }
 
-    if let Some(inputs) = delete_inbound_shipment_lines {
+    if let Some(inputs) = input.delete_inbound_shipment_lines {
         let (has_errors, responses) = do_delete_inbound_shipment_lines(connection_manager, inputs);
         result.delete_inbound_shipment_lines = Some(responses);
         if has_errors {
@@ -81,7 +86,7 @@ pub fn get_batch_inbound_shipment_response(
         }
     }
 
-    if let Some(inputs) = update_inbound_shipments {
+    if let Some(inputs) = input.update_inbound_shipments {
         let (has_errors, responses) = do_update_inbound_shipments(connection_manager, inputs);
         result.update_inbound_shipments = Some(responses);
         if has_errors {
@@ -89,7 +94,7 @@ pub fn get_batch_inbound_shipment_response(
         }
     }
 
-    if let Some(inputs) = delete_inbound_shipments {
+    if let Some(inputs) = input.delete_inbound_shipments {
         let (has_errors, responses) = do_delete_inbound_shipments(connection_manager, inputs);
         result.delete_inbound_shipments = Some(responses);
         if has_errors {

--- a/graphql/src/schema/mutations/mod.rs
+++ b/graphql/src/schema/mutations/mod.rs
@@ -241,53 +241,19 @@ impl Mutations {
     async fn batch_inbound_shipment(
         &self,
         ctx: &Context<'_>,
-        insert_inbound_shipments: Option<Vec<InsertInboundShipmentInput>>,
-        insert_inbound_shipment_lines: Option<Vec<InsertInboundShipmentLineInput>>,
-        update_inbound_shipment_lines: Option<Vec<UpdateInboundShipmentLineInput>>,
-        delete_inbound_shipment_lines: Option<Vec<DeleteInboundShipmentLineInput>>,
-        update_inbound_shipments: Option<Vec<UpdateInboundShipmentInput>>,
-        delete_inbound_shipments: Option<Vec<DeleteInboundShipmentInput>>,
+        input: BatchInboundShipmentInput,
     ) -> BatchInboundShipmentResponse {
         let connection_manager = ctx.get_connection_manager();
 
-        get_batch_inbound_shipment_response(
-            connection_manager,
-            insert_inbound_shipments,
-            insert_inbound_shipment_lines,
-            update_inbound_shipment_lines,
-            delete_inbound_shipment_lines,
-            update_inbound_shipments,
-            delete_inbound_shipments,
-        )
+        get_batch_inbound_shipment_response(connection_manager, input)
     }
 
     async fn batch_outbound_shipment(
         &self,
         ctx: &Context<'_>,
-        insert_outbound_shipments: Option<Vec<InsertOutboundShipmentInput>>,
-        insert_outbound_shipment_lines: Option<Vec<InsertOutboundShipmentLineInput>>,
-        update_outbound_shipment_lines: Option<Vec<UpdateOutboundShipmentLineInput>>,
-        delete_outbound_shipment_lines: Option<Vec<DeleteOutboundShipmentLineInput>>,
-        insert_outbound_shipment_service_lines: Option<Vec<InsertOutboundShipmentServiceLineInput>>,
-        update_outbound_shipment_service_lines: Option<Vec<UpdateOutboundShipmentServiceLineInput>>,
-        delete_outbound_shipment_service_lines: Option<Vec<DeleteOutboundShipmentServiceLineInput>>,
-        update_outbound_shipments: Option<Vec<UpdateOutboundShipmentInput>>,
-        delete_outbound_shipments: Option<Vec<String>>,
-    ) -> BatchOutboundShipmentResponse {
-        let connection_manager = ctx.get_connection_manager();
-
-        get_batch_outbound_shipment_response(
-            connection_manager,
-            insert_outbound_shipments,
-            insert_outbound_shipment_lines,
-            update_outbound_shipment_lines,
-            delete_outbound_shipment_lines,
-            insert_outbound_shipment_service_lines,
-            update_outbound_shipment_service_lines,
-            delete_outbound_shipment_service_lines,
-            update_outbound_shipments,
-            delete_outbound_shipments,
-        )
+        input: BatchOutboundShipmentInput,
+    ) -> Result<BatchOutboundShipmentResponse> {
+        get_batch_outbound_shipment_response(ctx, input)
     }
 
     async fn insert_stocktake(
@@ -705,6 +671,18 @@ impl InvoiceLineBelongsToAnotherInvoice {
 #[graphql(concrete(
     name = "DeleteOutboundShipmentServiceLineResponseWithId",
     params(DeleteOutboundShipmentServiceLineResponse)
+))]
+#[graphql(concrete(
+    name = "InsertOutboundShipmentUnallocatedLineResponseWithId",
+    params(outbound_shipment::unallocated_line::InsertResponse)
+))]
+#[graphql(concrete(
+    name = "UpdateOutboundShipmentUnallocatedLineResponseWithId",
+    params(outbound_shipment::unallocated_line::UpdateResponse)
+))]
+#[graphql(concrete(
+    name = "DeleteOutboundShipmentUnallocatedLineResponseWithId",
+    params(outbound_shipment::unallocated_line::DeleteResponse)
 ))]
 pub struct MutationWithId<T: OutputType> {
     pub id: String,

--- a/graphql/src/schema/mutations/outbound_shipment/batch.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/batch.rs
@@ -1,23 +1,25 @@
-use crate::schema::mutations::{
-    outbound_shipment::{
-        delete::get_delete_outbound_shipment_response, get_delete_outbound_shipment_line_response,
-        get_insert_outbound_shipment_line_response, get_update_outbound_shipment_line_response,
-        get_update_outbound_shipment_response,
+use crate::{
+    schema::mutations::{
+        MutationWithId,
+        {
+            get_delete_outbound_shipment_line_response, get_insert_outbound_shipment_line_response,
+            get_update_outbound_shipment_line_response, get_update_outbound_shipment_response,
+        },
     },
-    MutationWithId,
+    ContextExt,
 };
 use repository::StorageConnectionManager;
 
 use super::{
     delete::DeleteOutboundShipmentResponse,
-    get_delete_outbound_shipment_service_line_response,
+    get_delete_outbound_shipment_response, get_delete_outbound_shipment_service_line_response,
     get_insert_outbound_shipment_service_line_response,
     get_update_outbound_shipment_service_line_response,
     insert::{
         get_insert_outbound_shipment_response, InsertOutboundShipmentInput,
         InsertOutboundShipmentResponse,
     },
-    DeleteOutboundShipmentLineInput, DeleteOutboundShipmentLineResponse,
+    unallocated_line, DeleteOutboundShipmentLineInput, DeleteOutboundShipmentLineResponse,
     DeleteOutboundShipmentServiceLineInput, DeleteOutboundShipmentServiceLineResponse,
     InsertOutboundShipmentLineInput, InsertOutboundShipmentLineResponse,
     InsertOutboundShipmentServiceLineInput, InsertOutboundShipmentServiceLineResponse,
@@ -39,12 +41,18 @@ pub struct BatchOutboundShipmentResponse {
         Option<Vec<MutationWithId<UpdateOutboundShipmentServiceLineResponse>>>,
     delete_outbound_shipment_service_lines:
         Option<Vec<MutationWithId<DeleteOutboundShipmentServiceLineResponse>>>,
+    insert_outbound_shipment_unallocated_lines:
+        Option<Vec<MutationWithId<unallocated_line::InsertResponse>>>,
+    update_outbound_shipment_unallocated_lines:
+        Option<Vec<MutationWithId<unallocated_line::UpdateResponse>>>,
+    delete_outbound_shipment_unallocated_lines:
+        Option<Vec<MutationWithId<unallocated_line::DeleteResponse>>>,
     update_outbound_shipments: Option<Vec<MutationWithId<UpdateOutboundShipmentResponse>>>,
     delete_outbound_shipments: Option<Vec<MutationWithId<DeleteOutboundShipmentResponse>>>,
 }
 
-pub fn get_batch_outbound_shipment_response(
-    connection_manager: &StorageConnectionManager,
+#[derive(InputObject)]
+pub struct BatchOutboundShipmentInput {
     insert_outbound_shipments: Option<Vec<InsertOutboundShipmentInput>>,
     insert_outbound_shipment_lines: Option<Vec<InsertOutboundShipmentLineInput>>,
     update_outbound_shipment_lines: Option<Vec<UpdateOutboundShipmentLineInput>>,
@@ -52,9 +60,18 @@ pub fn get_batch_outbound_shipment_response(
     insert_outbound_shipment_service_lines: Option<Vec<InsertOutboundShipmentServiceLineInput>>,
     update_outbound_shipment_service_lines: Option<Vec<UpdateOutboundShipmentServiceLineInput>>,
     delete_outbound_shipment_service_lines: Option<Vec<DeleteOutboundShipmentServiceLineInput>>,
+    insert_outbound_shipment_unallocated_lines: Option<Vec<unallocated_line::InsertInput>>,
+    update_outbound_shipment_unallocated_lines: Option<Vec<unallocated_line::UpdateInput>>,
+    delete_outbound_shipment_unallocated_lines: Option<Vec<unallocated_line::DeleteInput>>,
     update_outbound_shipments: Option<Vec<UpdateOutboundShipmentInput>>,
     delete_outbound_shipments: Option<Vec<String>>,
-) -> BatchOutboundShipmentResponse {
+}
+
+pub fn get_batch_outbound_shipment_response(
+    ctx: &Context<'_>,
+    input: BatchOutboundShipmentInput,
+) -> Result<BatchOutboundShipmentResponse> {
+    let connection_manager = ctx.get_connection_manager();
     let mut result = BatchOutboundShipmentResponse {
         insert_outbound_shipments: None,
         insert_outbound_shipment_lines: None,
@@ -63,86 +80,113 @@ pub fn get_batch_outbound_shipment_response(
         insert_outbound_shipment_service_lines: None,
         update_outbound_shipment_service_lines: None,
         delete_outbound_shipment_service_lines: None,
+        insert_outbound_shipment_unallocated_lines: None,
+        update_outbound_shipment_unallocated_lines: None,
+        delete_outbound_shipment_unallocated_lines: None,
         update_outbound_shipments: None,
         delete_outbound_shipments: None,
     };
 
-    if let Some(inputs) = insert_outbound_shipments {
+    if let Some(inputs) = input.insert_outbound_shipments {
         let (has_errors, responses) = do_insert_outbound_shipments(connection_manager, inputs);
         result.insert_outbound_shipments = Some(responses);
         if has_errors {
-            return result;
+            return Ok(result);
         }
     }
 
-    if let Some(inputs) = insert_outbound_shipment_lines {
+    if let Some(inputs) = input.insert_outbound_shipment_lines {
         let (has_errors, responses) = do_insert_outbound_shipment_lines(connection_manager, inputs);
         result.insert_outbound_shipment_lines = Some(responses);
         if has_errors {
-            return result;
+            return Ok(result);
         }
     }
 
-    if let Some(inputs) = update_outbound_shipment_lines {
+    if let Some(inputs) = input.update_outbound_shipment_lines {
         let (has_errors, responses) = do_update_outbound_shipment_lines(connection_manager, inputs);
         result.update_outbound_shipment_lines = Some(responses);
         if has_errors {
-            return result;
+            return Ok(result);
         }
     }
 
-    if let Some(inputs) = delete_outbound_shipment_lines {
+    if let Some(inputs) = input.delete_outbound_shipment_lines {
         let (has_errors, responses) = do_delete_outbound_shipment_lines(connection_manager, inputs);
         result.delete_outbound_shipment_lines = Some(responses);
         if has_errors {
-            return result;
+            return Ok(result);
         }
     }
 
-    if let Some(inputs) = insert_outbound_shipment_service_lines {
+    if let Some(inputs) = input.insert_outbound_shipment_service_lines {
         let (has_errors, responses) =
             do_insert_outbound_shipment_service_lines(connection_manager, inputs);
         result.insert_outbound_shipment_service_lines = Some(responses);
         if has_errors {
-            return result;
+            return Ok(result);
         }
     }
 
-    if let Some(inputs) = update_outbound_shipment_service_lines {
+    if let Some(inputs) = input.update_outbound_shipment_service_lines {
         let (has_errors, responses) =
             do_update_outbound_shipment_service_lines(connection_manager, inputs);
         result.update_outbound_shipment_service_lines = Some(responses);
         if has_errors {
-            return result;
+            return Ok(result);
         }
     }
 
-    if let Some(inputs) = delete_outbound_shipment_service_lines {
+    if let Some(inputs) = input.delete_outbound_shipment_service_lines {
         let (has_errors, responses) =
             do_delete_outbound_shipment_service_lines(connection_manager, inputs);
         result.delete_outbound_shipment_service_lines = Some(responses);
         if has_errors {
-            return result;
+            return Ok(result);
         }
     }
 
-    if let Some(inputs) = update_outbound_shipments {
+    if let Some(inputs) = input.insert_outbound_shipment_unallocated_lines {
+        let (has_errors, responses) = do_insert_outbound_shipment_unallocated_lines(ctx, inputs)?;
+        result.insert_outbound_shipment_unallocated_lines = Some(responses);
+        if has_errors {
+            return Ok(result);
+        }
+    }
+
+    if let Some(inputs) = input.update_outbound_shipment_unallocated_lines {
+        let (has_errors, responses) = do_update_outbound_shipment_unallocated_lines(ctx, inputs)?;
+        result.update_outbound_shipment_unallocated_lines = Some(responses);
+        if has_errors {
+            return Ok(result);
+        }
+    }
+
+    if let Some(inputs) = input.delete_outbound_shipment_unallocated_lines {
+        let (has_errors, responses) = do_delete_outbound_shipment_unallocated_lines(ctx, inputs)?;
+        result.delete_outbound_shipment_unallocated_lines = Some(responses);
+        if has_errors {
+            return Ok(result);
+        }
+    }
+
+    if let Some(inputs) = input.update_outbound_shipments {
         let (has_errors, responses) = do_update_outbound_shipments(connection_manager, inputs);
         result.update_outbound_shipments = Some(responses);
         if has_errors {
-            return result;
+            return Ok(result);
         }
     }
 
-    if let Some(inputs) = delete_outbound_shipments {
+    if let Some(inputs) = input.delete_outbound_shipments {
         let (has_errors, responses) = do_delete_outbound_shipments(connection_manager, inputs);
         result.delete_outbound_shipments = Some(responses);
         if has_errors {
-            return result;
+            return Ok(result);
         }
     }
 
-    result
+    Ok(result)
 }
 
 pub fn do_insert_outbound_shipments(
@@ -359,4 +403,70 @@ pub fn do_delete_outbound_shipment_service_lines(
     });
 
     (has_errors, responses)
+}
+
+pub fn do_insert_outbound_shipment_unallocated_lines(
+    ctx: &Context<'_>,
+    inputs: Vec<unallocated_line::InsertInput>,
+) -> Result<(bool, Vec<MutationWithId<unallocated_line::InsertResponse>>)> {
+    let mut responses = Vec::new();
+    for input in inputs.into_iter() {
+        let id = input.id.clone();
+        responses.push(MutationWithId {
+            id,
+            response: unallocated_line::insert(ctx, input)?,
+        });
+    }
+    let has_errors = responses.iter().any(|mutation_with_id| {
+        matches!(
+            mutation_with_id.response,
+            unallocated_line::InsertResponse::Error(_)
+        )
+    });
+
+    Ok((has_errors, responses))
+}
+
+pub fn do_update_outbound_shipment_unallocated_lines(
+    ctx: &Context<'_>,
+    inputs: Vec<unallocated_line::UpdateInput>,
+) -> Result<(bool, Vec<MutationWithId<unallocated_line::UpdateResponse>>)> {
+    let mut responses = Vec::new();
+    for input in inputs.into_iter() {
+        let id = input.id.clone();
+        responses.push(MutationWithId {
+            id,
+            response: unallocated_line::update(ctx, input)?,
+        });
+    }
+    let has_errors = responses.iter().any(|mutation_with_id| {
+        matches!(
+            mutation_with_id.response,
+            unallocated_line::UpdateResponse::Error(_)
+        )
+    });
+
+    Ok((has_errors, responses))
+}
+
+pub fn do_delete_outbound_shipment_unallocated_lines(
+    ctx: &Context<'_>,
+    inputs: Vec<unallocated_line::DeleteInput>,
+) -> Result<(bool, Vec<MutationWithId<unallocated_line::DeleteResponse>>)> {
+    let mut responses = Vec::new();
+    for input in inputs.into_iter() {
+        let id = input.id.clone();
+        responses.push(MutationWithId {
+            id,
+            response: unallocated_line::delete(ctx, input)?,
+        });
+    }
+    let has_errors = responses.iter().any(|mutation_with_id| {
+        matches!(
+            mutation_with_id.response,
+            unallocated_line::DeleteResponse::Error(_)
+        )
+    });
+
+    Ok((has_errors, responses))
 }

--- a/graphql/src/schema/mutations/outbound_shipment/unallocated_line/delete.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/unallocated_line/delete.rs
@@ -46,22 +46,24 @@ pub fn delete(ctx: &Context<'_>, input: DeleteInput) -> Result<DeleteResponse> {
     let service_provider = ctx.service_provider();
     let service_context = service_provider.context()?;
 
+    let id = input.id.clone();
+
     let response = match service_provider
         .outbound_shipment_line
         .delete_outbound_shipment_unallocated_line(&service_context, input.into())
     {
         Ok(id) => DeleteResponse::Response(GenericDeleteResponse(id)),
         Err(error) => DeleteResponse::Error(DeleteError {
-            error: map_error(error)?,
+            error: map_error(&id, error)?,
         }),
     };
 
     Ok(response)
 }
 
-fn map_error(error: ServiceError) -> Result<DeleteErrorInterface> {
+fn map_error(id: &str, error: ServiceError) -> Result<DeleteErrorInterface> {
     use StandardGraphqlError::*;
-    let formatted_error = format!("{:#?}", error);
+    let formatted_error = format!("Delete unallocated line {}: {:#?}", id, error);
 
     let graphql_error = match error {
         // Structured Errors

--- a/graphql/src/schema/mutations/outbound_shipment/unallocated_line/insert.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/unallocated_line/insert.rs
@@ -82,22 +82,24 @@ pub fn insert(ctx: &Context<'_>, input: InsertInput) -> Result<InsertResponse> {
     let service_provider = ctx.service_provider();
     let service_context = service_provider.context()?;
 
+    let id = input.id.clone();
+
     let response = match service_provider
         .outbound_shipment_line
         .insert_outbound_shipment_unallocated_line(&service_context, input.into())
     {
         Ok(invoice_line) => InsertResponse::Response(invoice_line.into()),
         Err(error) => InsertResponse::Error(InsertError {
-            error: map_error(error)?,
+            error: map_error(&id, error)?,
         }),
     };
 
     Ok(response)
 }
 
-fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
+fn map_error(id: &str, error: ServiceError) -> Result<InsertErrorInterface> {
     use StandardGraphqlError::*;
-    let formatted_error = format!("{:#?}", error);
+    let formatted_error = format!("Insert unallocated line {}: {:#?}", id, error);
 
     let graphql_error = match error {
         // Structured Errors

--- a/graphql/src/schema/mutations/outbound_shipment/unallocated_line/update.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/unallocated_line/update.rs
@@ -47,22 +47,24 @@ pub fn update(ctx: &Context<'_>, input: UpdateInput) -> Result<UpdateResponse> {
     let service_provider = ctx.service_provider();
     let service_context = service_provider.context()?;
 
+    let id = input.id.clone();
+
     let response = match service_provider
         .outbound_shipment_line
         .update_outbound_shipment_unallocated_line(&service_context, input.into())
     {
         Ok(invoice_line) => UpdateResponse::Response(invoice_line.into()),
         Err(error) => UpdateResponse::Error(UpdateError {
-            error: map_error(error)?,
+            error: map_error(&id, error)?,
         }),
     };
 
     Ok(response)
 }
 
-fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
+fn map_error(id: &str, error: ServiceError) -> Result<UpdateErrorInterface> {
     use StandardGraphqlError::*;
-    let formatted_error = format!("{:#?}", error);
+    let formatted_error = format!("Update unallocated line {}: {:#?}", id, error);
 
     let graphql_error = match error {
         // Structured Errors

--- a/server/tests/graphql/inbound_shipment_batch.rs
+++ b/server/tests/graphql/inbound_shipment_batch.rs
@@ -1,0 +1,85 @@
+mod graphql {
+    use crate::graphql::assert_graphql_query;
+    use repository::{
+        mock::{mock_stock_line_a, mock_stock_line_b, mock_store_a, MockDataInserts},
+        InboundShipmentLineRowRepository,
+    };
+    use serde_json::json;
+    use server::test_utils::setup_all;
+
+    #[actix_rt::test]
+    async fn test_graphql_inboundshipment_batch() {
+        let (_, connection, _, settings) = setup_all(
+            "omsupply-database-gql-inboundshipment_batch",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let query = r#"mutation BatchInboundShipment($storeId: String, $input: BatchInboundShipmentInput!) {
+          batchInboundShipment(input: $input) {
+            __typename
+            ... on BatchInboundShipmentResponses {                    
+              insertInboundShipments {
+                id
+                response {
+                  ... on InvoiceNod {
+                    id
+                  }
+                }
+              }
+          }
+        }"#;
+
+        // success
+       
+
+        let variables = Some(json!({
+            "input": {
+              "insertInboundShipments": [
+                {
+                  "id": "batch_inboundshipment_1",
+                  "createdDatetime": "2022-02-09T15:16:00",
+                },
+              ],
+              "insertInboundShipmentLines": [
+                {
+                  "id": "batch_inboundshipment_line_1",
+                  "inboundshipmentId": "batch_inboundshipment_1",
+                  "stockLineId": stock_line_a.id,
+                },
+                {
+                  "id": "batch_inboundshipment_line_2",
+                  "inboundshipmentId": "batch_inboundshipment_1",
+                  "stockLineId": stock_line_b.id,
+                }
+              ],
+            }
+        }));
+        let expected = json!({
+          "batchInboundShipment": {
+              "__typename": "BatchInboundShipmentResponses",
+              "insertInboundShipments": [
+                {
+                  "id": "batch_inboundshipment_1",
+                }
+              ],
+              "insertInboundShipmentLines": [
+                {
+                  "id": "batch_inboundshipment_line_1",
+                  "response": {
+                    "id": "batch_inboundshipment_line_1",
+                  }
+                },
+                {
+                  "id": "batch_inboundshipment_line_2",
+                  "response": {
+                    "id": "batch_inboundshipment_line_2",
+                  }
+                }
+              ],
+            }
+          }
+        );
+        assert_graphql_query!(&settings, query, &variables, &expected, None);
+    }
+}

--- a/server/tests/graphql/unallocated_line/delete.rs
+++ b/server/tests/graphql/unallocated_line/delete.rs
@@ -103,8 +103,13 @@ mod graphql {
         // LineIsNotUnallocatedLine
         let test_service = TestService(Box::new(|_| Err(ServiceError::LineIsNotUnallocatedLine)));
         let expected_message = "Bad user input";
-        let expected_extensions =
-            json!({ "details": format!("{:#?}", ServiceError::LineIsNotUnallocatedLine) });
+        let expected_extensions = json!({
+            "details":
+                format!(
+                    "Delete unallocated line n/a: {:#?}",
+                    ServiceError::LineIsNotUnallocatedLine
+                )
+        });
         assert_standard_graphql_error!(
             &settings,
             &mutation,

--- a/server/tests/graphql/unallocated_line/insert.rs
+++ b/server/tests/graphql/unallocated_line/insert.rs
@@ -202,8 +202,13 @@ mod graphql {
         // NotAStockItem
         let test_service = TestService(Box::new(|_| Err(ServiceError::NotAStockItem)));
         let expected_message = "Bad user input";
-        let expected_extensions =
-            json!({ "details": format!("{:#?}", ServiceError::NotAStockItem) });
+        let expected_extensions = json!({
+            "details":
+                format!(
+                    "Insert unallocated line n/a: {:#?}",
+                    ServiceError::NotAStockItem
+                )
+        });
         assert_standard_graphql_error!(
             &settings,
             &mutation,

--- a/server/tests/graphql/unallocated_line/update.rs
+++ b/server/tests/graphql/unallocated_line/update.rs
@@ -108,8 +108,13 @@ mod graphql {
         // LineIsNotUnallocatedLine
         let test_service = TestService(Box::new(|_| Err(ServiceError::LineIsNotUnallocatedLine)));
         let expected_message = "Bad user input";
-        let expected_extensions =
-            json!({ "details": format!("{:#?}", ServiceError::LineIsNotUnallocatedLine) });
+        let expected_extensions = json!({
+            "details":
+                format!(
+                    "Update unallocated line n/a: {:#?}",
+                    ServiceError::LineIsNotUnallocatedLine
+                )
+        });
         assert_standard_graphql_error!(
             &settings,
             &mutation,


### PR DESCRIPTION
closes: #768 

Also added unallocated line mutations to outbound shipment.

There is a mix and match of trait services and older services taking connection manager, to decided to keep it simple for now and made a bulletpoint to address this (and use transaction, similar to stocktake batch mutation), anyways added https://github.com/openmsupply/remote-server/issues/749
