### PR TITLE
Automatically run DB migrations when starting the server

### DIFF
--- a/repository/src/lib.rs
+++ b/repository/src/lib.rs
@@ -1,5 +1,7 @@
 #[macro_use]
 extern crate diesel;
+#[macro_use]
+extern crate diesel_migrations;
 
 pub mod database_settings;
 mod db_diesel;
@@ -15,3 +17,15 @@ pub use self::repository_error::RepositoryError;
 pub use database_settings::get_storage_connection_manager;
 
 mod tests;
+
+#[cfg(feature = "postgres")]
+embed_migrations!("./migrations/postgres");
+#[cfg(not(feature = "postgres"))]
+embed_migrations!("./migrations/sqlite");
+
+pub fn run_db_migrations(connection: &StorageConnection) -> Result<(), String> {
+    Ok(
+        embedded_migrations::run_with_output(&connection.connection, &mut std::io::stdout())
+            .map_err(|err| format!("{}", err))?,
+    )
+}


### PR DESCRIPTION
Checks for outstanding migrations and applies them.

Should also make developing remote sync a bit more easier, i.e. to start with a fresh DB.

Should automatically create an sql db on Android as well (untested) 