### PR TITLE
836 Unblock batch delete

### DIFF
--- a/graphql/graphql_schema/schema.graphql
+++ b/graphql/graphql_schema/schema.graphql
@@ -115,13 +115,13 @@ type CannotDeleteInvoiceWithLines implements DeleteErrorInterface & DeleteInboun
 type CannotDeleteRequisitionWithLines implements DeleteRequestRequisitionErrorInterface {
 	description: String!
 }
-type CannotEditInvoice implements InsertOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteInboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & DeleteErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & UpdateInboundShipmentErrorInterface & DeleteInboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface {
+type CannotEditInvoice implements UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteInboundShipmentErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & DeleteErrorInterface {
 	description: String!
 }
-type CannotEditRequisition implements SupplyRequestedQuantityErrorInterface & DeleteRequestRequisitionErrorInterface & DeleteRequestRequisitionLineErrorInterface & UpdateResponseRequisitionErrorInterface & UpdateRequestRequisitionErrorInterface & CreateRequisitionShipmentErrorInterface & AddFromMasterListErrorInterface & UpdateResponseRequisitionLineErrorInterface & InsertRequestRequisitionLineErrorInterface & UpdateRequestRequisitionLineErrorInterface & UseSuggestedQuantityErrorInterface {
+type CannotEditRequisition implements DeleteRequestRequisitionLineErrorInterface & DeleteRequestRequisitionErrorInterface & UseSuggestedQuantityErrorInterface & AddFromMasterListErrorInterface & UpdateResponseRequisitionErrorInterface & CreateRequisitionShipmentErrorInterface & InsertRequestRequisitionLineErrorInterface & UpdateRequestRequisitionErrorInterface & UpdateResponseRequisitionLineErrorInterface & UpdateRequestRequisitionLineErrorInterface & SupplyRequestedQuantityErrorInterface {
 	description: String!
 }
-type CannotReverseInvoiceStatus implements UpdateInboundShipmentErrorInterface & UpdateErrorInterface {
+type CannotReverseInvoiceStatus implements UpdateErrorInterface & UpdateInboundShipmentErrorInterface {
 	description: String!
 }
 type CreateRequisitionShipmentError {
@@ -134,7 +134,7 @@ input CreateRequisitionShipmentInput {
 	responseRequisitionId: String!
 }
 union CreateRequisitionShipmentResponse = | CreateRequisitionShipmentError | InvoiceNode
-type DatabaseError implements DeleteLocationErrorInterface & UpdateLocationErrorInterface & UpdateInboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & AuthTokenErrorInterface & DeleteInboundShipmentErrorInterface & UpdateErrorInterface & NodeErrorInterface & InsertOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & InsertLocationErrorInterface & InsertErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface & DeleteErrorInterface & UserRegisterErrorInterface & InsertInboundShipmentLineErrorInterface & RefreshTokenErrorInterface & InsertInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface {
+type DatabaseError implements RefreshTokenErrorInterface & UpdateInboundShipmentLineErrorInterface & NodeErrorInterface & InsertInboundShipmentLineErrorInterface & UpdateErrorInterface & DeleteLocationErrorInterface & InsertErrorInterface & InsertOutboundShipmentLineErrorInterface & UserRegisterErrorInterface & AuthTokenErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentErrorInterface & UpdateInboundShipmentErrorInterface & DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & InsertLocationErrorInterface & DeleteErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & UpdateLocationErrorInterface & UpdateOutboundShipmentLineErrorInterface {
 	description: String!
 	fullError: String!
 }
@@ -339,7 +339,7 @@ enum ForeignKey {
 	locationId
 	requisitionId
 }
-type ForeignKeyError implements UpdateInboundShipmentLineErrorInterface & InsertInboundShipmentErrorInterface & UpdateInboundShipmentErrorInterface & UpdateResponseRequisitionLineErrorInterface & InsertErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentUnallocatedLineErrorInterface & InsertRequestRequisitionLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteInboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & UpdateErrorInterface & InsertOutboundShipmentLineErrorInterface & UpdateRequestRequisitionLineErrorInterface {
+type ForeignKeyError implements InsertErrorInterface & UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentUnallocatedLineErrorInterface & UpdateInboundShipmentErrorInterface & InsertOutboundShipmentLineErrorInterface & UpdateRequestRequisitionLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentErrorInterface & UpdateErrorInterface & DeleteOutboundShipmentLineErrorInterface & InsertRequestRequisitionLineErrorInterface & UpdateResponseRequisitionLineErrorInterface & DeleteInboundShipmentLineErrorInterface {
 	description: String!
 	key: ForeignKey!
 }
@@ -549,7 +549,7 @@ type InsertStocktakeResponseWithId {
 	id: String!
 	response: InsertStocktakeResponse!
 }
-type InternalError implements UpdateLocationErrorInterface & InsertLocationErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & AuthTokenErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & LogoutErrorInterface & UserRegisterErrorInterface & RefreshTokenErrorInterface {
+type InternalError implements UpdateOutboundShipmentServiceLineErrorInterface & UserRegisterErrorInterface & InsertLocationErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & DeleteErrorInterface & AuthTokenErrorInterface & UpdateLocationErrorInterface & DeleteInboundShipmentErrorInterface & LogoutErrorInterface & RefreshTokenErrorInterface {
 	description: String!
 	fullError: String!
 }
@@ -571,7 +571,7 @@ type InvoiceCountsSummary {
 	today: Int!
 	thisWeek: Int!
 }
-type InvoiceDoesNotBelongToCurrentStore implements DeleteOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface & DeleteErrorInterface & DeleteInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & DeleteInboundShipmentErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentLineErrorInterface & UpdateInboundShipmentErrorInterface {
+type InvoiceDoesNotBelongToCurrentStore implements UpdateInboundShipmentErrorInterface & InsertInboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface & DeleteErrorInterface & UpdateInboundShipmentLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteInboundShipmentErrorInterface {
 	description: String!
 }
 input InvoiceFilterInput {
@@ -595,7 +595,7 @@ input InvoiceFilterInput {
 type InvoiceIsNotEditable implements UpdateErrorInterface {
 	description: String!
 }
-type InvoiceLineBelongsToAnotherInvoice implements UpdateOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & UpdateInboundShipmentLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteInboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface {
+type InvoiceLineBelongsToAnotherInvoice implements DeleteOutboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface {
 	description: String!
 }
 type InvoiceLineConnector {
@@ -1005,10 +1005,10 @@ type NotARefreshToken implements RefreshTokenErrorInterface {
 type NotAServiceItem implements InsertOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface {
 	description: String!
 }
-type NotAnInboundShipment implements UpdateInboundShipmentLineErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteInboundShipmentErrorInterface & UpdateInboundShipmentErrorInterface & InsertInboundShipmentLineErrorInterface {
+type NotAnInboundShipment implements UpdateInboundShipmentLineErrorInterface & DeleteInboundShipmentErrorInterface & InsertInboundShipmentLineErrorInterface & UpdateInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface {
 	description: String!
 }
-type NotAnOutboundShipment implements InsertOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteErrorInterface & UpdateOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface {
+type NotAnOutboundShipment implements InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteErrorInterface {
 	description: String!
 }
 type NotAnOutboundShipmentError implements UpdateErrorInterface {
@@ -1022,14 +1022,14 @@ type NotEnoughStockForReduction implements InsertOutboundShipmentLineErrorInterf
 type NothingRemainingToSupply implements CreateRequisitionShipmentErrorInterface {
 	description: String!
 }
-type OtherPartyCannotBeThisStoreError implements UpdateErrorInterface & InsertErrorInterface {
+type OtherPartyCannotBeThisStoreError implements InsertErrorInterface & UpdateErrorInterface {
 	description: String!
 }
 type OtherPartyNotACustomerError implements UpdateErrorInterface & InsertErrorInterface {
 	description: String!
 	otherParty: NameNode!
 }
-type OtherPartyNotASupplier implements UpdateInboundShipmentErrorInterface & InsertRequestRequisitionErrorInterface & InsertInboundShipmentErrorInterface {
+type OtherPartyNotASupplier implements InsertRequestRequisitionErrorInterface & InsertInboundShipmentErrorInterface & UpdateInboundShipmentErrorInterface {
 	description: String!
 	otherParty: NameNode!
 }
@@ -1098,7 +1098,7 @@ type Queries {
 	requisitions(storeId: String!, page: PaginationInput, filter: RequisitionFilterInput, sort: [RequisitionSortInput!]): RequisitionsResponse!
 	requisitionByNumber(storeId: String!, requisitionNumber: Int!, type: RequisitionNodeType!): RequisitionResponse!
 }
-type RangeError implements InsertOutboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface {
+type RangeError implements UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface {
 	description: String!
 	field: RangeField!
 	max: Int
@@ -1109,16 +1109,16 @@ enum RangeField {
 	numberOfPacks
 	packSize
 }
-type RecordAlreadyExist implements InsertOutboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & InsertLocationErrorInterface & InsertErrorInterface & InsertInboundShipmentErrorInterface & UserRegisterErrorInterface {
+type RecordAlreadyExist implements InsertInboundShipmentLineErrorInterface & UserRegisterErrorInterface & InsertLocationErrorInterface & InsertInboundShipmentErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertErrorInterface & InsertOutboundShipmentServiceLineErrorInterface {
 	description: String!
 }
 type RecordBelongsToAnotherStore implements UpdateLocationErrorInterface & DeleteLocationErrorInterface {
 	description: String!
 }
-type RecordDoesNotExist implements CreateRequisitionShipmentErrorInterface & UpdateRequestRequisitionErrorInterface & DeleteRequestRequisitionErrorInterface & UseSuggestedQuantityErrorInterface & UpdateResponseRequisitionLineErrorInterface & SupplyRequestedQuantityErrorInterface & UpdateOutboundShipmentUnallocatedLineErrorInterface & DeleteOutboundShipmentUnallocatedLineErrorInterface & AddFromMasterListErrorInterface & UpdateRequestRequisitionLineErrorInterface & UpdateResponseRequisitionErrorInterface & DeleteRequestRequisitionLineErrorInterface {
+type RecordDoesNotExist implements CreateRequisitionShipmentErrorInterface & DeleteRequestRequisitionErrorInterface & DeleteRequestRequisitionLineErrorInterface & UseSuggestedQuantityErrorInterface & UpdateOutboundShipmentUnallocatedLineErrorInterface & AddFromMasterListErrorInterface & UpdateRequestRequisitionErrorInterface & UpdateResponseRequisitionErrorInterface & DeleteOutboundShipmentUnallocatedLineErrorInterface & UpdateRequestRequisitionLineErrorInterface & UpdateResponseRequisitionLineErrorInterface & SupplyRequestedQuantityErrorInterface {
 	description: String!
 }
-type RecordNotFound implements DeleteInboundShipmentErrorInterface & UpdateLocationErrorInterface & NodeErrorInterface & UpdateInboundShipmentErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & UpdateErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteErrorInterface & UpdateInboundShipmentLineErrorInterface & DeleteLocationErrorInterface {
+type RecordNotFound implements DeleteOutboundShipmentLineErrorInterface & DeleteLocationErrorInterface & UpdateErrorInterface & NodeErrorInterface & DeleteErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateInboundShipmentErrorInterface & UpdateLocationErrorInterface & DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface {
 	description: String!
 }
 type RefreshToken {
@@ -1285,7 +1285,7 @@ type StockCounts {
 	expired: Int!
 	expiringSoon: Int!
 }
-type StockLineAlreadyExistsInInvoice implements InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface {
+type StockLineAlreadyExistsInInvoice implements UpdateOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface {
 	description: String!
 	line: InvoiceLineResponse!
 }

--- a/graphql/invoice/src/mutations/inbound_shipment/delete.rs
+++ b/graphql/invoice/src/mutations/inbound_shipment/delete.rs
@@ -2,7 +2,7 @@ use async_graphql::*;
 use domain::inbound_shipment::DeleteInboundShipment;
 
 use graphql_core::simple_generic_errors::{
-    CannotEditInvoice, InvoiceDoesNotBelongToCurrentStore, NotAnInboundShipment,
+    CannotEditInvoice, InternalError, InvoiceDoesNotBelongToCurrentStore, NotAnInboundShipment,
 };
 use graphql_core::simple_generic_errors::{DatabaseError, RecordNotFound};
 use graphql_types::generic_errors::CannotDeleteInvoiceWithLines;
@@ -48,6 +48,7 @@ pub enum DeleteErrorInterface {
     NotAnInboundShipment(NotAnInboundShipment),
     InvoiceDoesNotBelongToCurrentStore(InvoiceDoesNotBelongToCurrentStore),
     CannotDeleteInvoiceWithLines(CannotDeleteInvoiceWithLines),
+    InternalError(InternalError),
 }
 
 impl From<DeleteInboundShipmentInput> for DeleteInboundShipment {
@@ -80,6 +81,12 @@ impl From<DeleteInboundShipmentError> for DeleteInboundShipmentResponse {
                 OutError::CannotDeleteInvoiceWithLines(CannotDeleteInvoiceWithLines(
                     InvoiceLineConnector::from_vec(lines),
                 ))
+            }
+            DeleteInboundShipmentError::LineDeleteError { line_id, error } => {
+                OutError::InternalError(InternalError(format!(
+                    "failed to delete line {} with error {:#?}",
+                    line_id, error
+                )))
             }
         };
 

--- a/graphql/invoice/src/mutations/outbound_shipment/delete.rs
+++ b/graphql/invoice/src/mutations/outbound_shipment/delete.rs
@@ -1,6 +1,6 @@
 use graphql_core::simple_generic_errors::{
-    CannotEditInvoice, DatabaseError, InvoiceDoesNotBelongToCurrentStore, NotAnOutboundShipment,
-    RecordNotFound,
+    CannotEditInvoice, DatabaseError, InternalError, InvoiceDoesNotBelongToCurrentStore,
+    NotAnOutboundShipment, RecordNotFound,
 };
 use graphql_types::{
     generic_errors::CannotDeleteInvoiceWithLines,
@@ -42,6 +42,7 @@ pub enum DeleteErrorInterface {
     NotAnOutboundShipment(NotAnOutboundShipment),
     InvoiceDoesNotBelongToCurrentStore(InvoiceDoesNotBelongToCurrentStore),
     CannotDeleteInvoiceWithLines(CannotDeleteInvoiceWithLines),
+    InternalError(InternalError),
     DatabaseError(DatabaseError),
 }
 
@@ -68,6 +69,12 @@ impl From<DeleteOutboundShipmentError> for DeleteOutboundShipmentResponse {
             }
             DeleteOutboundShipmentError::NotAnOutboundShipment => {
                 OutError::NotAnOutboundShipment(NotAnOutboundShipment {})
+            }
+            DeleteOutboundShipmentError::LineDeleteError { line_id, error } => {
+                OutError::InternalError(InternalError(format!(
+                    "failed to delete line {} with error {:#?}",
+                    line_id, error
+                )))
             }
         };
 

--- a/graphql/requisition/src/mutations/request_requisition/delete.rs
+++ b/graphql/requisition/src/mutations/request_requisition/delete.rs
@@ -100,6 +100,7 @@ fn map_error(error: ServiceError) -> Result<DeleteErrorInterface> {
         ServiceError::NotThisStoreRequisition => BadUserInput(formatted_error),
         ServiceError::NotARequestRequisition => BadUserInput(formatted_error),
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
+        ServiceError::LineDeleteError { .. } => InternalError(formatted_error),
     };
 
     Err(graphql_error.extend())

--- a/graphql/stocktake/src/mutations/delete.rs
+++ b/graphql/stocktake/src/mutations/delete.rs
@@ -68,6 +68,9 @@ pub fn do_delete_stocktake(
                 ServiceError::CannotEditFinalised => {
                     StandardGraphqlError::BadUserInput(formatted_error)
                 }
+                ServiceError::LineDeleteError { .. } => {
+                    StandardGraphqlError::InternalError(formatted_error)
+                }
             };
             Err(graphql_error.extend())
         }

--- a/server/tests/graphql/inbound_shipment_delete.rs
+++ b/server/tests/graphql/inbound_shipment_delete.rs
@@ -1,5 +1,5 @@
 mod graphql {
-    use crate::graphql::common::{assert_matches, get_invoice_lines_inline};
+    use crate::graphql::common::assert_matches;
     use crate::graphql::common::{
         assert_unwrap_enum, assert_unwrap_optional_key, get_invoice_inline,
     };
@@ -57,7 +57,6 @@ mod graphql {
             setup_all("test_delete_inbound_shipment_query", MockDataInserts::all()).await;
 
         // Setup
-        let invoice_with_lines_id = "inbound_shipment_a";
         let empty_draft_invoice_id = "empty_draft_inbound_shipment";
 
         let verified_inbound_shipment = get_invoice_inline!(
@@ -71,7 +70,6 @@ mod graphql {
             InvoiceFilter::new().r#type(InvoiceType::OutboundShipment.equal_to()),
             &connection
         );
-        let lines_in_invoice = get_invoice_lines_inline!(invoice_with_lines_id, &connection);
 
         let base_variables = delete::Variables {
             id: empty_draft_invoice_id.to_string(),
@@ -122,26 +120,29 @@ mod graphql {
             },)
         );
 
+        // TODO https://github.com/openmsupply/remote-server/issues/839
+        // let invoice_with_lines_id = "inbound_shipment_a";
+        // let lines_in_invoice = get_invoice_lines_inline!(invoice_with_lines_id, &connection);
         // Test CannotDeleteInvoiceWithLines
 
-        let mut variables = base_variables.clone();
-        variables.id = invoice_with_lines_id.to_string();
+        // let mut variables = base_variables.clone();
+        // variables.id = invoice_with_lines_id.to_string();
 
-        let query = Delete::build_query(variables);
-        let response: Response<delete::ResponseData> = get_gql_result(&settings, query).await;
+        // let query = Delete::build_query(variables);
+        // let response: Response<delete::ResponseData> = get_gql_result(&settings, query).await;
 
-        let error_variant = assert_unwrap_error!(response);
-        let error = assert_unwrap_enum!(error_variant, CannotDeleteInvoiceWithLines);
-        let lines = error.lines.nodes;
+        // let error_variant = assert_unwrap_error!(response);
+        // let error = assert_unwrap_enum!(error_variant, CannotDeleteInvoiceWithLines);
+        // let lines = error.lines.nodes;
 
-        let mut api_lines: Vec<String> = lines.into_iter().map(|line| line.id).collect();
+        // let mut api_lines: Vec<String> = lines.into_iter().map(|line| line.id).collect();
 
-        let mut db_lines: Vec<String> = lines_in_invoice.into_iter().map(|line| line.id).collect();
+        // let mut db_lines: Vec<String> = lines_in_invoice.into_iter().map(|line| line.id).collect();
 
-        api_lines.sort();
-        db_lines.sort();
+        // api_lines.sort();
+        // db_lines.sort();
 
-        assert_eq!(api_lines, db_lines);
+        // assert_eq!(api_lines, db_lines);
 
         // Test Success
 

--- a/server/tests/graphql/outbound_shipment_delete.rs
+++ b/server/tests/graphql/outbound_shipment_delete.rs
@@ -69,19 +69,20 @@ mod graphql {
         );
         assert_graphql_query!(&settings, query, &variables, &expected, None);
 
+        // TODO https://github.com/openmsupply/remote-server/issues/839
         // CannotDeleteInvoiceWithLines
-        let variables = Some(json!({
-          "id": "outbound_shipment_a"
-        }));
-        let expected = json!({
-            "deleteOutboundShipment": {
-              "error": {
-                "__typename": "CannotDeleteInvoiceWithLines"
-              }
-            }
-          }
-        );
-        assert_graphql_query!(&settings, query, &variables, &expected, None);
+        // let variables = Some(json!({
+        //   "id": "outbound_shipment_a"
+        // }));
+        // let expected = json!({
+        //     "deleteOutboundShipment": {
+        //       "error": {
+        //         "__typename": "CannotDeleteInvoiceWithLines"
+        //       }
+        //     }
+        //   }
+        // );
+        // assert_graphql_query!(&settings, query, &variables, &expected, None);
 
         // Test succeeding delete
         let variables = Some(json!({

--- a/service/src/invoice/inbound_shipment/delete/mod.rs
+++ b/service/src/invoice/inbound_shipment/delete/mod.rs
@@ -1,11 +1,21 @@
-use domain::{inbound_shipment::DeleteInboundShipment, invoice_line::InvoiceLine};
-use repository::{InvoiceRepository, RepositoryError, StorageConnectionManager, TransactionError};
+use domain::{
+    inbound_shipment::{DeleteInboundShipment, DeleteInboundShipmentLine},
+    invoice_line::InvoiceLine,
+    EqualFilter,
+};
+use repository::{
+    InvoiceLineFilter, InvoiceLineRepository, InvoiceRepository, RepositoryError,
+    StorageConnectionManager, TransactionError,
+};
 
 mod validate;
 
 use validate::validate;
 
-use crate::WithDBError;
+use crate::{
+    invoice_line::{delete_inbound_shipment_line, DeleteInboundShipmentLineError},
+    WithDBError,
+};
 
 pub fn delete_inbound_shipment(
     connection_manager: &StorageConnectionManager,
@@ -15,6 +25,26 @@ pub fn delete_inbound_shipment(
     connection
         .transaction_sync(|connection| {
             validate(&input, &connection)?;
+
+            // TODO https://github.com/openmsupply/remote-server/issues/839
+            let lines = InvoiceLineRepository::new(&connection).query_by_filter(
+                InvoiceLineFilter::new().invoice_id(EqualFilter::equal_to(&input.id)),
+            )?;
+            for line in lines {
+                delete_inbound_shipment_line(
+                    connection_manager,
+                    DeleteInboundShipmentLine {
+                        id: line.id.clone(),
+                        invoice_id: input.id.clone(),
+                    },
+                )
+                .map_err(|error| DeleteInboundShipmentError::LineDeleteError {
+                    line_id: line.id,
+                    error,
+                })?;
+            }
+            // End TODO
+
             InvoiceRepository::new(&connection).delete(&input.id)?;
             Ok(())
         })
@@ -35,6 +65,10 @@ pub enum DeleteInboundShipmentError {
     NotAnInboundShipment,
     NotThisStoreInvoice,
     CannotEditFinalised,
+    LineDeleteError {
+        line_id: String,
+        error: DeleteInboundShipmentLineError,
+    },
     InvoiceLinesExists(Vec<InvoiceLine>),
 }
 

--- a/service/src/invoice/inbound_shipment/delete/validate.rs
+++ b/service/src/invoice/inbound_shipment/delete/validate.rs
@@ -1,6 +1,6 @@
 use crate::invoice::{
-    check_invoice_exists, check_invoice_is_editable, check_invoice_is_empty, check_invoice_type,
-    InvoiceDoesNotExist, InvoiceIsNotEditable, InvoiceLinesExist, WrongInvoiceType,
+    check_invoice_exists, check_invoice_is_editable, check_invoice_type, InvoiceDoesNotExist,
+    InvoiceIsNotEditable, InvoiceLinesExist, WrongInvoiceType,
 };
 use domain::{inbound_shipment::DeleteInboundShipment, invoice::InvoiceType};
 use repository::{schema::InvoiceRow, StorageConnection};
@@ -16,7 +16,8 @@ pub fn validate(
     // check_store(invoice, connection)?; InvoiceDoesNotBelongToCurrentStore
     check_invoice_type(&invoice, InvoiceType::InboundShipment)?;
     check_invoice_is_editable(&invoice)?;
-    check_invoice_is_empty(&input.id, connection)?;
+
+    // check_invoice_is_empty(&input.id, connection)?; https://github.com/openmsupply/remote-server/issues/839
 
     Ok(invoice)
 }

--- a/service/src/invoice/outbound_shipment/delete/mod.rs
+++ b/service/src/invoice/outbound_shipment/delete/mod.rs
@@ -1,11 +1,14 @@
-use domain::invoice_line::InvoiceLine;
-use repository::{InvoiceRepository, RepositoryError, StorageConnectionManager, TransactionError};
+use domain::{invoice_line::InvoiceLine, EqualFilter, outbound_shipment::DeleteOutboundShipmentLine};
+use repository::{
+    InvoiceLineFilter, InvoiceLineRepository, InvoiceRepository, RepositoryError,
+    StorageConnectionManager, TransactionError,
+};
 
 pub mod validate;
 
 use validate::validate;
 
-use crate::WithDBError;
+use crate::{invoice_line::{delete_outbound_shipment_line, DeleteOutboundShipmentLineError}, WithDBError};
 
 pub fn delete_outbound_shipment(
     connection_manager: &StorageConnectionManager,
@@ -14,6 +17,25 @@ pub fn delete_outbound_shipment(
     let connection = connection_manager.connection()?;
     connection.transaction_sync(|connection| {
         validate(&id, &connection)?;
+
+        // TODO https://github.com/openmsupply/remote-server/issues/839
+        let lines = InvoiceLineRepository::new(&connection)
+            .query_by_filter(InvoiceLineFilter::new().invoice_id(EqualFilter::equal_to(&id)))?;
+        for line in lines {
+            delete_outbound_shipment_line(
+                connection_manager,
+                DeleteOutboundShipmentLine {
+                    id: line.id.clone(),
+                    invoice_id: id.clone(),
+                },
+            )
+            .map_err(|error| DeleteOutboundShipmentError::LineDeleteError {
+                line_id: line.id,
+                error,
+            })?;
+        }
+        // End TODO
+
         InvoiceRepository::new(&connection).delete(&id)?;
         Ok(())
     })?;
@@ -26,6 +48,10 @@ pub enum DeleteOutboundShipmentError {
     NotThisStoreInvoice,
     CannotEditFinalised,
     InvoiceLinesExists(Vec<InvoiceLine>),
+    LineDeleteError {
+        line_id: String,
+        error: DeleteOutboundShipmentLineError,
+    },
     NotAnOutboundShipment,
 }
 

--- a/service/src/invoice/outbound_shipment/delete/validate.rs
+++ b/service/src/invoice/outbound_shipment/delete/validate.rs
@@ -2,8 +2,8 @@ use domain::invoice::InvoiceType;
 use repository::{schema::InvoiceRow, StorageConnection};
 
 use crate::invoice::{
-    check_invoice_exists, check_invoice_is_editable, check_invoice_is_empty, check_invoice_type,
-    InvoiceDoesNotExist, InvoiceIsNotEditable, InvoiceLinesExist, WrongInvoiceType,
+    check_invoice_exists, check_invoice_is_editable, check_invoice_type, InvoiceDoesNotExist,
+    InvoiceIsNotEditable, InvoiceLinesExist, WrongInvoiceType,
 };
 
 use super::DeleteOutboundShipmentError;
@@ -17,7 +17,8 @@ pub fn validate(
     // check_store(invoice, connection)?; InvoiceDoesNotBelongToCurrentStore
     check_invoice_type(&invoice, InvoiceType::OutboundShipment)?;
     check_invoice_is_editable(&invoice)?;
-    check_invoice_is_empty(&id, connection)?;
+
+    // check_invoice_is_empty(&id, connection)?; https://github.com/openmsupply/remote-server/issues/839
 
     Ok(invoice)
 }

--- a/service/src/invoice_line/inbound_shipment_line/delete/mod.rs
+++ b/service/src/invoice_line/inbound_shipment_line/delete/mod.rs
@@ -37,6 +37,8 @@ pub fn delete_inbound_shipment_line(
         )?;
     Ok(line.id)
 }
+
+#[derive(Debug)]
 pub enum DeleteInboundShipmentLineError {
     LineDoesNotExist,
     DatabaseError(RepositoryError),

--- a/service/src/invoice_line/outbound_shipment_line/delete/mod.rs
+++ b/service/src/invoice_line/outbound_shipment_line/delete/mod.rs
@@ -49,6 +49,7 @@ pub fn delete_outbound_shipment_line(
     Ok(line.id)
 }
 
+#[derive(Debug)]
 pub enum DeleteOutboundShipmentLineError {
     LineDoesNotExist,
     DatabaseError(RepositoryError),

--- a/service/src/requisition/request_requisition/delete.rs
+++ b/service/src/requisition/request_requisition/delete.rs
@@ -1,10 +1,16 @@
 use crate::{
-    requisition::common::{check_requisition_exists, get_lines_for_requisition},
+    requisition::common::check_requisition_exists,
+    requisition_line::request_requisition_line::{
+        delete_request_requisition_line, DeleteRequestRequisitionLine,
+        DeleteRequestRequisitionLineError,
+    },
     service_provider::ServiceContext,
 };
+use domain::EqualFilter;
 use repository::{
     schema::{RequisitionRowStatus, RequisitionRowType},
-    RepositoryError, RequisitionRowRepository, StorageConnection,
+    RepositoryError, RequisitionLineFilter, RequisitionLineRepository, RequisitionRowRepository,
+    StorageConnection,
 };
 
 #[derive(Debug, PartialEq)]
@@ -20,6 +26,10 @@ pub enum DeleteRequestRequisitionError {
     CannotEditRequisition,
     CannotDeleteRequisitionWithLines,
     NotARequestRequisition,
+    LineDeleteError {
+        line_id: String,
+        error: DeleteRequestRequisitionLineError,
+    },
     DatabaseError(RepositoryError),
 }
 
@@ -34,6 +44,28 @@ pub fn delete_request_requisition(
         .connection
         .transaction_sync(|connection| {
             validate(connection, store_id, &input)?;
+
+            // TODO https://github.com/openmsupply/remote-server/issues/839
+            let lines = RequisitionLineRepository::new(&connection).query_by_filter(
+                RequisitionLineFilter::new().requisition_id(EqualFilter::equal_to(&input.id)),
+            )?;
+            for line in lines {
+                delete_request_requisition_line(
+                    ctx,
+                    store_id,
+                    DeleteRequestRequisitionLine {
+                        id: line.requisition_line_row.id.clone(),
+                    },
+                )
+                .map_err(|error| {
+                    DeleteRequestRequisitionError::LineDeleteError {
+                        line_id: line.requisition_line_row.id,
+                        error,
+                    }
+                })?;
+            }
+            // End TODO
+
             match RequisitionRowRepository::new(&connection).delete(&input.id) {
                 Ok(_) => Ok(input.id),
                 Err(error) => Err(OutError::DatabaseError(error)),
@@ -63,10 +95,10 @@ fn validate(
     if requisition_row.r#type != RequisitionRowType::Request {
         return Err(OutError::NotARequestRequisition);
     }
-
-    if !get_lines_for_requisition(connection, &input.id)?.is_empty() {
-        return Err(OutError::CannotDeleteRequisitionWithLines);
-    }
+    // TODO https://github.com/openmsupply/remote-server/issues/839
+    // if !get_lines_for_requisition(connection, &input.id)?.is_empty() {
+    //     return Err(OutError::CannotDeleteRequisitionWithLines);
+    // }
 
     Ok(())
 }
@@ -83,8 +115,7 @@ mod test_delete {
     use repository::{
         mock::{
             mock_draft_request_requisition_for_update_test,
-            mock_draft_response_requisition_for_update_test,
-            mock_request_draft_requisition_calculation_test, mock_sent_request_requisition,
+            mock_draft_response_requisition_for_update_test, mock_sent_request_requisition,
             MockDataInserts,
         },
         test_db::setup_all,
@@ -154,20 +185,20 @@ mod test_delete {
             ),
             Err(ServiceError::NotARequestRequisition)
         );
-
+        // TODO https://github.com/openmsupply/remote-server/issues/839
         // CannotDeleteRequisitionWithLines
-        assert_eq!(
-            service.delete_request_requisition(
-                &context,
-                "store_a",
-                DeleteRequestRequisition {
-                    id: mock_request_draft_requisition_calculation_test()
-                        .requisition
-                        .id,
-                },
-            ),
-            Err(ServiceError::CannotDeleteRequisitionWithLines)
-        );
+        // assert_eq!(
+        //     service.delete_request_requisition(
+        //         &context,
+        //         "store_a",
+        //         DeleteRequestRequisition {
+        //             id: mock_request_draft_requisition_calculation_test()
+        //                 .requisition
+        //                 .id,
+        //         },
+        //     ),
+        //     Err(ServiceError::CannotDeleteRequisitionWithLines)
+        // );
     }
 
     #[actix_rt::test]

--- a/service/src/stocktake/tests.rs
+++ b/service/src/stocktake/tests.rs
@@ -373,13 +373,14 @@ mod stocktake_test {
             .unwrap_err();
         assert_eq!(error, DeleteStocktakeError::InvalidStore);
 
+        // TODO https://github.com/openmsupply/remote-server/issues/839
         // error: StocktakeLinesExist
-        let store_a = mock_store_a();
-        let stocktake_a = mock_stocktake_a();
-        let error = service
-            .delete_stocktake(&context, &store_a.id, &stocktake_a.id)
-            .unwrap_err();
-        assert_eq!(error, DeleteStocktakeError::StocktakeLinesExist);
+        // let store_a = mock_store_a();
+        // let stocktake_a = mock_stocktake_a();
+        // let error = service
+        //     .delete_stocktake(&context, &store_a.id, &stocktake_a.id)
+        //     .unwrap_err();
+        // assert_eq!(error, DeleteStocktakeError::StocktakeLinesExist);
 
         // error: CannotEditFinalised
         let store_a = mock_store_a();


### PR DESCRIPTION
closes #836 

* Remove check for lines existing
* Add removal of lines when record is deleted
* Add TODO's with link to issue
* Had to butcher transactions in shipment delete (in sqlite can't have two concurrent transactions and line services take connection manager)

Didn't add test but did a manual test

Used internal error for now in older pattern graphql mapping.
