### PR TITLE
781 Remove external deps from graphql types

### DIFF
--- a/graphql/graphql_schema/query.graphql
+++ b/graphql/graphql_schema/query.graphql
@@ -447,7 +447,7 @@ fragment InvoiceNode on InvoiceNode {
   id
   invoiceNumber
   lines {
-    ...InvoiceLinesResponse
+    ...InvoiceLineConnector
   }
   otherPartyId
   otherPartyName
@@ -475,12 +475,6 @@ fragment InvoiceLineResponse on InvoiceLineResponse {
   __typename
   ...NodeError
   ...InvoiceLineNode
-}
-
-fragment InvoiceLinesResponse on InvoiceLinesResponse {
-  __typename
-  ...ConnectorError
-  ...InvoiceLineConnector
 }
 
 fragment InvoiceLineNode on InvoiceLineNode {
@@ -587,30 +581,11 @@ fragment NodeErrorInterface on NodeErrorInterface {
   ...RecordNotFound
 }
 
-fragment PaginationError on PaginationError {
-  description
-  rangeError {
-    ...RangeError
-  }
-}
-
 fragment RangeError on RangeError {
   description
   field
   max
   min
-}
-
-fragment ConnectorError on ConnectorError {
-  error {
-    ...ConnectorErrorInterface
-  }
-}
-
-fragment ConnectorErrorInterface on ConnectorErrorInterface {
-  __typename
-  ...DatabaseError
-  ...PaginationError
 }
 
 fragment CannotEditInvoice on CannotEditInvoice {

--- a/graphql/graphql_schema/schema.graphql
+++ b/graphql/graphql_schema/schema.graphql
@@ -19,9 +19,6 @@ type AuthToken {
 	"""
 	token: String!
 }
-"""
-Generic Error Wrapper
-"""
 type AuthTokenError {
 	error: AuthTokenErrorInterface!
 }
@@ -29,6 +26,14 @@ interface AuthTokenErrorInterface {
 	description: String!
 }
 union AuthTokenResponse = | AuthTokenError | AuthToken
+input BatchInboundShipmentInput {
+	insertInboundShipments: [InsertInboundShipmentInput!]
+	insertInboundShipmentLines: [InsertInboundShipmentLineInput!]
+	updateInboundShipmentLines: [UpdateInboundShipmentLineInput!]
+	deleteInboundShipmentLines: [DeleteInboundShipmentLineInput!]
+	updateInboundShipments: [UpdateInboundShipmentInput!]
+	deleteInboundShipments: [DeleteInboundShipmentInput!]
+}
 type BatchInboundShipmentResponse {
 	insertInboundShipments: [InsertInboundShipmentResponseWithId!]
 	insertInboundShipmentLines: [InsertInboundShipmentLineResponseWithId!]
@@ -37,8 +42,22 @@ type BatchInboundShipmentResponse {
 	updateInboundShipments: [UpdateInboundShipmentResponseWithId!]
 	deleteInboundShipments: [DeleteInboundShipmentResponseWithId!]
 }
-type BatchIsReserved implements UpdateInboundShipmentLineErrorInterface & DeleteInboundShipmentLineErrorInterface {
+type BatchIsReserved implements DeleteInboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface {
 	description: String!
+}
+input BatchOutboundShipmentInput {
+	insertOutboundShipments: [InsertOutboundShipmentInput!]
+	insertOutboundShipmentLines: [InsertOutboundShipmentLineInput!]
+	updateOutboundShipmentLines: [UpdateOutboundShipmentLineInput!]
+	deleteOutboundShipmentLines: [DeleteOutboundShipmentLineInput!]
+	insertOutboundShipmentServiceLines: [InsertOutboundShipmentServiceLineInput!]
+	updateOutboundShipmentServiceLines: [UpdateOutboundShipmentServiceLineInput!]
+	deleteOutboundShipmentServiceLines: [DeleteOutboundShipmentServiceLineInput!]
+	insertOutboundShipmentUnallocatedLines: [InsertOutboundShipmentUnallocatedLineInput!]
+	updateOutboundShipmentUnallocatedLines: [UpdateOutboundShipmentUnallocatedLineInput!]
+	deleteOutboundShipmentUnallocatedLines: [DeleteOutboundShipmentUnallocatedLineInput!]
+	updateOutboundShipments: [UpdateOutboundShipmentInput!]
+	deleteOutboundShipments: [String!]
 }
 type BatchOutboundShipmentResponse {
 	insertOutboundShipments: [InsertOutboundShipmentResponseWithId!]
@@ -48,42 +67,61 @@ type BatchOutboundShipmentResponse {
 	insertOutboundShipmentServiceLines: [InsertOutboundShipmentServiceLineResponseWithId!]
 	updateOutboundShipmentServiceLines: [UpdateOutboundShipmentServiceLineResponseWithId!]
 	deleteOutboundShipmentServiceLines: [DeleteOutboundShipmentServiceLineResponseWithId!]
+	insertOutboundShipmentUnallocatedLines: [InsertOutboundShipmentUnallocatedLineResponseWithId!]
+	updateOutboundShipmentUnallocatedLines: [UpdateOutboundShipmentUnallocatedLineResponseWithId!]
+	deleteOutboundShipmentUnallocatedLines: [DeleteOutboundShipmentUnallocatedLineResponseWithId!]
 	updateOutboundShipments: [UpdateOutboundShipmentResponseWithId!]
 	deleteOutboundShipments: [DeleteOutboundShipmentResponseWithId!]
 }
-type CanOnlyChangeToAllocatedWhenNoUnallocatedLines implements UpdateOutboundShipmentErrorInterface {
+input BatchStocktakeInput {
+	insertStocktakes: [InsertStocktakeInput!]
+	insertStocktakeLines: [InsertStocktakeLineInput!]
+	updateStocktakeLines: [UpdateStocktakeLineInput!]
+	deleteStocktakeLines: [DeleteStocktakeLineInput!]
+	updateStocktakes: [UpdateStocktakeInput!]
+	deleteStocktakes: [DeleteStocktakeInput!]
+}
+union BatchStocktakeResponse = | BatchStocktakeResponses | BatchStocktakeResponsesWithErrors
+type BatchStocktakeResponses {
+	insertStocktakes: [InsertStocktakeResponseWithId!]
+	insertStocktakeLines: [InsertStocktakeLineResponseWithId!]
+	updateStocktakeLines: [UpdateStocktakeLineResponseWithId!]
+	deleteStocktakeLines: [DeleteStocktakeLineResponseWithId!]
+	updateStocktakes: [UpdateStocktakeResponseWithId!]
+	deleteStocktakes: [DeleteStocktakeResponseWithId!]
+}
+type BatchStocktakeResponsesWithErrors {
+	insertStocktakes: [InsertStocktakeResponseWithId!]
+	insertStocktakeLines: [InsertStocktakeLineResponseWithId!]
+	updateStocktakeLines: [UpdateStocktakeLineResponseWithId!]
+	deleteStocktakeLines: [DeleteStocktakeLineResponseWithId!]
+	updateStocktakes: [UpdateStocktakeResponseWithId!]
+	deleteStocktakes: [DeleteStocktakeResponseWithId!]
+}
+type CanOnlyChangeToAllocatedWhenNoUnallocatedLines implements UpdateErrorInterface {
 	description: String!
 	invoiceLines: InvoiceLineConnector!
 }
-type CanOnlyEditInvoicesInLoggedInStoreError implements UpdateOutboundShipmentErrorInterface {
+type CanOnlyEditInvoicesInLoggedInStoreError implements UpdateErrorInterface {
 	description: String!
 }
-type CannotChangeStatusOfInvoiceOnHold implements UpdateInboundShipmentErrorInterface & UpdateOutboundShipmentErrorInterface {
+type CannotChangeStatusOfInvoiceOnHold implements UpdateErrorInterface & UpdateInboundShipmentErrorInterface {
 	description: String!
 }
-type CannotDeleteInvoiceWithLines implements DeleteInboundShipmentErrorInterface & DeleteOutboundShipmentErrorInterface {
+type CannotDeleteInvoiceWithLines implements DeleteInboundShipmentErrorInterface & DeleteErrorInterface {
 	description: String!
 	lines: InvoiceLineConnector!
 }
 type CannotDeleteRequisitionWithLines implements DeleteRequestRequisitionErrorInterface {
 	description: String!
 }
-type CannotEditInvoice implements DeleteOutboundShipmentErrorInterface & UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentLineErrorInterface & UpdateInboundShipmentErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface {
+type CannotEditInvoice implements DeleteOutboundShipmentLineErrorInterface & DeleteInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & DeleteErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & UpdateInboundShipmentErrorInterface & InsertOutboundShipmentLineErrorInterface & DeleteInboundShipmentErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & UpdateInboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface {
 	description: String!
 }
-type CannotEditRequisition implements DeleteRequestRequisitionErrorInterface & DeleteRequestRequisitionLineErrorInterface & UpdateRequestRequisitionErrorInterface & UpdateResponseRequisitionLineErrorInterface & UpdateRequestRequisitionLineErrorInterface & UseSuggestedQuantityErrorInterface & InsertRequestRequisitionLineErrorInterface & UpdateResponseRequisitionErrorInterface & AddFromMasterListErrorInterface & SupplyRequestedQuantityErrorInterface & CreateRequisitionShipmentErrorInterface {
+type CannotEditRequisition implements UseSuggestedQuantityErrorInterface & SupplyRequestedQuantityErrorInterface & DeleteRequestRequisitionLineErrorInterface & UpdateResponseRequisitionErrorInterface & DeleteRequestRequisitionErrorInterface & InsertRequestRequisitionLineErrorInterface & AddFromMasterListErrorInterface & UpdateRequestRequisitionLineErrorInterface & UpdateResponseRequisitionLineErrorInterface & UpdateRequestRequisitionErrorInterface & CreateRequisitionShipmentErrorInterface {
 	description: String!
 }
-type CannotReverseInvoiceStatus implements UpdateInboundShipmentErrorInterface & UpdateOutboundShipmentErrorInterface {
-	description: String!
-}
-"""
-Generic Error Wrapper
-"""
-type ConnectorError {
-	error: ConnectorErrorInterface!
-}
-interface ConnectorErrorInterface {
+type CannotReverseInvoiceStatus implements UpdateInboundShipmentErrorInterface & UpdateErrorInterface {
 	description: String!
 }
 type CreateRequisitionShipmentError {
@@ -96,7 +134,7 @@ input CreateRequisitionShipmentInput {
 	responseRequisitionId: String!
 }
 union CreateRequisitionShipmentResponse = | CreateRequisitionShipmentError | InvoiceNode
-type DatabaseError implements DeleteOutboundShipmentLineErrorInterface & DeleteLocationErrorInterface & RefreshTokenErrorInterface & UpdateLocationErrorInterface & UpdateOutboundShipmentErrorInterface & UserRegisterErrorInterface & AuthTokenErrorInterface & InsertLocationErrorInterface & InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentErrorInterface & InsertInboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface & InsertInboundShipmentErrorInterface & NodeErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & ConnectorErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteInboundShipmentErrorInterface & UpdateInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteOutboundShipmentErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface {
+type DatabaseError implements DeleteInboundShipmentErrorInterface & AuthTokenErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & InsertErrorInterface & InsertOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & RefreshTokenErrorInterface & DeleteOutboundShipmentLineErrorInterface & UpdateErrorInterface & UpdateLocationErrorInterface & DeleteErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & DeleteLocationErrorInterface & UserRegisterErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & DeleteInboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface & NodeErrorInterface & InsertInboundShipmentErrorInterface & InsertLocationErrorInterface {
 	description: String!
 	fullError: String!
 }
@@ -111,21 +149,18 @@ input DatetimeFilterInput {
 	beforeOrEqualTo: DateTime
 	afterOrEqualTo: DateTime
 }
-"""
-Generic Error Wrapper
-"""
-type DeleteInboundShipmentError {
-	error: DeleteInboundShipmentErrorInterface!
+interface DeleteErrorInterface {
+	description: String!
 }
 interface DeleteInboundShipmentErrorInterface {
 	description: String!
 }
+type DeleteInboundShipmentError {
+	error: DeleteInboundShipmentErrorInterface!
+}
 input DeleteInboundShipmentInput {
 	id: String!
 }
-"""
-Generic Error Wrapper
-"""
 type DeleteInboundShipmentLineError {
 	error: DeleteInboundShipmentLineErrorInterface!
 }
@@ -156,18 +191,9 @@ input DeleteLocationInput {
 	id: String!
 }
 union DeleteLocationResponse = | DeleteLocationError | DeleteResponse
-"""
-Generic Error Wrapper
-"""
 type DeleteOutboundShipmentError {
-	error: DeleteOutboundShipmentErrorInterface!
+	error: DeleteErrorInterface!
 }
-interface DeleteOutboundShipmentErrorInterface {
-	description: String!
-}
-"""
-Generic Error Wrapper
-"""
 type DeleteOutboundShipmentLineError {
 	error: DeleteOutboundShipmentLineErrorInterface!
 }
@@ -188,9 +214,6 @@ type DeleteOutboundShipmentResponseWithId {
 	id: String!
 	response: DeleteOutboundShipmentResponse!
 }
-"""
-Generic Error Wrapper
-"""
 type DeleteOutboundShipmentServiceLineError {
 	error: DeleteOutboundShipmentServiceLineErrorInterface!
 }
@@ -216,6 +239,10 @@ input DeleteOutboundShipmentUnallocatedLineInput {
 	id: String!
 }
 union DeleteOutboundShipmentUnallocatedLineResponse = | DeleteOutboundShipmentUnallocatedLineError | DeleteResponse
+type DeleteOutboundShipmentUnallocatedLineResponseWithId {
+	id: String!
+	response: DeleteOutboundShipmentUnallocatedLineResponse!
+}
 type DeleteRequestRequisitionError {
 	error: DeleteRequestRequisitionErrorInterface!
 }
@@ -239,23 +266,31 @@ union DeleteRequestRequisitionResponse = | DeleteRequestRequisitionError | Delet
 type DeleteResponse {
 	id: String!
 }
-input DeleteStockTakeInput {
+input DeleteStocktakeInput {
 	id: String!
 }
-input DeleteStockTakeLineInput {
+input DeleteStocktakeLineInput {
 	id: String!
 }
-type DeleteStockTakeLineNode {
+type DeleteStocktakeLineNode {
 	id: String!
 }
-union DeleteStockTakeLineResponse = | DeleteStockTakeLineNode
-type DeleteStockTakeNode {
+union DeleteStocktakeLineResponse = | DeleteStocktakeLineNode
+type DeleteStocktakeLineResponseWithId {
+	id: String!
+	response: DeleteStocktakeLineResponse!
+}
+type DeleteStocktakeNode {
 	"""
-	The id of the deleted stock take
+	The id of the deleted stocktake
 	"""
 	id: String!
 }
-union DeleteStockTakeResponse = | DeleteStockTakeNode
+union DeleteStocktakeResponse = | DeleteStocktakeNode
+type DeleteStocktakeResponseWithId {
+	id: String!
+	response: DeleteStocktakeResponse!
+}
 input EqualFilterBigNumberInput {
 	equalTo: Int
 	equalAny: [Int!]
@@ -286,10 +321,10 @@ input EqualFilterRequisitionTypeInput {
 	equalAny: [RequisitionNodeType!]
 	notEqualTo: RequisitionNodeType
 }
-input EqualFilterStockTakeStatusInput {
-	equalTo: StockTakeNodeStatus
-	equalAny: [StockTakeNodeStatus!]
-	notEqualTo: StockTakeNodeStatus
+input EqualFilterStocktakeStatusInput {
+	equalTo: StocktakeNodeStatus
+	equalAny: [StocktakeNodeStatus!]
+	notEqualTo: StocktakeNodeStatus
 }
 input EqualFilterStringInput {
 	equalTo: String
@@ -304,21 +339,21 @@ enum ForeignKey {
 	locationId
 	requisitionId
 }
-type ForeignKeyError implements UpdateOutboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface & InsertOutboundShipmentErrorInterface & UpdateResponseRequisitionLineErrorInterface & InsertRequestRequisitionLineErrorInterface & UpdateRequestRequisitionLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & DeleteInboundShipmentLineErrorInterface & InsertInboundShipmentErrorInterface & UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & UpdateInboundShipmentErrorInterface & InsertOutboundShipmentUnallocatedLineErrorInterface & UpdateInboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface {
+type ForeignKeyError implements UpdateOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteInboundShipmentLineErrorInterface & UpdateRequestRequisitionLineErrorInterface & InsertErrorInterface & InsertOutboundShipmentLineErrorInterface & UpdateResponseRequisitionLineErrorInterface & UpdateInboundShipmentLineErrorInterface & InsertInboundShipmentErrorInterface & UpdateInboundShipmentErrorInterface & UpdateErrorInterface & DeleteOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & InsertRequestRequisitionLineErrorInterface & InsertOutboundShipmentUnallocatedLineErrorInterface & InsertInboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface {
 	description: String!
 	key: ForeignKey!
 }
 type InboundInvoiceCounts {
 	created: InvoiceCountsSummary!
 }
-"""
-Generic Error Wrapper
-"""
-type InsertInboundShipmentError {
-	error: InsertInboundShipmentErrorInterface!
+interface InsertErrorInterface {
+	description: String!
 }
 interface InsertInboundShipmentErrorInterface {
 	description: String!
+}
+type InsertInboundShipmentError {
+	error: InsertInboundShipmentErrorInterface!
 }
 input InsertInboundShipmentInput {
 	id: String!
@@ -328,9 +363,6 @@ input InsertInboundShipmentInput {
 	theirReference: String
 	colour: String
 }
-"""
-Generic Error Wrapper
-"""
 type InsertInboundShipmentLineError {
 	error: InsertInboundShipmentLineErrorInterface!
 }
@@ -375,14 +407,8 @@ input InsertLocationInput {
 	onHold: Boolean
 }
 union InsertLocationResponse = | InsertLocationError | LocationNode
-"""
-Generic Error Wrapper
-"""
 type InsertOutboundShipmentError {
-	error: InsertOutboundShipmentErrorInterface!
-}
-interface InsertOutboundShipmentErrorInterface {
-	description: String!
+	error: InsertErrorInterface!
 }
 input InsertOutboundShipmentInput {
 	"""
@@ -399,9 +425,6 @@ input InsertOutboundShipmentInput {
 	theirReference: String
 	colour: String
 }
-"""
-Generic Error Wrapper
-"""
 type InsertOutboundShipmentLineError {
 	error: InsertOutboundShipmentLineErrorInterface!
 }
@@ -428,9 +451,6 @@ type InsertOutboundShipmentResponseWithId {
 	id: String!
 	response: InsertOutboundShipmentResponse!
 }
-"""
-Generic Error Wrapper
-"""
 type InsertOutboundShipmentServiceLineError {
 	error: InsertOutboundShipmentServiceLineErrorInterface!
 }
@@ -465,6 +485,10 @@ input InsertOutboundShipmentUnallocatedLineInput {
 	quantity: Int!
 }
 union InsertOutboundShipmentUnallocatedLineResponse = | InsertOutboundShipmentUnallocatedLineError | InvoiceLineNode
+type InsertOutboundShipmentUnallocatedLineResponseWithId {
+	id: String!
+	response: InsertOutboundShipmentUnallocatedLineResponse!
+}
 type InsertRequestRequisitionError {
 	error: InsertRequestRequisitionErrorInterface!
 }
@@ -494,15 +518,15 @@ input InsertRequestRequisitionLineInput {
 }
 union InsertRequestRequisitionLineResponse = | InsertRequestRequisitionLineError | RequisitionLineNode
 union InsertRequestRequisitionResponse = | InsertRequestRequisitionError | RequisitionNode
-input InsertStockTakeInput {
+input InsertStocktakeInput {
 	id: String!
 	comment: String
 	description: String
 	createdDatetime: NaiveDateTime!
 }
-input InsertStockTakeLineInput {
+input InsertStocktakeLineInput {
 	id: String!
-	stockTakeId: String!
+	stocktakeId: String!
 	stockLineId: String
 	locationId: String
 	comment: String
@@ -515,9 +539,17 @@ input InsertStockTakeLineInput {
 	sellPricePerPack: Float
 	note: String
 }
-union InsertStockTakeLineResponse = | StockTakeLineNode
-union InsertStockTakeResponse = | StockTakeNode
-type InternalError implements AuthTokenErrorInterface & UserRegisterErrorInterface & UpdateLocationErrorInterface & LogoutErrorInterface & InsertLocationErrorInterface & RefreshTokenErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface {
+union InsertStocktakeLineResponse = | StocktakeLineNode
+type InsertStocktakeLineResponseWithId {
+	id: String!
+	response: InsertStocktakeLineResponse!
+}
+union InsertStocktakeResponse = | StocktakeNode
+type InsertStocktakeResponseWithId {
+	id: String!
+	response: InsertStocktakeResponse!
+}
+type InternalError implements UserRegisterErrorInterface & UpdateLocationErrorInterface & AuthTokenErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & RefreshTokenErrorInterface & InsertLocationErrorInterface & LogoutErrorInterface & InsertOutboundShipmentServiceLineErrorInterface {
 	description: String!
 	fullError: String!
 }
@@ -527,9 +559,6 @@ type InvalidCredentials implements AuthTokenErrorInterface {
 type InvalidToken implements RefreshTokenErrorInterface {
 	description: String!
 }
-"""
-Generic Connector
-"""
 type InvoiceConnector {
 	totalCount: Int!
 	nodes: [InvoiceNode!]!
@@ -542,7 +571,7 @@ type InvoiceCountsSummary {
 	today: Int!
 	thisWeek: Int!
 }
-type InvoiceDoesNotBelongToCurrentStore implements DeleteOutboundShipmentServiceLineErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateInboundShipmentErrorInterface & DeleteInboundShipmentErrorInterface & UpdateOutboundShipmentLineErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteOutboundShipmentErrorInterface {
+type InvoiceDoesNotBelongToCurrentStore implements DeleteOutboundShipmentServiceLineErrorInterface & DeleteErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface & DeleteInboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & DeleteInboundShipmentErrorInterface & UpdateInboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface {
 	description: String!
 }
 input InvoiceFilterInput {
@@ -563,21 +592,18 @@ input InvoiceFilterInput {
 	requisitionId: EqualFilterStringInput
 	linkedInvoiceId: EqualFilterStringInput
 }
-type InvoiceIsNotEditable implements UpdateOutboundShipmentErrorInterface {
+type InvoiceIsNotEditable implements UpdateErrorInterface {
 	description: String!
 }
-type InvoiceLineBelongsToAnotherInvoice implements DeleteOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteInboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface {
+type InvoiceLineBelongsToAnotherInvoice implements UpdateInboundShipmentLineErrorInterface & DeleteInboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentLineErrorInterface {
 	description: String!
 	invoice: InvoiceResponse!
 }
-"""
-Generic Connector
-"""
 type InvoiceLineConnector {
 	totalCount: Int!
 	nodes: [InvoiceLineNode!]!
 }
-type InvoiceLineHasNoStockLineError implements UpdateOutboundShipmentErrorInterface {
+type InvoiceLineHasNoStockLineError implements UpdateErrorInterface {
 	description: String!
 	invoiceLineId: String!
 }
@@ -587,7 +613,7 @@ type InvoiceLineNode {
 	itemId: String!
 	itemName: String!
 	itemCode: String!
-	item: ItemResponse!
+	item: ItemNode!
 	packSize: Int!
 	numberOfPacks: Int!
 	costPricePerPack: Float!
@@ -608,7 +634,6 @@ enum InvoiceLineNodeType {
 	SERVICE
 }
 union InvoiceLineResponse = | NodeError | InvoiceLineNode
-union InvoiceLinesResponse = | ConnectorError | InvoiceLineConnector
 type InvoiceNode {
 	id: String!
 	otherPartyName: String!
@@ -636,7 +661,7 @@ type InvoiceNode {
 	Inbound Shipment <-> Outbound Shipment, where Inbound Shipment originated from Outbound Shipment
 	"""
 	linkedShipment: InvoiceNode
-	lines: InvoiceLinesResponse!
+	lines: InvoiceLineConnector!
 	pricing: InvoicePriceResponse!
 	otherParty: NameResponse!
 }
@@ -687,16 +712,13 @@ ascending)
 	"""
 	desc: Boolean
 }
-union InvoicesResponse = | ConnectorError | InvoiceConnector
+union InvoicesResponse = | InvoiceConnector
 type ItemConnector {
 	totalCount: Int!
 	nodes: [ItemNode!]!
 }
-type ItemDoesNotMatchStockLine implements UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface {
+type ItemDoesNotMatchStockLine implements InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface {
 	description: String!
-}
-type ItemError {
-	error: ItemResponseError!
 }
 input ItemFilterInput {
 	id: EqualFilterStringInput
@@ -711,10 +733,8 @@ type ItemNode {
 	isVisible: Boolean!
 	unitName: String
 	stats(storeId: String!, lookBackDatetime: NaiveDateTime): ItemStatsNode!
-	availableBatches: StockLinesResponse!
+	availableBatches(storeId: String!): StockLineConnector!
 }
-union ItemResponse = | ItemError | ItemNode
-union ItemResponseError = | InternalError
 enum ItemSortFieldInput {
 	name
 	code
@@ -735,13 +755,10 @@ type ItemStatsNode {
 	availableStockOnHand: Int!
 	availableMonthsOfStockOnHand: Float!
 }
-union ItemsResponse = | ConnectorError | ItemConnector
+union ItemsResponse = | ItemConnector
 type LineDoesNotReferenceStockLine implements UpdateOutboundShipmentLineErrorInterface {
 	description: String!
 }
-"""
-Generic Connector
-"""
 type LocationConnector {
 	totalCount: Int!
 	nodes: [LocationNode!]!
@@ -764,7 +781,7 @@ type LocationNode {
 	name: String!
 	code: String!
 	onHold: Boolean!
-	stock: StockLinesResponse!
+	stock: StockLineConnector!
 }
 type LocationNotFound implements InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface {
 	description: String!
@@ -785,16 +802,13 @@ ascending)
 	"""
 	desc: Boolean
 }
-union LocationsResponse = | ConnectorError | LocationConnector
+union LocationsResponse = | LocationConnector
 type Logout {
 	"""
 	User id of the logged out user
 	"""
 	userId: String!
 }
-"""
-Generic Error Wrapper
-"""
 type LogoutError {
 	error: LogoutErrorInterface!
 }
@@ -850,7 +864,7 @@ ascending)
 	"""
 	desc: Boolean
 }
-union MasterListsResponse = | ConnectorError | MasterListConnector
+union MasterListsResponse = | MasterListConnector
 type Mutations {
 	registerUser(input: UserRegisterInput!): UserRegisterResponse!
 	insertLocation(storeId: String!, input: InsertLocationInput!): InsertLocationResponse!
@@ -871,17 +885,18 @@ type Mutations {
 	insertInboundShipment(storeId: String!, input: InsertInboundShipmentInput!): InsertInboundShipmentResponse!
 	updateInboundShipment(input: UpdateInboundShipmentInput!): UpdateInboundShipmentResponse!
 	deleteInboundShipment(input: DeleteInboundShipmentInput!): DeleteInboundShipmentResponse!
-	insertInboundShipmentLine(storeId: String!, input: InsertInboundShipmentLineInput!): InsertInboundShipmentLineResponse!
+	insertInboundShipmentLine(input: InsertInboundShipmentLineInput!): InsertInboundShipmentLineResponse!
 	updateInboundShipmentLine(input: UpdateInboundShipmentLineInput!): UpdateInboundShipmentLineResponse!
 	deleteInboundShipmentLine(input: DeleteInboundShipmentLineInput!): DeleteInboundShipmentLineResponse!
-	batchInboundShipment(storeId: String!, insertInboundShipments: [InsertInboundShipmentInput!], insertInboundShipmentLines: [InsertInboundShipmentLineInput!], updateInboundShipmentLines: [UpdateInboundShipmentLineInput!], deleteInboundShipmentLines: [DeleteInboundShipmentLineInput!], updateInboundShipments: [UpdateInboundShipmentInput!], deleteInboundShipments: [DeleteInboundShipmentInput!]): BatchInboundShipmentResponse!
-	batchOutboundShipment(storeId: String!, insertOutboundShipments: [InsertOutboundShipmentInput!], insertOutboundShipmentLines: [InsertOutboundShipmentLineInput!], updateOutboundShipmentLines: [UpdateOutboundShipmentLineInput!], deleteOutboundShipmentLines: [DeleteOutboundShipmentLineInput!], insertOutboundShipmentServiceLines: [InsertOutboundShipmentServiceLineInput!], updateOutboundShipmentServiceLines: [UpdateOutboundShipmentServiceLineInput!], deleteOutboundShipmentServiceLines: [DeleteOutboundShipmentServiceLineInput!], updateOutboundShipments: [UpdateOutboundShipmentInput!], deleteOutboundShipments: [String!]): BatchOutboundShipmentResponse!
-	insertStockTake(storeId: String!, input: InsertStockTakeInput!): InsertStockTakeResponse!
-	updateStockTake(storeId: String!, input: UpdateStockTakeInput!): UpdateStockTakeResponse!
-	deleteStockTake(storeId: String!, input: DeleteStockTakeInput!): DeleteStockTakeResponse!
-	insertStockTakeLine(storeId: String!, input: InsertStockTakeLineInput!): InsertStockTakeLineResponse!
-	updateStockTakeLine(storeId: String!, input: UpdateStockTakeLineInput!): UpdateStockTakeLineResponse!
-	deleteStockTakeLine(storeId: String!, input: DeleteStockTakeLineInput!): DeleteStockTakeLineResponse!
+	batchInboundShipment(storeId: String!, input: BatchInboundShipmentInput!): BatchInboundShipmentResponse!
+	batchOutboundShipment(storeId: String!, input: BatchOutboundShipmentInput!): BatchOutboundShipmentResponse!
+	insertStocktake(storeId: String!, input: InsertStocktakeInput!): InsertStocktakeResponse!
+	updateStocktake(storeId: String!, input: UpdateStocktakeInput!): UpdateStocktakeResponse!
+	deleteStocktake(storeId: String!, input: DeleteStocktakeInput!): DeleteStocktakeResponse!
+	insertStocktakeLine(storeId: String!, input: InsertStocktakeLineInput!): InsertStocktakeLineResponse!
+	updateStocktakeLine(storeId: String!, input: UpdateStocktakeLineInput!): UpdateStocktakeLineResponse!
+	deleteStocktakeLine(storeId: String!, input: DeleteStocktakeLineInput!): DeleteStocktakeLineResponse!
+	batchStocktake(storeId: String!, input: BatchStocktakeInput!): BatchStocktakeResponse!
 	insertRequestRequisition(storeId: String!, input: InsertRequestRequisitionInput!): InsertRequestRequisitionResponse!
 	updateRequestRequisition(storeId: String!, input: UpdateRequestRequisitionInput!): UpdateRequestRequisitionResponse!
 	deleteRequestRequisition(storeId: String!, input: DeleteRequestRequisitionInput!): DeleteRequestRequisitionResponse!
@@ -975,7 +990,7 @@ ascending)
 	"""
 	desc: Boolean
 }
-union NamesResponse = | ConnectorError | NameConnector
+union NamesResponse = | NameConnector
 type NoRefreshTokenProvided implements RefreshTokenErrorInterface {
 	description: String!
 }
@@ -991,19 +1006,19 @@ interface NodeErrorInterface {
 type NotARefreshToken implements RefreshTokenErrorInterface {
 	description: String!
 }
-type NotAServiceItem implements InsertOutboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface {
+type NotAServiceItem implements UpdateOutboundShipmentServiceLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface {
 	description: String!
 }
-type NotAnInboundShipment implements UpdateInboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface & UpdateInboundShipmentErrorInterface & DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface {
+type NotAnInboundShipment implements DeleteInboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface & UpdateInboundShipmentErrorInterface & DeleteInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface {
 	description: String!
 }
-type NotAnOutboundShipment implements DeleteOutboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface {
+type NotAnOutboundShipment implements DeleteErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface & DeleteOutboundShipmentLineErrorInterface {
 	description: String!
 }
-type NotAnOutboundShipmentError implements UpdateOutboundShipmentErrorInterface {
+type NotAnOutboundShipmentError implements UpdateErrorInterface {
 	description: String!
 }
-type NotEnoughStockForReduction implements InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface {
+type NotEnoughStockForReduction implements UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface {
 	description: String!
 	line: InvoiceLineResponse
 	batch: StockLineResponse!
@@ -1011,14 +1026,14 @@ type NotEnoughStockForReduction implements InsertOutboundShipmentLineErrorInterf
 type NothingRemainingToSupply implements CreateRequisitionShipmentErrorInterface {
 	description: String!
 }
-type OtherPartyCannotBeThisStoreError implements UpdateOutboundShipmentErrorInterface & InsertOutboundShipmentErrorInterface {
+type OtherPartyCannotBeThisStoreError implements InsertErrorInterface & UpdateErrorInterface {
 	description: String!
 }
-type OtherPartyNotACustomerError implements UpdateOutboundShipmentErrorInterface & InsertOutboundShipmentErrorInterface {
+type OtherPartyNotACustomerError implements InsertErrorInterface & UpdateErrorInterface {
 	description: String!
 	otherParty: NameNode!
 }
-type OtherPartyNotASupplier implements UpdateInboundShipmentErrorInterface & InsertRequestRequisitionErrorInterface & InsertInboundShipmentErrorInterface {
+type OtherPartyNotASupplier implements UpdateInboundShipmentErrorInterface & InsertInboundShipmentErrorInterface & InsertRequestRequisitionErrorInterface {
 	description: String!
 	otherParty: NameNode!
 }
@@ -1028,10 +1043,6 @@ type OutboundInvoiceCounts {
 	Number of outbound shipments ready to be picked
 	"""
 	toBePicked: Int!
-}
-type PaginationError implements ConnectorErrorInterface {
-	description: String!
-	rangeError: RangeError!
 }
 """
 Pagination input.
@@ -1079,17 +1090,19 @@ type Queries {
 	Query omSupply "item" entries
 	"""
 	items(page: PaginationInput, filter: ItemFilterInput, sort: [ItemSortInput!]): ItemsResponse!
-	invoice(id: String!): InvoiceResponse!
-	invoiceByNumber(invoiceNumber: Int!, type: InvoiceNodeType!): InvoiceResponse!
-	invoices(page: PaginationInput, filter: InvoiceFilterInput, sort: [InvoiceSortInput!]): InvoicesResponse!
+	invoice(storeId: String!, id: String!): InvoiceResponse!
+	invoiceByNumber(storeId: String!, invoiceNumber: Int!, type: InvoiceNodeType!): InvoiceResponse!
+	invoices(storeId: String!, page: PaginationInput, filter: InvoiceFilterInput, sort: [InvoiceSortInput!]): InvoicesResponse!
 	invoiceCounts(timezoneOffset: Int): InvoiceCounts!
 	stockCounts(timezoneOffset: Int, daysTillExpired: Int): StockCounts!
-	stockTakes(storeId: String!, page: PaginationInput, filter: StockTakeFilterInput, sort: [StockTakeSortInput!]): StockTakesResponse!
+	stocktake(storeId: String!, id: String!): StocktakeResponse!
+	stocktakeByNumber(storeId: String!, stocktakeNumber: Int!): StocktakeResponse!
+	stocktakes(storeId: String!, page: PaginationInput, filter: StocktakeFilterInput, sort: [StocktakeSortInput!]): StocktakesResponse!
 	requisition(storeId: String!, id: String!): RequisitionResponse!
 	requisitions(storeId: String!, page: PaginationInput, filter: RequisitionFilterInput, sort: [RequisitionSortInput!]): RequisitionsResponse!
 	requisitionByNumber(storeId: String!, requisitionNumber: Int!, type: RequisitionNodeType!): RequisitionResponse!
 }
-type RangeError implements UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface {
+type RangeError implements InsertOutboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface {
 	description: String!
 	field: RangeField!
 	max: Int
@@ -1100,16 +1113,16 @@ enum RangeField {
 	numberOfPacks
 	packSize
 }
-type RecordAlreadyExist implements InsertLocationErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface & InsertOutboundShipmentErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentErrorInterface & UserRegisterErrorInterface {
+type RecordAlreadyExist implements UserRegisterErrorInterface & InsertLocationErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentErrorInterface & InsertErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface {
 	description: String!
 }
-type RecordBelongsToAnotherStore implements UpdateLocationErrorInterface & DeleteLocationErrorInterface {
+type RecordBelongsToAnotherStore implements DeleteLocationErrorInterface & UpdateLocationErrorInterface {
 	description: String!
 }
-type RecordDoesNotExist implements SupplyRequestedQuantityErrorInterface & UpdateRequestRequisitionErrorInterface & UseSuggestedQuantityErrorInterface & UpdateRequestRequisitionLineErrorInterface & UpdateResponseRequisitionErrorInterface & UpdateResponseRequisitionLineErrorInterface & DeleteRequestRequisitionLineErrorInterface & DeleteOutboundShipmentUnallocatedLineErrorInterface & AddFromMasterListErrorInterface & UpdateOutboundShipmentUnallocatedLineErrorInterface & CreateRequisitionShipmentErrorInterface & DeleteRequestRequisitionErrorInterface {
+type RecordDoesNotExist implements CreateRequisitionShipmentErrorInterface & SupplyRequestedQuantityErrorInterface & UseSuggestedQuantityErrorInterface & DeleteOutboundShipmentUnallocatedLineErrorInterface & AddFromMasterListErrorInterface & UpdateRequestRequisitionLineErrorInterface & DeleteRequestRequisitionErrorInterface & UpdateOutboundShipmentUnallocatedLineErrorInterface & UpdateRequestRequisitionErrorInterface & DeleteRequestRequisitionLineErrorInterface & UpdateResponseRequisitionErrorInterface & UpdateResponseRequisitionLineErrorInterface {
 	description: String!
 }
-type RecordNotFound implements DeleteInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteLocationErrorInterface & DeleteOutboundShipmentErrorInterface & UpdateOutboundShipmentErrorInterface & UpdateLocationErrorInterface & NodeErrorInterface & UpdateOutboundShipmentLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & UpdateInboundShipmentErrorInterface {
+type RecordNotFound implements DeleteOutboundShipmentLineErrorInterface & DeleteInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateLocationErrorInterface & DeleteErrorInterface & UpdateInboundShipmentErrorInterface & DeleteInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & NodeErrorInterface & UpdateErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteLocationErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface {
 	description: String!
 }
 type RefreshToken {
@@ -1118,9 +1131,6 @@ type RefreshToken {
 	"""
 	token: String!
 }
-"""
-Generic Error Wrapper
-"""
 type RefreshTokenError {
 	error: RefreshTokenErrorInterface!
 }
@@ -1171,7 +1181,7 @@ type RequisitionLineNode {
 	Calculated quantity
 	When months_of_stock < requisition.min_months_of_stock, calculated = average_monthy_consumption * requisition.max_months_of_stock - months_of_stock
 	"""
-	SuggestedQuantity: Int!
+	suggestedQuantity: Int!
 	"""
 	OutboundShipment lines linked to requisitions line
 	"""
@@ -1271,21 +1281,18 @@ input SimpleStringFilterInput {
 	"""
 	like: String
 }
-type SnapshotCountCurrentCountMismatch implements UpdateStockTakeErrorInterface {
+type SnapshotCountCurrentCountMismatch implements UpdateStocktakeErrorInterface {
 	description: String!
-	lines: StockTakeLineConnector!
+	lines: StocktakeLineConnector!
 }
 type StockCounts {
 	expired: Int!
 	expiringSoon: Int!
 }
-type StockLineAlreadyExistsInInvoice implements InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface {
+type StockLineAlreadyExistsInInvoice implements UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface {
 	description: String!
 	line: InvoiceLineResponse!
 }
-"""
-Generic Connector
-"""
 type StockLineConnector {
 	totalCount: Int!
 	nodes: [StockLineNode!]!
@@ -1314,32 +1321,31 @@ type StockLineNode {
 	location: LocationResponse
 }
 union StockLineResponse = | NodeError | StockLineNode
-union StockLinesResponse = | ConnectorError | StockLineConnector
-type StockTakeConnector {
+type StocktakeConnector {
 	totalCount: Int!
-	nodes: [StockTakeNode!]!
+	nodes: [StocktakeNode!]!
 }
-input StockTakeFilterInput {
+input StocktakeFilterInput {
 	id: EqualFilterStringInput
-	stockTakeNumber: EqualFilterBigNumberInput
-	status: EqualFilterStockTakeStatusInput
+	stocktakeNumber: EqualFilterBigNumberInput
+	status: EqualFilterStocktakeStatusInput
 	createdDatetime: DatetimeFilterInput
 	finalisedDatetime: DatetimeFilterInput
 }
-type StockTakeLineConnector {
+type StocktakeLineConnector {
 	totalCount: Int!
-	nodes: [StockTakeLineNode!]!
+	nodes: [StocktakeLineNode!]!
 }
-type StockTakeLineNode {
+type StocktakeLineNode {
 	id: String!
-	stockTakeId: String!
+	stocktakeId: String!
 	stockLine: StockLineNode
 	location: LocationNode
 	comment: String
 	snapshotNumberOfPacks: Int!
 	countedNumberOfPacks: Int
 	itemId: String!
-	item: ItemNode
+	item: ItemNode!
 	batch: String
 	expiryDate: NaiveDate
 	packSize: Int
@@ -1347,40 +1353,41 @@ type StockTakeLineNode {
 	sellPricePerPack: Float
 	note: String
 }
-type StockTakeNode {
+type StocktakeNode {
 	id: String!
 	storeId: String!
-	stockTakeNumber: Int!
+	stocktakeNumber: Int!
 	comment: String
 	description: String
-	status: StockTakeNodeStatus!
+	status: StocktakeNodeStatus!
 	createdDatetime: NaiveDateTime!
 	finalisedDatetime: NaiveDateTime
 	inventoryAdjustmentId: String
 	inventoryAdjustment: InvoiceNode
-	lines: StockTakeLineConnector!
+	lines: StocktakeLineConnector!
 }
-enum StockTakeNodeStatus {
+enum StocktakeNodeStatus {
 	NEW
 	FINALISED
 }
-enum StockTakeSortFieldInput {
+union StocktakeResponse = | StocktakeNode | NodeError
+enum StocktakeSortFieldInput {
 	status
 	createdDatetime
 	finalisedDatetime
 }
-input StockTakeSortInput {
+input StocktakeSortInput {
 	"""
 	Sort query result by `key`
 	"""
-	key: StockTakeSortFieldInput!
+	key: StocktakeSortFieldInput!
 	"""
 	Sort query result is sorted descending or ascending (if not provided the default is
 ascending)
 	"""
 	desc: Boolean
 }
-union StockTakesResponse = | StockTakeConnector
+union StocktakesResponse = | StocktakeConnector
 type StoreConnector {
 	totalCount: Int!
 	nodes: [StoreNode!]!
@@ -1421,18 +1428,18 @@ type UnallocatedLinesOnlyEditableInNewInvoice implements InsertOutboundShipmentU
 enum UniqueValueKey {
 	code
 }
-type UniqueValueViolation implements UpdateLocationErrorInterface & InsertLocationErrorInterface {
+type UniqueValueViolation implements InsertLocationErrorInterface & UpdateLocationErrorInterface {
 	description: String!
 	field: UniqueValueKey!
 }
-"""
-Generic Error Wrapper
-"""
-type UpdateInboundShipmentError {
-	error: UpdateInboundShipmentErrorInterface!
+interface UpdateErrorInterface {
+	description: String!
 }
 interface UpdateInboundShipmentErrorInterface {
 	description: String!
+}
+type UpdateInboundShipmentError {
+	error: UpdateInboundShipmentErrorInterface!
 }
 input UpdateInboundShipmentInput {
 	id: String!
@@ -1443,9 +1450,6 @@ input UpdateInboundShipmentInput {
 	theirReference: String
 	colour: String
 }
-"""
-Generic Error Wrapper
-"""
 type UpdateInboundShipmentLineError {
 	error: UpdateInboundShipmentLineErrorInterface!
 }
@@ -1491,14 +1495,8 @@ input UpdateLocationInput {
 	onHold: Boolean
 }
 union UpdateLocationResponse = | UpdateLocationError | LocationNode
-"""
-Generic Error Wrapper
-"""
 type UpdateOutboundShipmentError {
-	error: UpdateOutboundShipmentErrorInterface!
-}
-interface UpdateOutboundShipmentErrorInterface {
-	description: String!
+	error: UpdateErrorInterface!
 }
 input UpdateOutboundShipmentInput {
 	"""
@@ -1523,9 +1521,6 @@ existing invoice items gets updated.
 	theirReference: String
 	colour: String
 }
-"""
-Generic Error Wrapper
-"""
 type UpdateOutboundShipmentLineError {
 	error: UpdateOutboundShipmentLineErrorInterface!
 }
@@ -1552,9 +1547,6 @@ type UpdateOutboundShipmentResponseWithId {
 	id: String!
 	response: UpdateOutboundShipmentResponse!
 }
-"""
-Generic Error Wrapper
-"""
 type UpdateOutboundShipmentServiceLineError {
 	error: UpdateOutboundShipmentServiceLineErrorInterface!
 }
@@ -1592,6 +1584,10 @@ input UpdateOutboundShipmentUnallocatedLineInput {
 	quantity: Int!
 }
 union UpdateOutboundShipmentUnallocatedLineResponse = | UpdateOutboundShipmentUnallocatedLineError | InvoiceLineNode
+type UpdateOutboundShipmentUnallocatedLineResponseWithId {
+	id: String!
+	response: UpdateOutboundShipmentUnallocatedLineResponse!
+}
 type UpdateRequestRequisitionError {
 	error: UpdateRequestRequisitionErrorInterface!
 }
@@ -1650,19 +1646,19 @@ union UpdateResponseRequisitionResponse = | UpdateResponseRequisitionError | Req
 enum UpdateResponseRequisitionStatusInput {
 	FINALISED
 }
-type UpdateStockTakeError {
-	error: UpdateStockTakeErrorInterface!
+type UpdateStocktakeError {
+	error: UpdateStocktakeErrorInterface!
 }
-interface UpdateStockTakeErrorInterface {
+interface UpdateStocktakeErrorInterface {
 	description: String!
 }
-input UpdateStockTakeInput {
+input UpdateStocktakeInput {
 	id: String!
 	comment: String
 	description: String
-	status: StockTakeNodeStatus
+	status: StocktakeNodeStatus
 }
-input UpdateStockTakeLineInput {
+input UpdateStocktakeLineInput {
 	id: String!
 	locationId: String
 	comment: String
@@ -1675,8 +1671,16 @@ input UpdateStockTakeLineInput {
 	sellPricePerPack: Float
 	note: String
 }
-union UpdateStockTakeLineResponse = | StockTakeLineNode
-union UpdateStockTakeResponse = | StockTakeNode | UpdateStockTakeError
+union UpdateStocktakeLineResponse = | StocktakeLineNode
+type UpdateStocktakeLineResponseWithId {
+	id: String!
+	response: UpdateStocktakeLineResponse!
+}
+union UpdateStocktakeResponse = | StocktakeNode | UpdateStocktakeError
+type UpdateStocktakeResponseWithId {
+	id: String!
+	response: UpdateStocktakeResponse!
+}
 type UseSuggestedQuantityError {
 	error: UseSuggestedQuantityErrorInterface!
 }
@@ -1700,9 +1704,6 @@ type User {
 type UserNameDoesNotExist implements AuthTokenErrorInterface {
 	description: String!
 }
-"""
-Generic Error Wrapper
-"""
 type UserRegisterError {
 	error: UserRegisterErrorInterface!
 }

--- a/graphql/src/loader/invoice_line_query.rs
+++ b/graphql/src/loader/invoice_line_query.rs
@@ -1,14 +1,10 @@
+use super::{extract_unique_requisition_and_item_ids, RequisitionAndItemId};
+use crate::standard_graphql_error::StandardGraphqlError;
 use async_graphql::dataloader::*;
 use async_graphql::*;
 use domain::{invoice_line::InvoiceLine, EqualFilter};
 use repository::{InvoiceLineFilter, InvoiceLineRepository, StorageConnectionManager};
 use std::collections::HashMap;
-
-use service::ListError;
-
-use crate::standard_graphql_error::StandardGraphqlError;
-
-use super::{extract_unique_requisition_and_item_ids, RequisitionAndItemId};
 
 pub struct InvoiceLineQueryLoader {
     pub connection_manager: StorageConnectionManager,
@@ -17,7 +13,7 @@ pub struct InvoiceLineQueryLoader {
 #[async_trait::async_trait]
 impl Loader<String> for InvoiceLineQueryLoader {
     type Value = Vec<InvoiceLine>;
-    type Error = ListError;
+    type Error = async_graphql::Error;
 
     async fn load(
         &self,

--- a/graphql/src/schema/mutations/inbound_shipment/delete.rs
+++ b/graphql/src/schema/mutations/inbound_shipment/delete.rs
@@ -40,7 +40,7 @@ pub fn get_delete_inbound_shipment_response(
 }
 
 #[derive(Interface)]
-#[graphql(name = "DeleteInboundShipmenErrorInterface")]
+#[graphql(name = "DeleteInboundShipmentErrorInterface")]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum DeleteErrorInterface {
     DatabaseError(DatabaseError),

--- a/graphql/src/schema/mutations/inbound_shipment/delete.rs
+++ b/graphql/src/schema/mutations/inbound_shipment/delete.rs
@@ -40,6 +40,7 @@ pub fn get_delete_inbound_shipment_response(
 }
 
 #[derive(Interface)]
+#[graphql(name = "DeleteInboundShipmenErrorInterface")]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum DeleteErrorInterface {
     DatabaseError(DatabaseError),

--- a/graphql/src/schema/mutations/inbound_shipment/delete.rs
+++ b/graphql/src/schema/mutations/inbound_shipment/delete.rs
@@ -5,7 +5,7 @@ use crate::schema::{
         CannotDeleteInvoiceWithLines, CannotEditInvoice, DeleteResponse,
         InvoiceDoesNotBelongToCurrentStore, NotAnInboundShipment,
     },
-    types::{DatabaseError, ErrorWrapper, RecordNotFound},
+    types::{DatabaseError, InvoiceLineConnector, RecordNotFound},
 };
 use domain::inbound_shipment::DeleteInboundShipment;
 use repository::StorageConnectionManager;
@@ -16,9 +16,15 @@ pub struct DeleteInboundShipmentInput {
     pub id: String,
 }
 
+#[derive(SimpleObject)]
+#[graphql(name = "DeleteInboundShipmentError")]
+pub struct DeleteError {
+    pub error: DeleteErrorInterface,
+}
+
 #[derive(Union)]
 pub enum DeleteInboundShipmentResponse {
-    Error(ErrorWrapper<DeleteInboundShipmentErrorInterface>),
+    Error(DeleteError),
     Response(DeleteResponse),
 }
 
@@ -35,7 +41,7 @@ pub fn get_delete_inbound_shipment_response(
 
 #[derive(Interface)]
 #[graphql(field(name = "description", type = "&str"))]
-pub enum DeleteInboundShipmentErrorInterface {
+pub enum DeleteErrorInterface {
     DatabaseError(DatabaseError),
     RecordNotFound(RecordNotFound),
     CannotEditInvoice(CannotEditInvoice),
@@ -52,7 +58,7 @@ impl From<DeleteInboundShipmentInput> for DeleteInboundShipment {
 
 impl From<DeleteInboundShipmentError> for DeleteInboundShipmentResponse {
     fn from(error: DeleteInboundShipmentError) -> Self {
-        use DeleteInboundShipmentErrorInterface as OutError;
+        use DeleteErrorInterface as OutError;
         let error = match error {
             DeleteInboundShipmentError::InvoiceDoesNotExist => {
                 OutError::RecordNotFound(RecordNotFound {})
@@ -71,10 +77,12 @@ impl From<DeleteInboundShipmentError> for DeleteInboundShipmentResponse {
                 OutError::CannotEditInvoice(CannotEditInvoice {})
             }
             DeleteInboundShipmentError::InvoiceLinesExists(lines) => {
-                OutError::CannotDeleteInvoiceWithLines(CannotDeleteInvoiceWithLines(lines.into()))
+                OutError::CannotDeleteInvoiceWithLines(CannotDeleteInvoiceWithLines(
+                    InvoiceLineConnector::from_vec(lines),
+                ))
             }
         };
 
-        DeleteInboundShipmentResponse::Error(ErrorWrapper { error })
+        DeleteInboundShipmentResponse::Error(DeleteError { error })
     }
 }

--- a/graphql/src/schema/mutations/inbound_shipment/insert.rs
+++ b/graphql/src/schema/mutations/inbound_shipment/insert.rs
@@ -56,7 +56,7 @@ pub fn get_insert_inbound_shipment_response(
 }
 
 #[derive(Interface)]
-#[graphql(name = "InsertInboundShipmenErrorInterface")]
+#[graphql(name = "InsertInboundShipmentErrorInterface")]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum InsertErrorInterface {
     DatabaseError(DatabaseError),

--- a/graphql/src/schema/mutations/inbound_shipment/insert.rs
+++ b/graphql/src/schema/mutations/inbound_shipment/insert.rs
@@ -3,7 +3,7 @@ use async_graphql::*;
 use crate::schema::{
     mutations::{ForeignKey, ForeignKeyError, OtherPartyNotASupplier, RecordAlreadyExist},
     queries::invoice::*,
-    types::{DatabaseError, ErrorWrapper, InvoiceNode, NameNode, NodeError},
+    types::{DatabaseError, InvoiceNode, NameNode, NodeError},
 };
 use domain::inbound_shipment::InsertInboundShipment;
 use repository::StorageConnectionManager;
@@ -19,9 +19,15 @@ pub struct InsertInboundShipmentInput {
     pub colour: Option<String>,
 }
 
+#[derive(SimpleObject)]
+#[graphql(name = "InsertInboundShipmentError")]
+pub struct InsertError {
+    pub error: InsertErrorInterface,
+}
+
 #[derive(Union)]
 pub enum InsertInboundShipmentResponse {
-    Error(ErrorWrapper<InsertInboundShipmentErrorInterface>),
+    Error(InsertError),
     NodeError(NodeError),
     Response(InvoiceNode),
 }
@@ -35,8 +41,8 @@ pub fn get_insert_inbound_shipment_response(
     let connection = match connection_manager.connection() {
         Ok(con) => con,
         Err(err) => {
-            return InsertInboundShipmentResponse::Error(ErrorWrapper {
-                error: InsertInboundShipmentErrorInterface::DatabaseError(DatabaseError(err)),
+            return InsertInboundShipmentResponse::Error(InsertError {
+                error: InsertErrorInterface::DatabaseError(DatabaseError(err)),
             })
         }
     };
@@ -51,7 +57,7 @@ pub fn get_insert_inbound_shipment_response(
 
 #[derive(Interface)]
 #[graphql(field(name = "description", type = "&str"))]
-pub enum InsertInboundShipmentErrorInterface {
+pub enum InsertErrorInterface {
     DatabaseError(DatabaseError),
     ForeignKeyError(ForeignKeyError),
     RecordAlreadyExist(RecordAlreadyExist),
@@ -82,7 +88,7 @@ impl From<InsertInboundShipmentInput> for InsertInboundShipment {
 
 impl From<InsertInboundShipmentError> for InsertInboundShipmentResponse {
     fn from(error: InsertInboundShipmentError) -> Self {
-        use InsertInboundShipmentErrorInterface as OutError;
+        use InsertErrorInterface as OutError;
         let error = match error {
             InsertInboundShipmentError::InvoiceAlreadyExists => {
                 OutError::RecordAlreadyExist(RecordAlreadyExist {})
@@ -98,6 +104,6 @@ impl From<InsertInboundShipmentError> for InsertInboundShipmentResponse {
             }
         };
 
-        InsertInboundShipmentResponse::Error(ErrorWrapper { error })
+        InsertInboundShipmentResponse::Error(InsertError { error })
     }
 }

--- a/graphql/src/schema/mutations/inbound_shipment/insert.rs
+++ b/graphql/src/schema/mutations/inbound_shipment/insert.rs
@@ -56,6 +56,7 @@ pub fn get_insert_inbound_shipment_response(
 }
 
 #[derive(Interface)]
+#[graphql(name = "InsertInboundShipmenErrorInterface")]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum InsertErrorInterface {
     DatabaseError(DatabaseError),

--- a/graphql/src/schema/mutations/inbound_shipment/line/delete.rs
+++ b/graphql/src/schema/mutations/inbound_shipment/line/delete.rs
@@ -7,7 +7,7 @@ use crate::schema::{
         InvoiceDoesNotBelongToCurrentStore, InvoiceLineBelongsToAnotherInvoice,
         NotAnInboundShipment,
     },
-    types::{DatabaseError, ErrorWrapper, RecordNotFound},
+    types::{DatabaseError, RecordNotFound},
 };
 use domain::inbound_shipment::DeleteInboundShipmentLine;
 use repository::StorageConnectionManager;
@@ -19,9 +19,15 @@ pub struct DeleteInboundShipmentLineInput {
     pub invoice_id: String,
 }
 
+#[derive(SimpleObject)]
+#[graphql(name = "DeleteInboundShipmentLineError")]
+pub struct DeleteError {
+    pub error: DeleteErrorInterface,
+}
+
 #[derive(Union)]
 pub enum DeleteInboundShipmentLineResponse {
-    Error(ErrorWrapper<DeleteInboundShipmentLineErrorInterface>),
+    Error(DeleteError),
     Response(DeleteResponse),
 }
 
@@ -38,7 +44,7 @@ pub fn get_delete_inbound_shipment_line_response(
 
 #[derive(Interface)]
 #[graphql(field(name = "description", type = "&str"))]
-pub enum DeleteInboundShipmentLineErrorInterface {
+pub enum DeleteErrorInterface {
     DatabaseError(DatabaseError),
     RecordNotFound(RecordNotFound),
     ForeignKeyError(ForeignKeyError),
@@ -60,7 +66,7 @@ impl From<DeleteInboundShipmentLineInput> for DeleteInboundShipmentLine {
 
 impl From<DeleteInboundShipmentLineError> for DeleteInboundShipmentLineResponse {
     fn from(error: DeleteInboundShipmentLineError) -> Self {
-        use DeleteInboundShipmentLineErrorInterface as OutError;
+        use DeleteErrorInterface as OutError;
         let error = match error {
             DeleteInboundShipmentLineError::LineDoesNotExist => {
                 OutError::RecordNotFound(RecordNotFound {})
@@ -91,6 +97,6 @@ impl From<DeleteInboundShipmentLineError> for DeleteInboundShipmentLineResponse 
             }
         };
 
-        DeleteInboundShipmentLineResponse::Error(ErrorWrapper { error })
+        DeleteInboundShipmentLineResponse::Error(DeleteError { error })
     }
 }

--- a/graphql/src/schema/mutations/inbound_shipment/line/delete.rs
+++ b/graphql/src/schema/mutations/inbound_shipment/line/delete.rs
@@ -43,6 +43,7 @@ pub fn get_delete_inbound_shipment_line_response(
 }
 
 #[derive(Interface)]
+#[graphql(name = "DeleteInboundShipmentLineErrorInterface")]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum DeleteErrorInterface {
     DatabaseError(DatabaseError),

--- a/graphql/src/schema/mutations/inbound_shipment/line/insert.rs
+++ b/graphql/src/schema/mutations/inbound_shipment/line/insert.rs
@@ -68,6 +68,7 @@ pub fn get_insert_inbound_shipment_line_response(
 }
 
 #[derive(Interface)]
+#[graphql(name = "InsertInboundShipmentLineErrorInterface")]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum InsertErrorInterface {
     DatabaseError(DatabaseError),

--- a/graphql/src/schema/mutations/inbound_shipment/line/insert.rs
+++ b/graphql/src/schema/mutations/inbound_shipment/line/insert.rs
@@ -7,8 +7,8 @@ use crate::schema::{
         NotAnInboundShipment, RecordAlreadyExist,
     },
     types::{
-        get_invoice_line_response, DatabaseError, ErrorWrapper, InvoiceLineNode,
-        InvoiceLineResponse, NodeError, Range, RangeError, RangeField,
+        get_invoice_line_response, DatabaseError, InvoiceLineNode, InvoiceLineResponse, NodeError,
+        Range, RangeError, RangeField,
     },
 };
 use domain::inbound_shipment::InsertInboundShipmentLine;
@@ -32,9 +32,15 @@ pub struct InsertInboundShipmentLineInput {
     pub tax: Option<f64>,
 }
 
+#[derive(SimpleObject)]
+#[graphql(name = "InsertInboundShipmentLineError")]
+pub struct InsertError {
+    pub error: InsertErrorInterface,
+}
+
 #[derive(Union)]
 pub enum InsertInboundShipmentLineResponse {
-    Error(ErrorWrapper<InsertInboundShipmentLineErrorInterface>),
+    Error(InsertError),
     NodeError(NodeError),
     Response(InvoiceLineNode),
 }
@@ -47,8 +53,8 @@ pub fn get_insert_inbound_shipment_line_response(
     let connection = match connection_manager.connection() {
         Ok(con) => con,
         Err(err) => {
-            return InsertInboundShipmentLineResponse::Error(ErrorWrapper {
-                error: InsertInboundShipmentLineErrorInterface::DatabaseError(DatabaseError(err)),
+            return InsertInboundShipmentLineResponse::Error(InsertError {
+                error: InsertErrorInterface::DatabaseError(DatabaseError(err)),
             })
         }
     };
@@ -63,7 +69,7 @@ pub fn get_insert_inbound_shipment_line_response(
 
 #[derive(Interface)]
 #[graphql(field(name = "description", type = "&str"))]
-pub enum InsertInboundShipmentLineErrorInterface {
+pub enum InsertErrorInterface {
     DatabaseError(DatabaseError),
     ForeignKeyError(ForeignKeyError),
     RecordAlreadyExist(RecordAlreadyExist),
@@ -111,7 +117,7 @@ impl From<InsertInboundShipmentLineInput> for InsertInboundShipmentLine {
 
 impl From<InsertInboundShipmentLineError> for InsertInboundShipmentLineResponse {
     fn from(error: InsertInboundShipmentLineError) -> Self {
-        use InsertInboundShipmentLineErrorInterface as OutError;
+        use InsertErrorInterface as OutError;
         let error = match error {
             InsertInboundShipmentLineError::LineAlreadyExists => {
                 OutError::RecordAlreadyExist(RecordAlreadyExist {})
@@ -149,6 +155,6 @@ impl From<InsertInboundShipmentLineError> for InsertInboundShipmentLineResponse 
             }
         };
 
-        InsertInboundShipmentLineResponse::Error(ErrorWrapper { error })
+        InsertInboundShipmentLineResponse::Error(InsertError { error })
     }
 }

--- a/graphql/src/schema/mutations/inbound_shipment/line/update.rs
+++ b/graphql/src/schema/mutations/inbound_shipment/line/update.rs
@@ -7,8 +7,8 @@ use crate::schema::{
         InvoiceLineBelongsToAnotherInvoice, NotAnInboundShipment,
     },
     types::{
-        get_invoice_line_response, DatabaseError, ErrorWrapper, InvoiceLineNode,
-        InvoiceLineResponse, NodeError, Range, RangeError, RangeField, RecordNotFound,
+        get_invoice_line_response, DatabaseError, InvoiceLineNode, InvoiceLineResponse, NodeError,
+        Range, RangeError, RangeField, RecordNotFound,
     },
 };
 use domain::inbound_shipment::UpdateInboundShipmentLine;
@@ -31,9 +31,15 @@ pub struct UpdateInboundShipmentLineInput {
     pub number_of_packs: Option<u32>,
 }
 
+#[derive(SimpleObject)]
+#[graphql(name = "UpdateInboundShipmentLineError")]
+pub struct UpdateError {
+    pub error: UpdateErrorInterface,
+}
+
 #[derive(Union)]
 pub enum UpdateInboundShipmentLineResponse {
-    Error(ErrorWrapper<UpdateInboundShipmentLineErrorInterface>),
+    Error(UpdateError),
     NodeError(NodeError),
     Response(InvoiceLineNode),
 }
@@ -54,7 +60,7 @@ pub fn get_update_inbound_shipment_line_response(
 
 #[derive(Interface)]
 #[graphql(field(name = "description", type = "&str"))]
-pub enum UpdateInboundShipmentLineErrorInterface {
+pub enum UpdateErrorInterface {
     DatabaseError(DatabaseError),
     ForeignKeyError(ForeignKeyError),
     RecordNotFound(RecordNotFound),
@@ -98,7 +104,7 @@ impl From<UpdateInboundShipmentLineInput> for UpdateInboundShipmentLine {
 
 impl From<UpdateInboundShipmentLineError> for UpdateInboundShipmentLineResponse {
     fn from(error: UpdateInboundShipmentLineError) -> Self {
-        use UpdateInboundShipmentLineErrorInterface as OutError;
+        use UpdateErrorInterface as OutError;
         let error = match error {
             UpdateInboundShipmentLineError::LineDoesNotExist => {
                 OutError::RecordNotFound(RecordNotFound {})
@@ -144,6 +150,6 @@ impl From<UpdateInboundShipmentLineError> for UpdateInboundShipmentLineResponse 
             }
         };
 
-        UpdateInboundShipmentLineResponse::Error(ErrorWrapper { error })
+        UpdateInboundShipmentLineResponse::Error(UpdateError { error })
     }
 }

--- a/graphql/src/schema/mutations/inbound_shipment/line/update.rs
+++ b/graphql/src/schema/mutations/inbound_shipment/line/update.rs
@@ -59,6 +59,7 @@ pub fn get_update_inbound_shipment_line_response(
 }
 
 #[derive(Interface)]
+#[graphql(name = "UpdateInboundShipmentLineErrorInterface")]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum UpdateErrorInterface {
     DatabaseError(DatabaseError),

--- a/graphql/src/schema/mutations/inbound_shipment/update.rs
+++ b/graphql/src/schema/mutations/inbound_shipment/update.rs
@@ -76,7 +76,7 @@ pub fn get_update_inbound_shipment_response(
 }
 
 #[derive(Interface)]
-#[graphql(name = "UpdateInboundShipmenErrorInterface")]
+#[graphql(name = "UpdateInboundShipmentErrorInterface")]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum UpdateErrorInterface {
     DatabaseError(DatabaseError),

--- a/graphql/src/schema/mutations/inbound_shipment/update.rs
+++ b/graphql/src/schema/mutations/inbound_shipment/update.rs
@@ -76,6 +76,7 @@ pub fn get_update_inbound_shipment_response(
 }
 
 #[derive(Interface)]
+#[graphql(name = "UpdateInboundShipmenErrorInterface")]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum UpdateErrorInterface {
     DatabaseError(DatabaseError),

--- a/graphql/src/schema/mutations/location/delete.rs
+++ b/graphql/src/schema/mutations/location/delete.rs
@@ -8,7 +8,7 @@ use service::location::delete::{
 use crate::{
     schema::{
         mutations::{DeleteResponse, RecordBelongsToAnotherStore},
-        types::{Connector, DatabaseError, InvoiceLineNode, RecordNotFound, StockLineNode},
+        types::{DatabaseError, InvoiceLineConnector, RecordNotFound, StockLineConnector},
     },
     ContextExt,
 };
@@ -66,8 +66,8 @@ pub enum DeleteLocationErrorInterface {
 }
 
 pub struct LocationInUse {
-    stock_lines: Connector<StockLineNode>,
-    invoice_lines: Connector<InvoiceLineNode>,
+    stock_lines: StockLineConnector,
+    invoice_lines: InvoiceLineConnector,
 }
 
 #[Object]
@@ -76,11 +76,11 @@ impl LocationInUse {
         "Location in use"
     }
 
-    pub async fn stock_lines(&self) -> &Connector<StockLineNode> {
+    pub async fn stock_lines(&self) -> &StockLineConnector {
         &self.stock_lines
     }
 
-    pub async fn invoice_lines(&self) -> &Connector<InvoiceLineNode> {
+    pub async fn invoice_lines(&self) -> &InvoiceLineConnector {
         &self.invoice_lines
     }
 }
@@ -101,8 +101,8 @@ impl From<InError> for DeleteLocationError {
                 stock_lines,
                 invoice_lines,
             }) => OutError::LocationInUse(LocationInUse {
-                stock_lines: stock_lines.into(),
-                invoice_lines: invoice_lines.into(),
+                stock_lines: StockLineConnector::from_vec(stock_lines),
+                invoice_lines: InvoiceLineConnector::from_vec(invoice_lines),
             }),
             InError::LocationDoesNotBelongToCurrentStore => {
                 OutError::RecordBelongsToAnotherStore(RecordBelongsToAnotherStore {})

--- a/graphql/src/schema/mutations/location/insert.rs
+++ b/graphql/src/schema/mutations/location/insert.rs
@@ -27,7 +27,7 @@ pub fn insert_location(
         store_id,
         input.into(),
     ) {
-        Ok(location) => InsertLocationResponse::Response(location.into()),
+        Ok(location) => InsertLocationResponse::Response(LocationNode::from_domain(location)),
         Err(error) => InsertLocationResponse::Error(error.into()),
     }
 }

--- a/graphql/src/schema/mutations/location/update.rs
+++ b/graphql/src/schema/mutations/location/update.rs
@@ -6,7 +6,7 @@ use service::location::update::UpdateLocationError as InError;
 use crate::{
     schema::{
         mutations::{RecordBelongsToAnotherStore, UniqueValueKey, UniqueValueViolation},
-        types::{InternalError, LocationNode, RecordNotFound, DatabaseError},
+        types::{DatabaseError, InternalError, LocationNode, RecordNotFound},
     },
     ContextExt,
 };
@@ -27,7 +27,7 @@ pub fn update_location(
         store_id,
         input.into(),
     ) {
-        Ok(location) => UpdateLocationResponse::Response(location.into()),
+        Ok(location) => UpdateLocationResponse::Response(LocationNode::from_domain(location)),
         Err(error) => UpdateLocationResponse::Error(error.into()),
     }
 }

--- a/graphql/src/schema/mutations/mod.rs
+++ b/graphql/src/schema/mutations/mod.rs
@@ -33,7 +33,7 @@ use self::{
 
 use super::{
     queries::invoice::*,
-    types::{Connector, InvoiceLineNode, NameNode},
+    types::{InvoiceLineConnector, NameNode},
 };
 use crate::ContextExt;
 use async_graphql::*;
@@ -531,14 +531,14 @@ impl NotAnOutboundShipment {
     }
 }
 
-pub struct CannotDeleteInvoiceWithLines(pub Connector<InvoiceLineNode>);
+pub struct CannotDeleteInvoiceWithLines(pub InvoiceLineConnector);
 #[Object]
 impl CannotDeleteInvoiceWithLines {
     pub async fn description(&self) -> &'static str {
         "Cannot delete invoice with existing lines"
     }
 
-    pub async fn lines(&self) -> &Connector<InvoiceLineNode> {
+    pub async fn lines(&self) -> &InvoiceLineConnector {
         &self.0
     }
 }

--- a/graphql/src/schema/mutations/outbound_shipment/insert.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/insert.rs
@@ -1,7 +1,7 @@
 use crate::schema::{
     mutations::{ForeignKey, ForeignKeyError, RecordAlreadyExist},
     queries::invoice::*,
-    types::{DatabaseError, ErrorWrapper, InvoiceNode, InvoiceNodeStatus, NameNode, NodeError},
+    types::{DatabaseError, InvoiceNode, InvoiceNodeStatus, NameNode, NodeError},
 };
 use domain::{invoice::InvoiceStatus, outbound_shipment::InsertOutboundShipment};
 use repository::StorageConnectionManager;
@@ -9,7 +9,7 @@ use service::invoice::{insert_outbound_shipment, InsertOutboundShipmentError};
 
 use super::{OtherPartyCannotBeThisStoreError, OtherPartyNotACustomerError};
 
-use async_graphql::{InputObject, Interface, Union};
+use async_graphql::*;
 
 #[derive(InputObject)]
 pub struct InsertOutboundShipmentInput {
@@ -38,9 +38,15 @@ impl From<InsertOutboundShipmentInput> for InsertOutboundShipment {
     }
 }
 
+#[derive(SimpleObject)]
+#[graphql(name = "InsertOutboundShipmentError")]
+pub struct InsertError {
+    pub error: InsertErrorInterface,
+}
+
 #[derive(Union)]
 pub enum InsertOutboundShipmentResponse {
-    Error(ErrorWrapper<InsertOutboundShipmentErrorInterface>),
+    Error(InsertError),
     NodeError(NodeError),
     Response(InvoiceNode),
 }
@@ -54,8 +60,8 @@ pub fn get_insert_outbound_shipment_response(
     let connection = match connection_manager.connection() {
         Ok(con) => con,
         Err(err) => {
-            return InsertOutboundShipmentResponse::Error(ErrorWrapper {
-                error: InsertOutboundShipmentErrorInterface::DatabaseError(DatabaseError(err)),
+            return InsertOutboundShipmentResponse::Error(InsertError {
+                error: InsertErrorInterface::DatabaseError(DatabaseError(err)),
             })
         }
     };
@@ -70,7 +76,7 @@ pub fn get_insert_outbound_shipment_response(
 
 #[derive(Interface)]
 #[graphql(field(name = "description", type = "String"))]
-pub enum InsertOutboundShipmentErrorInterface {
+pub enum InsertErrorInterface {
     InvoiceAlreadyExists(RecordAlreadyExist),
     ForeignKeyError(ForeignKeyError),
     OtherPartyCannotBeThisStore(OtherPartyCannotBeThisStoreError),
@@ -80,7 +86,7 @@ pub enum InsertOutboundShipmentErrorInterface {
 
 impl From<InsertOutboundShipmentError> for InsertOutboundShipmentResponse {
     fn from(error: InsertOutboundShipmentError) -> Self {
-        use InsertOutboundShipmentErrorInterface as OutError;
+        use InsertErrorInterface as OutError;
         let error = match error {
             InsertOutboundShipmentError::OtherPartyCannotBeThisStore => {
                 OutError::OtherPartyCannotBeThisStore(OtherPartyCannotBeThisStoreError {})
@@ -99,6 +105,6 @@ impl From<InsertOutboundShipmentError> for InsertOutboundShipmentResponse {
             }
         };
 
-        InsertOutboundShipmentResponse::Error(ErrorWrapper { error })
+        InsertOutboundShipmentResponse::Error(InsertError { error })
     }
 }

--- a/graphql/src/schema/mutations/outbound_shipment/insert.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/insert.rs
@@ -29,7 +29,10 @@ impl From<InsertOutboundShipmentInput> for InsertOutboundShipment {
         InsertOutboundShipment {
             id: input.id,
             other_party_id: input.other_party_id,
-            status: input.status.map(|s| s.into()).unwrap_or(InvoiceStatus::New),
+            status: input
+                .status
+                .map(|s| s.to_domain())
+                .unwrap_or(InvoiceStatus::New),
             on_hold: input.on_hold,
             comment: input.comment,
             their_reference: input.their_reference,

--- a/graphql/src/schema/mutations/outbound_shipment/line/delete.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/line/delete.rs
@@ -6,7 +6,7 @@ use crate::schema::{
         InvoiceDoesNotBelongToCurrentStore, InvoiceLineBelongsToAnotherInvoice,
         NotAnOutboundShipment,
     },
-    types::{DatabaseError, ErrorWrapper, RecordNotFound},
+    types::{DatabaseError, RecordNotFound},
 };
 use domain::outbound_shipment::DeleteOutboundShipmentLine;
 use repository::StorageConnectionManager;
@@ -18,9 +18,15 @@ pub struct DeleteOutboundShipmentLineInput {
     pub invoice_id: String,
 }
 
+#[derive(SimpleObject)]
+#[graphql(name = "DeleteOutboundShipmentLineError")]
+pub struct DeleteError {
+    pub error: DeleteErrorInterface,
+}
+
 #[derive(Union)]
 pub enum DeleteOutboundShipmentLineResponse {
-    Error(ErrorWrapper<DeleteOutboundShipmentLineErrorInterface>),
+    Error(DeleteError),
     Response(DeleteResponse),
 }
 
@@ -37,7 +43,7 @@ pub fn get_delete_outbound_shipment_line_response(
 
 #[derive(Interface)]
 #[graphql(field(name = "description", type = "&str"))]
-pub enum DeleteOutboundShipmentLineErrorInterface {
+pub enum DeleteErrorInterface {
     DatabaseError(DatabaseError),
     RecordNotFound(RecordNotFound),
     ForeignKeyError(ForeignKeyError),
@@ -58,7 +64,7 @@ impl From<DeleteOutboundShipmentLineInput> for DeleteOutboundShipmentLine {
 
 impl From<DeleteOutboundShipmentLineError> for DeleteOutboundShipmentLineResponse {
     fn from(error: DeleteOutboundShipmentLineError) -> Self {
-        use DeleteOutboundShipmentLineErrorInterface as OutError;
+        use DeleteErrorInterface as OutError;
         let error = match error {
             DeleteOutboundShipmentLineError::LineDoesNotExist => {
                 OutError::RecordNotFound(RecordNotFound {})
@@ -85,6 +91,6 @@ impl From<DeleteOutboundShipmentLineError> for DeleteOutboundShipmentLineRespons
             }
         };
 
-        DeleteOutboundShipmentLineResponse::Error(ErrorWrapper { error })
+        DeleteOutboundShipmentLineResponse::Error(DeleteError { error })
     }
 }

--- a/graphql/src/schema/mutations/outbound_shipment/line/delete.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/line/delete.rs
@@ -42,6 +42,7 @@ pub fn get_delete_outbound_shipment_line_response(
 }
 
 #[derive(Interface)]
+#[graphql(name = "DeleteOutboundShipmentLineErrorInterface")]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum DeleteErrorInterface {
     DatabaseError(DatabaseError),

--- a/graphql/src/schema/mutations/outbound_shipment/line/insert.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/line/insert.rs
@@ -68,6 +68,7 @@ pub fn get_insert_outbound_shipment_line_response(
 }
 
 #[derive(Interface)]
+#[graphql(name = "InsertOutboundShipmentLineErrorInterface")]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum InsertErrorInterface {
     DatabaseError(DatabaseError),

--- a/graphql/src/schema/mutations/outbound_shipment/line/update.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/line/update.rs
@@ -63,6 +63,7 @@ pub enum UpdateOutboundShipmentLineResponse {
 }
 
 #[derive(Interface)]
+#[graphql(name = "UpdateOutboundShipmentLineErrorInterface")]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum UpdateErrorInterface {
     DatabaseError(DatabaseError),

--- a/graphql/src/schema/mutations/outbound_shipment/line/update.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/line/update.rs
@@ -7,8 +7,8 @@ use crate::schema::{
         NotAnOutboundShipment,
     },
     types::{
-        get_invoice_line_response, DatabaseError, ErrorWrapper, InvoiceLineNode,
-        InvoiceLineResponse, NodeError, Range, RangeError, RangeField, RecordNotFound,
+        get_invoice_line_response, DatabaseError, InvoiceLineNode, InvoiceLineResponse, NodeError,
+        Range, RangeError, RangeField, RecordNotFound,
     },
 };
 use domain::{
@@ -49,16 +49,22 @@ pub fn get_update_outbound_shipment_line_response(
     }
 }
 
+#[derive(SimpleObject)]
+#[graphql(name = "UpdateOutboundShipmentLineError")]
+pub struct UpdateError {
+    pub error: UpdateErrorInterface,
+}
+
 #[derive(Union)]
 pub enum UpdateOutboundShipmentLineResponse {
-    Error(ErrorWrapper<UpdateOutboundShipmentLineErrorInterface>),
+    Error(UpdateError),
     NodeError(NodeError),
     Response(InvoiceLineNode),
 }
 
 #[derive(Interface)]
 #[graphql(field(name = "description", type = "&str"))]
-pub enum UpdateOutboundShipmentLineErrorInterface {
+pub enum UpdateErrorInterface {
     DatabaseError(DatabaseError),
     ForeignKeyError(ForeignKeyError),
     RecordNotFound(RecordNotFound),
@@ -107,7 +113,7 @@ impl From<UpdateOutboundShipmentLineInput> for UpdateOutboundShipmentLine {
 
 impl From<UpdateOutboundShipmentLineError> for UpdateOutboundShipmentLineResponse {
     fn from(error: UpdateOutboundShipmentLineError) -> Self {
-        use UpdateOutboundShipmentLineErrorInterface as OutError;
+        use UpdateErrorInterface as OutError;
         let error = match error {
             UpdateOutboundShipmentLineError::DatabaseError(error) => {
                 OutError::DatabaseError(DatabaseError(error))
@@ -171,6 +177,6 @@ impl From<UpdateOutboundShipmentLineError> for UpdateOutboundShipmentLineRespons
             }
         };
 
-        UpdateOutboundShipmentLineResponse::Error(ErrorWrapper { error })
+        UpdateOutboundShipmentLineResponse::Error(UpdateError { error })
     }
 }

--- a/graphql/src/schema/mutations/outbound_shipment/service_line/delete.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/service_line/delete.rs
@@ -50,6 +50,7 @@ pub fn get_delete_outbound_shipment_service_line_response(
 }
 
 #[derive(Interface)]
+#[graphql(name = "DeleteOutboundShipmentServiceLineErrorInterface")]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum DeleteErrorInterface {
     DatabaseError(DatabaseError),

--- a/graphql/src/schema/mutations/outbound_shipment/service_line/insert.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/service_line/insert.rs
@@ -86,6 +86,7 @@ pub fn get_insert_outbound_shipment_service_line_response(
 }
 
 #[derive(Interface)]
+#[graphql(name = "InsertOutboundShipmentServiceLineErrorInterface")]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum InsertErrorInterface {
     DatabaseError(DatabaseError),

--- a/graphql/src/schema/mutations/outbound_shipment/service_line/update.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/service_line/update.rs
@@ -83,6 +83,7 @@ pub enum UpdateOutboundShipmentServiceLineResponse {
 }
 
 #[derive(Interface)]
+#[graphql(name = "UpdateOutboundShipmentServiceLineErrorInterface")]
 #[graphql(field(name = "description", type = "&str"))]
 pub enum UpdateErrorInterface {
     InternalError(InternalError),

--- a/graphql/src/schema/mutations/outbound_shipment/unallocated_line/insert.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/unallocated_line/insert.rs
@@ -88,7 +88,7 @@ pub fn insert(ctx: &Context<'_>, input: InsertInput) -> Result<InsertResponse> {
         .outbound_shipment_line
         .insert_outbound_shipment_unallocated_line(&service_context, input.into())
     {
-        Ok(invoice_line) => InsertResponse::Response(invoice_line.into()),
+        Ok(invoice_line) => InsertResponse::Response(InvoiceLineNode::from_domain(invoice_line)),
         Err(error) => InsertResponse::Error(InsertError {
             error: map_error(&id, error)?,
         }),

--- a/graphql/src/schema/mutations/outbound_shipment/unallocated_line/update.rs
+++ b/graphql/src/schema/mutations/outbound_shipment/unallocated_line/update.rs
@@ -53,7 +53,7 @@ pub fn update(ctx: &Context<'_>, input: UpdateInput) -> Result<UpdateResponse> {
         .outbound_shipment_line
         .update_outbound_shipment_unallocated_line(&service_context, input.into())
     {
-        Ok(invoice_line) => UpdateResponse::Response(invoice_line.into()),
+        Ok(invoice_line) => UpdateResponse::Response(InvoiceLineNode::from_domain(invoice_line)),
         Err(error) => UpdateResponse::Error(UpdateError {
             error: map_error(&id, error)?,
         }),

--- a/graphql/src/schema/mutations/requisition/response_requisition/create_requisition_shipment.rs
+++ b/graphql/src/schema/mutations/requisition/response_requisition/create_requisition_shipment.rs
@@ -62,7 +62,9 @@ pub fn create_requisition_shipment(
         .requisition_service
         .create_requisition_shipment(&service_context, store_id, input.to_domain())
     {
-        Ok(invoice) => CreateRequisitionShipmentResponse::Response(invoice.into()),
+        Ok(invoice) => {
+            CreateRequisitionShipmentResponse::Response(InvoiceNode::from_domain(invoice))
+        }
         Err(error) => CreateRequisitionShipmentResponse::Error(DeleteError {
             error: map_error(error)?,
         }),

--- a/graphql/src/schema/queries/invoice.rs
+++ b/graphql/src/schema/queries/invoice.rs
@@ -41,7 +41,7 @@ pub fn get_invoice_by_number(
         &service_context,
         store_id,
         invoice_number,
-        r#type.into(),
+        r#type.to_domain(),
     )?;
 
     let response = match invoice_option {

--- a/graphql/src/schema/queries/invoice.rs
+++ b/graphql/src/schema/queries/invoice.rs
@@ -22,7 +22,7 @@ pub fn get_invoice(
     id: String,
 ) -> InvoiceResponse {
     match get_invoice_service(connection_manager, store_id, id) {
-        Ok(invoice) => InvoiceResponse::Response(invoice.into()),
+        Ok(invoice) => InvoiceResponse::Response(InvoiceNode::from_domain(invoice)),
         Err(error) => InvoiceResponse::Error(error.into()),
     }
 }
@@ -45,7 +45,7 @@ pub fn get_invoice_by_number(
     )?;
 
     let response = match invoice_option {
-        Some(invoice) => InvoiceResponse::Response(invoice.into()),
+        Some(invoice) => InvoiceResponse::Response(InvoiceNode::from_domain(invoice)),
         None => InvoiceResponse::Error(NodeError {
             error: NodeErrorInterface::record_not_found(),
         }),

--- a/graphql/src/schema/queries/mod.rs
+++ b/graphql/src/schema/queries/mod.rs
@@ -108,7 +108,10 @@ impl Queries {
                 &service_context,
                 page.map(PaginationOption::from),
                 filter.map(LocationFilter::from),
-                convert_sort(sort),
+                // Currently only one sort option is supported, use the first from the list.
+                sort.map(|mut sort_list| sort_list.pop())
+                    .flatten()
+                    .map(|sort| sort.to_domain()),
             )
             .map_err(StandardGraphqlError::from_list_error)?;
 
@@ -176,7 +179,10 @@ impl Queries {
             Some(&store_id),
             page.map(PaginationOption::from),
             filter.map(InvoiceFilter::from),
-            convert_sort(sort),
+            // Currently only one sort option is supported, use the first from the list.
+            sort.map(|mut sort_list| sort_list.pop())
+                .flatten()
+                .map(|sort| sort.to_domain()),
         )
         .map_err(StandardGraphqlError::from_list_error)?;
 

--- a/graphql/src/schema/queries/requisition.rs
+++ b/graphql/src/schema/queries/requisition.rs
@@ -6,8 +6,7 @@ use service::permission_validation::{Resource, ResourceAccessRequest};
 use crate::{
     schema::types::{
         sort_filter_types::{
-            DatetimeFilterInput, EqualFilterBigNumberInput, EqualFilterInput,
-            SimpleStringFilterInput,
+            map_filter, DatetimeFilterInput, EqualFilterBigNumberInput, SimpleStringFilterInput,
         },
         PaginationInput, RecordNotFound, RequisitionConnector, RequisitionNode,
         RequisitionNodeStatus, RequisitionNodeType,
@@ -40,11 +39,24 @@ pub struct RequisitionSortInput {
 }
 
 #[derive(InputObject, Clone)]
+pub struct EqualFilterRequisitionTypeInput {
+    pub equal_to: Option<RequisitionNodeType>,
+    pub equal_any: Option<Vec<RequisitionNodeType>>,
+    pub not_equal_to: Option<RequisitionNodeType>,
+}
+#[derive(InputObject, Clone)]
+pub struct EqualFilterRequisitionStatusInput {
+    pub equal_to: Option<RequisitionNodeStatus>,
+    pub equal_any: Option<Vec<RequisitionNodeStatus>>,
+    pub not_equal_to: Option<RequisitionNodeStatus>,
+}
+
+#[derive(InputObject, Clone)]
 pub struct RequisitionFilterInput {
     pub id: Option<EqualFilterStringInput>,
     pub requisition_number: Option<EqualFilterBigNumberInput>,
-    pub r#type: Option<EqualFilterInput<RequisitionNodeType>>,
-    pub status: Option<EqualFilterInput<RequisitionNodeStatus>>,
+    pub r#type: Option<EqualFilterRequisitionTypeInput>,
+    pub status: Option<EqualFilterRequisitionStatusInput>,
     pub created_datetime: Option<DatetimeFilterInput>,
     pub sent_datetime: Option<DatetimeFilterInput>,
     pub finalised_datetime: Option<DatetimeFilterInput>,
@@ -195,10 +207,10 @@ impl RequisitionFilterInput {
             requisition_number: self.requisition_number.map(EqualFilter::from),
             r#type: self
                 .r#type
-                .map(|t| t.map_to_domain(RequisitionNodeType::to_domain)),
+                .map(|t| map_filter!(t, RequisitionNodeType::to_domain)),
             status: self
                 .status
-                .map(|t| t.map_to_domain(RequisitionNodeStatus::to_domain)),
+                .map(|t| map_filter!(t, RequisitionNodeStatus::to_domain)),
             created_datetime: self.created_datetime.map(DatetimeFilter::from),
             sent_datetime: self.sent_datetime.map(DatetimeFilter::from),
             finalised_datetime: self.finalised_datetime.map(DatetimeFilter::from),

--- a/graphql/src/schema/queries/stocktake.rs
+++ b/graphql/src/schema/queries/stocktake.rs
@@ -1,13 +1,3 @@
-use async_graphql::*;
-use domain::DatetimeFilter;
-use domain::EqualFilter;
-use domain::PaginationOption;
-use repository::schema::StocktakeStatus;
-use repository::StocktakeFilter;
-use service::permission_validation::Resource;
-use service::permission_validation::ResourceAccessRequest;
-use service::ListError;
-
 use crate::schema::types::ErrorWrapper;
 use crate::schema::types::NodeError;
 use crate::schema::types::NodeErrorInterface;
@@ -16,8 +6,7 @@ use crate::schema::types::StocktakeNode;
 use crate::schema::types::StocktakeNodeStatus;
 use crate::schema::types::{
     sort_filter_types::{
-        convert_sort, DatetimeFilterInput, EqualFilterBigNumberInput, EqualFilterInput,
-        EqualFilterStringInput,
+        DatetimeFilterInput, EqualFilterBigNumberInput, EqualFilterInput, EqualFilterStringInput,
     },
     PaginationInput,
 };
@@ -25,18 +14,33 @@ use crate::standard_graphql_error::list_error_to_gql_err;
 use crate::standard_graphql_error::validate_auth;
 use crate::standard_graphql_error::StandardGraphqlError;
 use crate::ContextExt;
-
-use super::SortInput;
+use async_graphql::*;
+use domain::DatetimeFilter;
+use domain::EqualFilter;
+use domain::PaginationOption;
+use repository::schema::StocktakeStatus;
+use repository::StocktakeFilter;
+use repository::{StocktakeSort, StocktakeSortField};
+use service::permission_validation::Resource;
+use service::permission_validation::ResourceAccessRequest;
+use service::ListError;
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
-#[graphql(remote = "repository::StocktakeSortField")]
 #[graphql(rename_items = "camelCase")]
 pub enum StocktakeSortFieldInput {
     Status,
     CreatedDatetime,
     FinalisedDatetime,
 }
-pub type StocktakeSortInput = SortInput<StocktakeSortFieldInput>;
+
+#[derive(InputObject)]
+pub struct StocktakeSortInput {
+    /// Sort query result by `key`
+    key: StocktakeSortFieldInput,
+    /// Sort query result is sorted descending or ascending (if not provided the default is
+    /// ascending)
+    desc: Option<bool>,
+}
 
 #[derive(InputObject, Clone)]
 pub struct StocktakeFilterInput {
@@ -95,7 +99,10 @@ pub fn stocktakes(
         store_id,
         page.map(PaginationOption::from),
         filter.map(StocktakeFilter::from),
-        convert_sort(sort),
+        // Currently only one sort option is supported, use the first from the list.
+        sort.map(|mut sort_list| sort_list.pop())
+            .flatten()
+            .map(|sort| sort.to_domain()),
     ) {
         Ok(stocktakes) => Ok(StocktakesResponse::Response(StocktakeConnector {
             total_count: stocktakes.count,
@@ -192,5 +199,22 @@ pub fn stocktake_by_number(
         }
 
         Err(err) => Err(list_error_to_gql_err(err)),
+    }
+}
+
+impl StocktakeSortInput {
+    pub fn to_domain(self) -> StocktakeSort {
+        use StocktakeSortField as to;
+        use StocktakeSortFieldInput as from;
+        let key = match self.key {
+            from::Status => to::Status,
+            from::CreatedDatetime => to::CreatedDatetime,
+            from::FinalisedDatetime => to::FinalisedDatetime,
+        };
+
+        StocktakeSort {
+            key,
+            desc: self.desc,
+        }
     }
 }

--- a/graphql/src/schema/types/location.rs
+++ b/graphql/src/schema/types/location.rs
@@ -1,15 +1,12 @@
+use super::{EqualFilterStringInput, NodeError, SortInput, StockLineConnector};
+use crate::{loader::StockLineByLocationIdLoader, ContextExt};
 use async_graphql::*;
 use async_graphql::{dataloader::DataLoader, Context};
 use domain::{
     location::{Location, LocationFilter},
     EqualFilter,
 };
-
-use crate::{loader::StockLineByLocationIdLoader, ContextExt};
-
-use super::{
-    Connector, ConnectorError, EqualFilterStringInput, NodeError, SortInput, StockLinesResponse,
-};
+use service::{usize_to_u32, ListResult};
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
 #[graphql(remote = "domain::location::LocationSortField")]
@@ -43,6 +40,12 @@ pub struct LocationNode {
     pub location: Location,
 }
 
+#[derive(SimpleObject)]
+pub struct LocationConnector {
+    total_count: u32,
+    nodes: Vec<LocationNode>,
+}
+
 #[Object]
 impl LocationNode {
     pub async fn id(&self) -> &str {
@@ -61,21 +64,19 @@ impl LocationNode {
         self.location.on_hold
     }
 
-    pub async fn stock(&self, ctx: &Context<'_>) -> StockLinesResponse {
+    pub async fn stock(&self, ctx: &Context<'_>) -> Result<StockLineConnector> {
         let loader = ctx.get_loader::<DataLoader<StockLineByLocationIdLoader>>();
-        match loader.load_one(self.location.id.clone()).await {
-            Ok(result_option) => {
-                StockLinesResponse::Response(result_option.unwrap_or(Vec::new()).into())
-            }
-            Err(error) => StockLinesResponse::Error(error.into()),
-        }
+        let result_option = loader.load_one(self.location.id.clone()).await?;
+
+        Ok(StockLineConnector::from_vec(
+            result_option.unwrap_or(vec![]),
+        ))
     }
 }
 
 #[derive(Union)]
 pub enum LocationsResponse {
-    Error(ConnectorError),
-    Response(Connector<LocationNode>),
+    Response(LocationConnector),
 }
 
 #[derive(Union)]
@@ -84,8 +85,31 @@ pub enum LocationResponse {
     Response(LocationNode),
 }
 
-impl From<Location> for LocationNode {
-    fn from(location: Location) -> Self {
+impl LocationNode {
+    pub fn from_domain(location: Location) -> LocationNode {
         LocationNode { location }
+    }
+}
+
+impl LocationConnector {
+    pub fn from_domain(locations: ListResult<Location>) -> LocationConnector {
+        LocationConnector {
+            total_count: locations.count,
+            nodes: locations
+                .rows
+                .into_iter()
+                .map(LocationNode::from_domain)
+                .collect(),
+        }
+    }
+
+    pub fn from_vec(locations: Vec<Location>) -> LocationConnector {
+        LocationConnector {
+            total_count: usize_to_u32(locations.len()),
+            nodes: locations
+                .into_iter()
+                .map(LocationNode::from_domain)
+                .collect(),
+        }
     }
 }

--- a/graphql/src/schema/types/master_list_line.rs
+++ b/graphql/src/schema/types/master_list_line.rs
@@ -52,6 +52,7 @@ impl MasterListLineNode {
         let item_option = loader
             .load_one(self.master_list_line.item_id.clone())
             .await?;
+
         let item = item_option.ok_or(
             StandardGraphqlError::InternalError(format!(
                 "Cannot find item_id {} for master_list_line_id {}",
@@ -60,7 +61,7 @@ impl MasterListLineNode {
             .extend(),
         )?;
 
-        Ok(ItemNode::from(item))
+        Ok(ItemNode::from_domain(item))
     }
 }
 

--- a/graphql/src/schema/types/name.rs
+++ b/graphql/src/schema/types/name.rs
@@ -53,8 +53,8 @@ pub struct NameNode {
     pub name: Name,
 }
 
-impl From<Name> for NameNode {
-    fn from(name: Name) -> Self {
+impl NameNode {
+    pub fn from_domain(name: Name) -> NameNode {
         NameNode { name }
     }
 }

--- a/graphql/src/schema/types/requisition_line.rs
+++ b/graphql/src/schema/types/requisition_line.rs
@@ -15,7 +15,7 @@ use crate::{
     ContextExt,
 };
 
-use super::{Connector, InvoiceLineNode, ItemNode, ItemStatsNode};
+use super::{InvoiceLineConnector, ItemNode, ItemStatsNode};
 
 #[derive(PartialEq, Debug)]
 pub struct RequisitionLineNode {
@@ -41,16 +41,15 @@ impl RequisitionLineNode {
     pub async fn item(&self, ctx: &Context<'_>) -> Result<ItemNode> {
         let loader = ctx.get_loader::<DataLoader<ItemLoader>>();
         let item_option = loader.load_one(self.row().item_id.clone()).await?;
-        let item = item_option.ok_or(
+
+        item_option.map(ItemNode::from_domain).ok_or(
             StandardGraphqlError::InternalError(format!(
                 "Cannot find item_id {} for requisition_line_id {}",
                 &self.row().item_id,
                 &self.row().id
             ))
             .extend(),
-        )?;
-
-        Ok(ItemNode::from(item))
+        )
     }
 
     /// Quantity requested
@@ -70,17 +69,14 @@ impl RequisitionLineNode {
     }
 
     /// OutboundShipment lines linked to requisitions line
-    pub async fn outbound_shipment_lines(
-        &self,
-        ctx: &Context<'_>,
-    ) -> Result<Connector<InvoiceLineNode>> {
+    pub async fn outbound_shipment_lines(&self, ctx: &Context<'_>) -> Result<InvoiceLineConnector> {
         // Outbound shipments link to response requisition, so for request requisition
         // use linked requisition id
         let requisition_row = &self.requisition_line.requisition_row;
         let requisition_id = match requisition_row.r#type {
             RequisitionRowType::Request => match &requisition_row.linked_requisition_id {
                 Some(linked_requisition_id) => linked_requisition_id,
-                None => return Ok(Connector::empty()),
+                None => return Ok(InvoiceLineConnector::empty()),
             },
             _ => &self.row().requisition_id,
         };
@@ -93,23 +89,20 @@ impl RequisitionLineNode {
             })
             .await?;
 
-        let list_result = result_option.unwrap_or(vec![]);
+        let result = result_option.unwrap_or(vec![]);
 
-        Ok(list_result.into())
+        Ok(InvoiceLineConnector::from_vec(result))
     }
 
     /// InboundShipment lines linked to requisitions line
-    pub async fn inbound_shipment_lines(
-        &self,
-        ctx: &Context<'_>,
-    ) -> Result<Connector<InvoiceLineNode>> {
+    pub async fn inbound_shipment_lines(&self, ctx: &Context<'_>) -> Result<InvoiceLineConnector> {
         // Outbound shipments links to request requisition, so for response requisition
         // use linked requisition id
         let requisition_row = &self.requisition_line.requisition_row;
         let requisition_id = match requisition_row.r#type {
             RequisitionRowType::Response => match &requisition_row.linked_requisition_id {
                 Some(linked_requisition_id) => linked_requisition_id,
-                None => return Ok(Connector::empty()),
+                None => return Ok(InvoiceLineConnector::empty()),
             },
             _ => &self.row().requisition_id,
         };
@@ -122,9 +115,9 @@ impl RequisitionLineNode {
             })
             .await?;
 
-        let list_result = result_option.unwrap_or(vec![]);
+        let result = result_option.unwrap_or(vec![]);
 
-        Ok(list_result.into())
+        Ok(InvoiceLineConnector::from_vec(result))
     }
 
     /// Snapshot Stats (when requisition was created)

--- a/graphql/src/schema/types/sort_filter_types.rs
+++ b/graphql/src/schema/types/sort_filter_types.rs
@@ -1,60 +1,17 @@
-use crate::schema::queries::{ItemSortFieldInput, NameSortFieldInput, StocktakeSortFieldInput};
-
 use super::{
-    InvoiceNodeStatus, InvoiceNodeType, InvoiceSortFieldInput, LocationSortFieldInput,
-    RequisitionNodeStatus, RequisitionNodeType, StocktakeNodeStatus,
+    InvoiceNodeStatus, InvoiceNodeType, RequisitionNodeStatus, RequisitionNodeType,
+    StocktakeNodeStatus,
 };
 
 use domain::{
     invoice::{InvoiceStatus, InvoiceType},
-    DatetimeFilter, EqualFilter, SimpleStringFilter, Sort,
+    DatetimeFilter, EqualFilter, SimpleStringFilter,
 };
 
 use async_graphql::{InputObject, InputType};
 use chrono::{DateTime, Utc};
 
-#[derive(InputObject)]
-#[graphql(concrete(name = "InvoiceSortInput", params(InvoiceSortFieldInput)))]
-#[graphql(concrete(name = "ItemSortInput", params(ItemSortFieldInput)))]
-#[graphql(concrete(name = "NameSortInput", params(NameSortFieldInput)))]
-#[graphql(concrete(name = "LocationSortInput", params(LocationSortFieldInput)))]
-#[graphql(concrete(name = "StocktakeSortInput", params(StocktakeSortFieldInput)))]
-pub struct SortInput<T: InputType> {
-    /// Sort query result by `key`
-    pub key: T,
-    /// Sort query result is sorted descending or ascending (if not provided the default is
-    /// ascending)
-    pub desc: Option<bool>,
-}
-
-impl<TInput, T> From<SortInput<TInput>> for Sort<T>
-where
-    TInput: InputType,
-    T: From<TInput>,
-{
-    fn from(sort: SortInput<TInput>) -> Self {
-        Sort {
-            key: T::from(sort.key),
-            desc: sort.desc,
-        }
-    }
-}
-
-pub fn convert_sort<FromField, ToField>(
-    from: Option<Vec<SortInput<FromField>>>,
-) -> Option<Sort<ToField>>
-where
-    FromField: InputType,
-    Sort<ToField>: From<SortInput<FromField>>,
-{
-    // Currently only one sort option is supported, use the first from the list.
-    from.map(|mut sort_list| sort_list.pop())
-        .flatten()
-        .map(Sort::from)
-}
-
 // simple string filter
-
 #[derive(InputObject, Clone)]
 pub struct SimpleStringFilterInput {
     /// Search term must be an exact match (case sensitive)

--- a/graphql/src/schema/types/stocktake.rs
+++ b/graphql/src/schema/types/stocktake.rs
@@ -12,7 +12,6 @@ use crate::{
 use super::{InvoiceNode, StocktakeLineConnector};
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq, Debug, Serialize)]
-#[graphql(remote = "repository::schema::StocktakeStatus")]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")] // only needed to be comparable in tests
 pub enum StocktakeNodeStatus {
     New,
@@ -46,7 +45,7 @@ impl StocktakeNode {
     }
 
     pub async fn status(&self) -> StocktakeNodeStatus {
-        StocktakeNodeStatus::from(self.stocktake.status.clone())
+        StocktakeNodeStatus::from_domain(&self.stocktake.status)
     }
 
     pub async fn created_datetime(&self) -> &NaiveDateTime {
@@ -92,7 +91,7 @@ impl StocktakeNode {
 }
 
 impl StocktakeNodeStatus {
-    pub fn to_domain(&self) -> StocktakeStatus {
+    pub fn to_domain(self) -> StocktakeStatus {
         match self {
             StocktakeNodeStatus::New => StocktakeStatus::New,
             StocktakeNodeStatus::Finalised => StocktakeStatus::Finalised,

--- a/graphql/src/schema/types/stocktake_line.rs
+++ b/graphql/src/schema/types/stocktake_line.rs
@@ -65,18 +65,17 @@ impl StocktakeLineNode {
         &self.line.line.item_id
     }
 
-    pub async fn item(&self, ctx: &Context<'_>) -> Result<Option<ItemNode>> {
+    pub async fn item(&self, ctx: &Context<'_>) -> Result<ItemNode> {
         let loader = ctx.get_loader::<DataLoader<ItemLoader>>();
         let item_option = loader.load_one(self.line.line.item_id.clone()).await?;
-        let item = item_option.ok_or(
+
+        item_option.map(ItemNode::from_domain).ok_or(
             StandardGraphqlError::InternalError(format!(
                 "Cannot find item_id {} for stocktake line id {}",
                 self.line.line.item_id, self.line.line.id
             ))
             .extend(),
-        )?;
-
-        Ok(Some(ItemNode::from(item)))
+        )
     }
 
     pub async fn batch(&self) -> &Option<String> {

--- a/server/tests/graphql/invoice_query.rs
+++ b/server/tests/graphql/invoice_query.rs
@@ -76,7 +76,7 @@ mod graphql {
                             }
                         })).collect::<Vec<serde_json::Value>>(),
                 },
-                "status": InvoiceNodeStatus::from(InvoiceStatus::from(full_invoice.invoice.status.clone())),
+                "status": InvoiceNodeStatus::from_domain(&InvoiceStatus::from(full_invoice.invoice.status.clone())),
             },
         });
         assert_graphql_query!(&settings, &query, &variables, &expected, None);


### PR DESCRIPTION
https://github.com/openmsupply/remote-server/issues/781
closes #802 (this was also done here since from was removed for item and required a change in resolvers)

Aftermath from removing types in types/mod.rs, i still kept NodeError for now. And most areas that I touched i tried to use latest pattern (even if it's out of scope of this issue, but will be done as part of the epic)

Also haven't yet relocated things from types to queries (like some sorts/filters, etc)

Added map_filter macro to help 