### PR TITLE
714 push core

### DIFF
--- a/android/src/android.rs
+++ b/android/src/android.rs
@@ -99,6 +99,8 @@ pub mod android {
                         username: "username".to_string(),
                         password: "password".to_string(),
                         interval: 300,
+                        central_server_site_id: 0,
+                        site_id: 1,
                     },
                     auth: AuthSettings {
                         // TODO:

--- a/android/src/android.rs
+++ b/android/src/android.rs
@@ -99,8 +99,9 @@ pub mod android {
                         username: "username".to_string(),
                         password: "password".to_string(),
                         interval: 300,
-                        central_server_site_id: 0,
-                        site_id: 1,
+                        central_server_site_id: 1,
+                        site_id: 2,
+                        site_hardware_id: "".to_string(),
                     },
                     auth: AuthSettings {
                         // TODO:

--- a/configuration/base.yaml
+++ b/configuration/base.yaml
@@ -5,6 +5,9 @@ sync:
   username: "username"
   password: "password"
   interval: 300
+  central_server_site_id: 1
+  site_id: 2
+  site_hardware_id: ""
 database:
   host: "localhost"
   port: 5432

--- a/repository/migrations/postgres/2022-02-11T15-00_create_key_value_store/up.sql
+++ b/repository/migrations/postgres/2022-02-11T15-00_create_key_value_store/up.sql
@@ -2,7 +2,8 @@ CREATE TYPE key_type AS ENUM (
     -- Cursor for pulling central records from the central server
     'CENTRAL_SYNC_PULL_CURSOR',
     'REMOTE_SYNC_INITILISATION_STARTED',
-    'REMOTE_SYNC_INITILISATION_FINISHED'
+    'REMOTE_SYNC_INITILISATION_FINISHED',
+    'REMOTE_SYNC_PUSH_CURSOR'
 );
 
 -- key value store, e.g. to store local server state

--- a/repository/src/db_diesel/changelog_row.rs
+++ b/repository/src/db_diesel/changelog_row.rs
@@ -29,4 +29,12 @@ impl<'a> ChangelogRepository<'a> {
             .load(&self.connection.connection)?;
         Ok(result)
     }
+
+    pub fn latest_changelog(&self) -> Result<Option<ChangelogRow>, RepositoryError> {
+        let result = changelog_deduped_dsl::changelog_deduped
+            .order(changelog_deduped_dsl::id.desc())
+            .first(&self.connection.connection)
+            .optional()?;
+        Ok(result)
+    }
 }

--- a/repository/src/db_diesel/number_row.rs
+++ b/repository/src/db_diesel/number_row.rs
@@ -16,6 +16,14 @@ impl<'a> NumberRowRepository<'a> {
         NumberRowRepository { connection }
     }
 
+    pub fn find_one_by_id(&self, id: &str) -> Result<Option<NumberRow>, RepositoryError> {
+        let result = number_dsl::number
+            .filter(number_dsl::id.eq(id))
+            .first(&self.connection.connection)
+            .optional()?;
+        Ok(result)
+    }
+
     pub fn find_one_by_type_and_store(
         &self,
         r#type: &NumberRowType,

--- a/repository/src/schema/key_value_store.rs
+++ b/repository/src/schema/key_value_store.rs
@@ -10,6 +10,7 @@ pub enum KeyValueType {
     /// Indicates if the remote data has been pulled and integrated from the central server
     /// Possible value: "true"
     RemoteSyncInitilisationFinished,
+    RemoteSyncPushCursor,
 }
 
 #[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq)]

--- a/server/src/settings.rs
+++ b/server/src/settings.rs
@@ -26,6 +26,8 @@ pub struct SyncSettings {
     pub username: String,
     pub password: String,
     pub interval: u64,
+    pub central_server_site_id: u32,
+    pub site_id: u32,
 }
 
 impl ServerSettings {

--- a/server/src/settings.rs
+++ b/server/src/settings.rs
@@ -28,6 +28,7 @@ pub struct SyncSettings {
     pub interval: u64,
     pub central_server_site_id: u32,
     pub site_id: u32,
+    pub site_hardware_id: String,
 }
 
 impl ServerSettings {

--- a/server/src/sync/central_data_synchroniser.rs
+++ b/server/src/sync/central_data_synchroniser.rs
@@ -151,7 +151,10 @@ impl CentralDataSynchroniser {
         Ok(())
     }
 
-    pub async fn pull(&self, connection: &StorageConnection) -> Result<(), CentralSyncError> {
+    pub async fn pull_and_integrate_records(
+        &self,
+        connection: &StorageConnection,
+    ) -> Result<(), CentralSyncError> {
         info!("Syncing central records...");
         self.pull_central_records(connection).await?;
         info!("Successfully synced central records");

--- a/server/src/sync/mod.rs
+++ b/server/src/sync/mod.rs
@@ -17,7 +17,7 @@ pub use synchroniser::Synchroniser;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-#[error("Failed to translate {table_name} sync record: {record}, error: {source}")]
+#[error("Failed to translate {table_name} sync record: {record}")]
 pub struct SyncTranslationError {
     pub table_name: &'static str,
     pub source: anyhow::Error,
@@ -26,12 +26,12 @@ pub struct SyncTranslationError {
 
 #[derive(Error, Debug)]
 pub enum SyncImportError {
-    #[error("Failed to translate sync records: {source}")]
+    #[error("Failed to translate sync records")]
     TranslationError {
         #[from]
         source: SyncTranslationError,
     },
-    #[error("Failed to integrate sync records: {source}")]
+    #[error("Failed to integrate sync records")]
     IntegrationError {
         source: RepositoryError,
         extra: String,

--- a/server/src/sync/remote_data_synchroniser.rs
+++ b/server/src/sync/remote_data_synchroniser.rs
@@ -88,6 +88,11 @@ impl RemoteDataSynchroniser {
 
         state.set_initial_remote_data_synced()?;
 
+        // Update push cursor after initial sync, i.e. set it to the end of the just received data
+        // so we only push new data to the central server
+        let cursor = state.get_push_cursor()?;
+        state.update_push_cursor(cursor + 1)?;
+
         Ok(())
     }
 

--- a/server/src/sync/remote_data_synchroniser.rs
+++ b/server/src/sync/remote_data_synchroniser.rs
@@ -369,7 +369,7 @@ mod tests {
         let central_server_site_id = 2;
         let sync = RemoteDataSynchroniser {
             sync_api_v5: SyncApiV5::new(url.clone(), credentials.clone(), client.clone()),
-            sync_api_v3: SyncApiV3::new(url, credentials, client, site_id).unwrap(),
+            sync_api_v3: SyncApiV3::new(url, credentials, client, "").unwrap(),
             site_id,
             central_server_site_id,
         };

--- a/server/src/sync/remote_data_synchroniser.rs
+++ b/server/src/sync/remote_data_synchroniser.rs
@@ -90,7 +90,10 @@ impl RemoteDataSynchroniser {
 
         // Update push cursor after initial sync, i.e. set it to the end of the just received data
         // so we only push new data to the central server
-        let cursor = state.get_push_cursor()?;
+        let cursor = ChangelogRepository::new(connection)
+            .latest_changelog()?
+            .map(|row| row.id)
+            .unwrap_or(0) as u32;
         state.update_push_cursor(cursor + 1)?;
 
         Ok(())

--- a/server/src/sync/remote_data_synchroniser.rs
+++ b/server/src/sync/remote_data_synchroniser.rs
@@ -186,13 +186,14 @@ impl RemoteDataSynchroniser {
                 "Remote push: Translate {} changelogs to push records...",
                 changelogs.len()
             );
+            let last_changelog_id = changelogs.last().map(|log| log.id).unwrap_or(cursor as i64);
             let records = translate_changelogs_to_push_records(connection, changelogs)?;
 
             self.sync_api_v3
                 .post_queued_records(self.site_id, self.central_server_site_id, &records)
                 .await?;
 
-            state.update_push_cursor(cursor + 1)?;
+            state.update_push_cursor(last_changelog_id as u32 + 1)?;
             info!(
                 "Remote push: {} records pushed to central server",
                 records.len()

--- a/server/src/sync/sync_api_v3.rs
+++ b/server/src/sync/sync_api_v3.rs
@@ -15,16 +15,28 @@ pub struct SyncApiV3 {
     credentials: SyncCredentials,
 }
 
-fn extra_headers(side_id: &str) -> anyhow::Result<HeaderMap> {
+fn extra_headers(side_id: u32) -> anyhow::Result<HeaderMap> {
     let mut headers = HeaderMap::new();
-    headers.insert("msupply-site-uuid", side_id.parse()?);
+    headers.insert("msupply-site-uuid", format!("{}", side_id).parse()?);
     headers.insert(CONTENT_LENGTH, "application/json".parse()?);
     headers.insert(ACCEPT, "application/json".parse()?);
     Ok(headers)
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct RemoteSyncRecordV3 {
+pub enum SyncTypeV3 {
+    #[serde(rename = "I")]
+    Insert,
+    #[serde(rename = "U")]
+    Update,
+    #[serde(rename = "D")]
+    Delete,
+    #[serde(rename = "M")]
+    Merge,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RemoteGetRecordV3 {
     #[serde(rename = "RecordType")]
     pub record_type: String,
     #[serde(rename = "SyncID")]
@@ -32,16 +44,33 @@ pub struct RemoteSyncRecordV3 {
     #[serde(rename = "KeyFieldID")]
     pub key_field_id: i64,
     #[serde(rename = "mergeIDtokeep")]
-    pub merge_id_tokeep: String,
+    pub merge_id_to_keep: String,
     #[serde(rename = "StoreID")]
     pub store_id: String,
     #[serde(rename = "RecordID")]
     pub record_id: String,
     #[serde(rename = "SyncType")]
-    pub sync_type: String, // e.g. "U"
+    pub sync_type: SyncTypeV3,
     #[serde(rename = "mergeIDtodelete")]
-    pub merge_id_todelete: String,
+    pub merge_id_to_delete: String,
     pub data: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RemotePostRecordV3 {
+    #[serde(rename = "SyncID")]
+    pub sync_id: String,
+    #[serde(rename = "RecordType")]
+    pub record_type: String,
+    #[serde(rename = "RecordID")]
+    pub record_id: String,
+    #[serde(rename = "SyncType")]
+    pub sync_type: SyncTypeV3,
+    #[serde(rename = "StoreID")]
+    pub store_id: Option<String>,
+    // if sync type is Delete data is None
+    #[serde(rename = "Data")]
+    pub data: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -55,7 +84,7 @@ impl SyncApiV3 {
         server_url: Url,
         credentials: SyncCredentials,
         client: Client,
-        site_id: &str,
+        site_id: u32,
     ) -> anyhow::Result<Self> {
         Ok(SyncApiV3 {
             server_url,
@@ -67,13 +96,10 @@ impl SyncApiV3 {
 
     pub async fn get_initial_dump(
         &self,
-        from_site: &str,
-        to_site: &str,
+        from_site: u32,
+        to_site: u32,
     ) -> anyhow::Result<serde_json::Value> {
-        let query = [
-            ("from_site", &from_site.to_string()),
-            ("to_site", &to_site.to_string()),
-        ];
+        let query = [("from_site", from_site), ("to_site", to_site)];
 
         let response = self
             .client
@@ -94,14 +120,14 @@ impl SyncApiV3 {
 
     pub async fn get_queued_records(
         &self,
-        from_site: &str,
-        to_site: &str,
+        from_site: u32,
+        to_site: u32,
         limit: u32,
-    ) -> anyhow::Result<Vec<RemoteSyncRecordV3>> {
+    ) -> anyhow::Result<Vec<RemoteGetRecordV3>> {
         let query = [
-            ("from_site", &from_site.to_string()),
-            ("to_site", &to_site.to_string()),
-            ("limit", &limit.to_string()),
+            ("from_site", from_site),
+            ("to_site", to_site),
+            ("limit", limit),
         ];
 
         let response = self
@@ -123,14 +149,11 @@ impl SyncApiV3 {
 
     pub async fn post_queued_records(
         &self,
-        from_site: &str,
-        to_site: &str,
-        records: &RemoteSyncRecordV3,
+        from_site: u32,
+        to_site: u32,
+        records: &Vec<RemotePostRecordV3>,
     ) -> anyhow::Result<serde_json::Value> {
-        let query = [
-            ("from_site", &from_site.to_string()),
-            ("to_site", &to_site.to_string()),
-        ];
+        let query = [("from_site", from_site), ("to_site", to_site)];
 
         let response = self
             .client
@@ -152,14 +175,11 @@ impl SyncApiV3 {
 
     pub async fn post_acknowledged_records(
         &self,
-        from_site: &str,
-        to_site: &str,
+        from_site: u32,
+        to_site: u32,
         records: &RemoteSyncAckV3,
     ) -> anyhow::Result<serde_json::Value> {
-        let query = [
-            ("from_site", &from_site.to_string()),
-            ("to_site", &to_site.to_string()),
-        ];
+        let query = [("from_site", from_site), ("to_site", to_site)];
 
         let response = self
             .client

--- a/server/src/sync/sync_api_v3.rs
+++ b/server/src/sync/sync_api_v3.rs
@@ -61,6 +61,7 @@ pub struct RemotePostRecordV3 {
     #[serde(rename = "SyncID")]
     pub sync_id: String,
     #[serde(rename = "RecordType")]
+    // Equivalent to the table name
     pub record_type: String,
     #[serde(rename = "RecordID")]
     pub record_id: String,
@@ -68,7 +69,7 @@ pub struct RemotePostRecordV3 {
     pub sync_type: SyncTypeV3,
     #[serde(rename = "StoreID")]
     pub store_id: Option<String>,
-    // if sync type is Delete data is None
+    // If sync type is Delete data is None
     #[serde(rename = "Data")]
     pub data: Option<serde_json::Value>,
 }

--- a/server/src/sync/synchroniser.rs
+++ b/server/src/sync/synchroniser.rs
@@ -56,7 +56,7 @@ impl Synchroniser {
         let url = Url::parse(&settings.url)?;
         let credentials = SyncCredentials::new(&settings.username, &settings.password);
         let sync_api_v5 = SyncApiV5::new(url.clone(), credentials.clone(), client.clone());
-        let sync_api_v3 = SyncApiV3::new(url, credentials, client, settings.site_id)?;
+        let sync_api_v3 = SyncApiV3::new(url, credentials, client, &settings.site_hardware_id)?;
         Ok(Synchroniser {
             remote_data: RemoteDataSynchroniser {
                 sync_api_v5: sync_api_v5.clone(),

--- a/server/src/sync/synchroniser.rs
+++ b/server/src/sync/synchroniser.rs
@@ -20,6 +20,32 @@ pub struct Synchroniser {
     remote_data: RemoteDataSynchroniser,
 }
 
+/// There are three types of data that is synced between the central server and the remote server:
+///
+/// 1) `central data`: Central data is managed by the central server and is readonly for the remote
+/// server. The remote server pulls the central data on a regular basis.
+/// 2) `remote data`: Remote data is managed by the remote server and is edited exclusively by the
+/// remote server. The remote server pushes (backs up) the remote data regularly to the central
+/// server. When a remote server instance is initialized the first time, existing remote data is
+/// fetched from the central server in an "initial pull", e.g. when a remote server has been
+/// re-installed and needs to fetch existing data.
+/// 3) `messages`: messages are dispatched by the central server between different sites (different
+/// remote servers) that are connected to the same central server. For example, a requisition
+/// request from site A to site B is dispatched from site A to site B.
+/// Messages are transmitted as remote data, i.e. they are pulled from the central server in the
+/// same way as remote data.
+/// Messages have the same data format as regular remote data and are only interpreted as messages
+/// by the receiving remote server, e.g. if data doesn't belong to the local remote server it must
+/// by a message.
+///
+/// Sync process:
+/// 1) Central data is regularly pulled from the central server.
+/// 2) If it is an initial remote server startup: pull existing remote data belonging to a remote
+/// server from the central server.
+/// After the initial pull the remote "data queue" turns into a "message queue" and messages are
+/// pulled from the central server through this queue.
+/// 3) Remote data is regularly pushed to the central server.
+///
 #[allow(unused_assignments)]
 impl Synchroniser {
     pub fn new(

--- a/server/src/sync/translation_remote/invoice.rs
+++ b/server/src/sync/translation_remote/invoice.rs
@@ -4,7 +4,7 @@ use repository::{
         ChangelogRow, ChangelogTableName, InvoiceRow, InvoiceRowStatus, InvoiceRowType,
         RemoteSyncBufferRow,
     },
-    InvoiceRepository, NameQueryRepository, StorageConnection,
+    EqualFilter, InvoiceRepository, NameFilter, NameQueryRepository, StorageConnection,
 };
 
 use serde::{Deserialize, Serialize};

--- a/server/src/sync/translation_remote/invoice_line.rs
+++ b/server/src/sync/translation_remote/invoice_line.rs
@@ -55,8 +55,8 @@ struct LegacyTransLineRow {
     note: Option<String>,
 }
 
-pub struct ShipmentLineTranslation {}
-impl RemotePullTranslation for ShipmentLineTranslation {
+pub struct InvoiceLineTranslation {}
+impl RemotePullTranslation for InvoiceLineTranslation {
     fn try_translate_pull(
         &self,
         connection: &StorageConnection,
@@ -92,13 +92,13 @@ impl RemotePullTranslation for ShipmentLineTranslation {
                 })
             }
         };
-        let line_type = to_shipment_line_type(&data._type).ok_or(SyncTranslationError {
+        let line_type = to_invoice_line_type(&data._type).ok_or(SyncTranslationError {
             table_name,
             source: anyhow::Error::msg(format!("Unsupported trans_line type: {:?}", data._type)),
             record: sync_record.data.clone(),
         })?;
         Ok(Some(IntegrationRecord::from_upsert(
-            IntegrationUpsertRecord::ShipmentLine(InvoiceLineRow {
+            IntegrationUpsertRecord::InvoiceLine(InvoiceLineRow {
                 id: data.ID,
                 invoice_id: data.transaction_ID,
                 item_id: data.item_ID,
@@ -123,7 +123,7 @@ impl RemotePullTranslation for ShipmentLineTranslation {
     }
 }
 
-fn to_shipment_line_type(_type: &LegacyTransLineType) -> Option<InvoiceLineRowType> {
+fn to_invoice_line_type(_type: &LegacyTransLineType) -> Option<InvoiceLineRowType> {
     let invoice_line_type = match _type {
         LegacyTransLineType::StockIn => InvoiceLineRowType::StockIn,
         LegacyTransLineType::StockOut => InvoiceLineRowType::StockOut,

--- a/server/src/sync/translation_remote/mod.rs
+++ b/server/src/sync/translation_remote/mod.rs
@@ -1,4 +1,4 @@
-use chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime};
+use chrono::{Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 use repository::schema::ChangelogTableName;
 use serde::{Deserialize, Deserializer};
 
@@ -67,4 +67,15 @@ pub fn date_and_time_to_datatime(date: NaiveDate, seconds: i64) -> NaiveDateTime
         date,
         NaiveTime::from_hms(0, 0, 0) + Duration::seconds(seconds),
     )
+}
+
+pub fn date_from_date_time(date_time: NaiveDateTime) -> NaiveDate {
+    NaiveDate::from_ymd(date_time.year(), date_time.month(), date_time.day())
+}
+
+/// returns the time part in seconds
+pub fn time_sec_from_date_time(date_time: NaiveDateTime) -> i64 {
+    let time = date_time.time();
+    let seconds = 60 * 60 * time.hour() + 60 * time.minute() + time.second();
+    seconds as i64
 }

--- a/server/src/sync/translation_remote/mod.rs
+++ b/server/src/sync/translation_remote/mod.rs
@@ -2,10 +2,10 @@ use chrono::{Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 use repository::schema::ChangelogTableName;
 use serde::{Deserialize, Deserializer};
 
+mod invoice;
+mod invoice_line;
 mod name_store_join;
 mod number;
-mod shipment;
-mod shipment_line;
 mod stock_line;
 mod stocktake;
 mod stocktake_line;

--- a/server/src/sync/translation_remote/mod.rs
+++ b/server/src/sync/translation_remote/mod.rs
@@ -11,6 +11,8 @@ mod stocktake;
 mod stocktake_line;
 
 pub mod pull;
+pub mod push;
+
 #[cfg(test)]
 pub mod test_data;
 

--- a/server/src/sync/translation_remote/mod.rs
+++ b/server/src/sync/translation_remote/mod.rs
@@ -69,12 +69,12 @@ pub fn date_and_time_to_datatime(date: NaiveDate, seconds: i64) -> NaiveDateTime
     )
 }
 
-pub fn date_from_date_time(date_time: NaiveDateTime) -> NaiveDate {
+pub fn date_from_date_time(date_time: &NaiveDateTime) -> NaiveDate {
     NaiveDate::from_ymd(date_time.year(), date_time.month(), date_time.day())
 }
 
 /// returns the time part in seconds
-pub fn time_sec_from_date_time(date_time: NaiveDateTime) -> i64 {
+pub fn time_sec_from_date_time(date_time: &NaiveDateTime) -> i64 {
     let time = date_time.time();
     let seconds = 60 * 60 * time.hour() + 60 * time.minute() + time.second();
     seconds as i64

--- a/server/src/sync/translation_remote/name_store_join.rs
+++ b/server/src/sync/translation_remote/name_store_join.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use crate::sync::SyncTranslationError;
 
 use super::{
-    IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation,
+    pull::{IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation},
     TRANSLATION_RECORD_NAME_STORE_JOIN,
 };
 
@@ -26,7 +26,7 @@ impl RemotePullTranslation for NameStoreJoinTranslation {
         &self,
         connection: &StorageConnection,
         sync_record: &RemoteSyncBufferRow,
-    ) -> Result<Option<super::IntegrationRecord>, SyncTranslationError> {
+    ) -> Result<Option<super::pull::IntegrationRecord>, SyncTranslationError> {
         let table_name = TRANSLATION_RECORD_NAME_STORE_JOIN;
 
         if sync_record.table_name != table_name {

--- a/server/src/sync/translation_remote/name_store_join.rs
+++ b/server/src/sync/translation_remote/name_store_join.rs
@@ -1,23 +1,24 @@
 use repository::{
-    schema::{NameStoreJoinRow, RemoteSyncBufferRow},
-    NameRepository, StorageConnection,
+    schema::{ChangelogRow, ChangelogTableName, NameStoreJoinRow, RemoteSyncBufferRow},
+    NameRepository, NameStoreJoinRepository, StorageConnection,
 };
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::sync::SyncTranslationError;
 
 use super::{
     pull::{IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation},
+    push::{to_push_translation_error, PushUpsertRecord, RemotePushUpsertTranslation},
     TRANSLATION_RECORD_NAME_STORE_JOIN,
 };
 
 #[allow(non_snake_case)]
-#[derive(Deserialize)]
-struct LegacyNameStoreJoinRow {
-    ID: String,
-    store_ID: String,
-    name_ID: String,
+#[derive(Deserialize, Serialize)]
+pub struct LegacyNameStoreJoinRow {
+    pub ID: String,
+    pub store_ID: String,
+    pub name_ID: String,
 }
 
 pub struct NameStoreJoinTranslation {}
@@ -67,5 +68,48 @@ impl RemotePullTranslation for NameStoreJoinTranslation {
                 name_is_supplier: name.is_supplier,
             }),
         )))
+    }
+}
+
+impl RemotePushUpsertTranslation for NameStoreJoinTranslation {
+    fn try_translate_push(
+        &self,
+        connection: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<Option<Vec<PushUpsertRecord>>, SyncTranslationError> {
+        if changelog.table_name != ChangelogTableName::NameStoreJoin {
+            return Ok(None);
+        }
+        let table_name = TRANSLATION_RECORD_NAME_STORE_JOIN;
+
+        let NameStoreJoinRow {
+            id,
+            name_id,
+            store_id,
+            name_is_customer: _,
+            name_is_supplier: _,
+        } = NameStoreJoinRepository::new(connection)
+            .find_one_by_id(&changelog.row_id)
+            .map_err(|err| to_push_translation_error(table_name, err.into(), changelog))?
+            .ok_or(to_push_translation_error(
+                table_name,
+                anyhow::Error::msg("Number row not found"),
+                changelog,
+            ))?;
+
+        let legacy_row = LegacyNameStoreJoinRow {
+            ID: id.clone(),
+            store_ID: store_id.clone(),
+            name_ID: name_id,
+        };
+
+        Ok(Some(vec![PushUpsertRecord {
+            sync_id: changelog.id,
+            store_id: Some(store_id),
+            table_name,
+            record_id: id,
+            data: serde_json::to_value(&legacy_row)
+                .map_err(|err| to_push_translation_error(table_name, err.into(), changelog))?,
+        }]))
     }
 }

--- a/server/src/sync/translation_remote/number.rs
+++ b/server/src/sync/translation_remote/number.rs
@@ -14,11 +14,11 @@ use super::{
 };
 
 #[allow(non_snake_case)]
-#[derive(Deserialize, Serialize)]
-struct LegacyNumberRow {
-    ID: String,
-    name: String,
-    value: i64,
+#[derive(Deserialize, Serialize, PartialEq)]
+pub struct LegacyNumberRow {
+    pub ID: String,
+    pub name: String,
+    pub value: i64,
 }
 
 pub struct NumberTranslation {}

--- a/server/src/sync/translation_remote/number.rs
+++ b/server/src/sync/translation_remote/number.rs
@@ -83,7 +83,7 @@ impl RemotePushUpsertTranslation for NumberTranslation {
                 changelog,
             ))?;
 
-        let name = match make_number_name(&r#type, &store_id) {
+        let name = match to_number_name(&r#type, &store_id) {
             Some(name) => name,
             None => return Ok(None),
         };
@@ -119,7 +119,7 @@ fn parse_number_name(value: String) -> Option<(NumberRowType, String)> {
     Some((number_type, store))
 }
 
-fn make_number_name(number_type: &NumberRowType, store_id: &str) -> Option<String> {
+fn to_number_name(number_type: &NumberRowType, store_id: &str) -> Option<String> {
     let number_str = match number_type {
         NumberRowType::InboundShipment => "supplier_invoice_number",
         NumberRowType::OutboundShipment => "customer_invoice_number",

--- a/server/src/sync/translation_remote/number.rs
+++ b/server/src/sync/translation_remote/number.rs
@@ -8,7 +8,8 @@ use serde::Deserialize;
 use crate::sync::SyncTranslationError;
 
 use super::{
-    IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation, TRANSLATION_RECORD_NUMBER,
+    pull::{IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation},
+    TRANSLATION_RECORD_NUMBER,
 };
 
 #[allow(non_snake_case)]

--- a/server/src/sync/translation_remote/pull.rs
+++ b/server/src/sync/translation_remote/pull.rs
@@ -12,9 +12,8 @@ use repository::{
 use crate::sync::{
     translation_remote::{
         invoice::InvoiceTranslation, invoice_line::InvoiceLineTranslation,
-        name_store_join::NameStoreJoinTranslation, number::NumberTranslation,
-        stock_line::StockLineTranslation, stocktake::StocktakeTranslation,
-        stocktake_line::StocktakeLineTranslation,
+        number::NumberTranslation, stock_line::StockLineTranslation,
+        stocktake::StocktakeTranslation, stocktake_line::StocktakeLineTranslation,
     },
     SyncImportError, SyncTranslationError,
 };
@@ -84,7 +83,8 @@ fn do_translation(
     let translations: Vec<Box<dyn RemotePullTranslation>> = vec![
         Box::new(NumberTranslation {}),
         Box::new(StockLineTranslation {}),
-        Box::new(NameStoreJoinTranslation {}),
+        // Don't pull name store joins for now
+        // Box::new(NameStoreJoinTranslation {}),
         Box::new(InvoiceTranslation {}),
         Box::new(InvoiceLineTranslation {}),
         Box::new(StocktakeTranslation {}),

--- a/server/src/sync/translation_remote/pull.rs
+++ b/server/src/sync/translation_remote/pull.rs
@@ -11,8 +11,8 @@ use repository::{
 
 use crate::sync::{
     translation_remote::{
+        invoice::InvoiceTranslation, invoice_line::InvoiceLineTranslation,
         name_store_join::NameStoreJoinTranslation, number::NumberTranslation,
-        shipment::ShipmentTranslation, shipment_line::ShipmentLineTranslation,
         stock_line::StockLineTranslation, stocktake::StocktakeTranslation,
         stocktake_line::StocktakeLineTranslation,
     },
@@ -24,8 +24,8 @@ pub enum IntegrationUpsertRecord {
     Number(NumberRow),
     StockLine(StockLineRow),
     NameStoreJoin(NameStoreJoinRow),
-    Shipment(InvoiceRow),
-    ShipmentLine(InvoiceLineRow),
+    Invoice(InvoiceRow),
+    InvoiceLine(InvoiceLineRow),
     Stocktake(StocktakeRow),
     StocktakeLine(StocktakeLineRow),
 }
@@ -85,8 +85,8 @@ fn do_translation(
         Box::new(NumberTranslation {}),
         Box::new(StockLineTranslation {}),
         Box::new(NameStoreJoinTranslation {}),
-        Box::new(ShipmentTranslation {}),
-        Box::new(ShipmentLineTranslation {}),
+        Box::new(InvoiceTranslation {}),
+        Box::new(InvoiceLineTranslation {}),
         Box::new(StocktakeTranslation {}),
         Box::new(StocktakeLineTranslation {}),
     ];
@@ -112,8 +112,8 @@ fn integrate_record(
         IntegrationUpsertRecord::NameStoreJoin(record) => {
             NameStoreJoinRepository::new(con).upsert_one(record)
         }
-        IntegrationUpsertRecord::Shipment(record) => InvoiceRepository::new(con).upsert_one(record),
-        IntegrationUpsertRecord::ShipmentLine(record) => {
+        IntegrationUpsertRecord::Invoice(record) => InvoiceRepository::new(con).upsert_one(record),
+        IntegrationUpsertRecord::InvoiceLine(record) => {
             InvoiceLineRowRepository::new(con).upsert_one(record)
         }
         IntegrationUpsertRecord::Stocktake(record) => {

--- a/server/src/sync/translation_remote/pull.rs
+++ b/server/src/sync/translation_remote/pull.rs
@@ -1,0 +1,160 @@
+use log::{info, warn};
+use repository::{
+    schema::{
+        InvoiceLineRow, InvoiceRow, NameStoreJoinRow, NumberRow, RemoteSyncBufferRow, StockLineRow,
+        StocktakeLineRow, StocktakeRow,
+    },
+    InvoiceLineRowRepository, InvoiceRepository, NameStoreJoinRepository, NumberRowRepository,
+    RepositoryError, StockLineRowRepository, StocktakeLineRowRepository, StocktakeRowRepository,
+    StorageConnection, TransactionError,
+};
+
+use crate::sync::{
+    translation_remote::{
+        name_store_join::NameStoreJoinTranslation, number::NumberTranslation,
+        shipment::ShipmentTranslation, shipment_line::ShipmentLineTranslation,
+        stock_line::StockLineTranslation, stocktake::StocktakeTranslation,
+        stocktake_line::StocktakeLineTranslation,
+    },
+    SyncImportError, SyncTranslationError,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum IntegrationUpsertRecord {
+    Number(NumberRow),
+    StockLine(StockLineRow),
+    NameStoreJoin(NameStoreJoinRow),
+    Shipment(InvoiceRow),
+    ShipmentLine(InvoiceLineRow),
+    Stocktake(StocktakeRow),
+    StocktakeLine(StocktakeLineRow),
+}
+#[derive(Debug, Clone, PartialEq)]
+pub struct IntegrationRecord {
+    pub upserts: Vec<IntegrationUpsertRecord>,
+}
+
+impl IntegrationRecord {
+    pub fn from_upsert(record: IntegrationUpsertRecord) -> Self {
+        IntegrationRecord {
+            upserts: vec![record],
+        }
+    }
+}
+
+pub trait RemotePullTranslation {
+    fn try_translate_pull(
+        &self,
+        connection: &StorageConnection,
+        sync_record: &RemoteSyncBufferRow,
+    ) -> Result<Option<IntegrationRecord>, SyncTranslationError>;
+}
+
+/// Imports sync records and writes them to the DB
+/// If needed data records are translated to the local DB schema.
+pub fn import_sync_pull_records(
+    connection: &StorageConnection,
+    records: &Vec<RemoteSyncBufferRow>,
+) -> Result<(), SyncImportError> {
+    let mut integration_records = IntegrationRecord {
+        upserts: Vec::new(),
+    };
+
+    info!(
+        "Translating {} remote sync buffer records...",
+        records.len()
+    );
+    for record in records {
+        do_translation(connection, &record, &mut integration_records)?;
+    }
+    info!("Succesfully translated remote sync buffer records");
+
+    info!("Storing integration remote records...");
+    store_integration_records(connection, &integration_records)?;
+    info!("Successfully stored integration remote records");
+
+    Ok(())
+}
+
+fn do_translation(
+    connection: &StorageConnection,
+    sync_record: &RemoteSyncBufferRow,
+    records: &mut IntegrationRecord,
+) -> Result<(), SyncTranslationError> {
+    let translations: Vec<Box<dyn RemotePullTranslation>> = vec![
+        Box::new(NumberTranslation {}),
+        Box::new(StockLineTranslation {}),
+        Box::new(NameStoreJoinTranslation {}),
+        Box::new(ShipmentTranslation {}),
+        Box::new(ShipmentLineTranslation {}),
+        Box::new(StocktakeTranslation {}),
+        Box::new(StocktakeLineTranslation {}),
+    ];
+    for translation in translations {
+        if let Some(mut result) = translation.try_translate_pull(connection, sync_record)? {
+            records.upserts.append(&mut result.upserts);
+            return Ok(());
+        }
+    }
+    warn!("Unhandled remote pull record: {:?}", sync_record);
+    Ok(())
+}
+
+fn integrate_record(
+    record: &IntegrationUpsertRecord,
+    con: &StorageConnection,
+) -> Result<(), RepositoryError> {
+    match &record {
+        IntegrationUpsertRecord::Number(record) => NumberRowRepository::new(con).upsert_one(record),
+        IntegrationUpsertRecord::StockLine(record) => {
+            StockLineRowRepository::new(con).upsert_one(record)
+        }
+        IntegrationUpsertRecord::NameStoreJoin(record) => {
+            NameStoreJoinRepository::new(con).upsert_one(record)
+        }
+        IntegrationUpsertRecord::Shipment(record) => InvoiceRepository::new(con).upsert_one(record),
+        IntegrationUpsertRecord::ShipmentLine(record) => {
+            InvoiceLineRowRepository::new(con).upsert_one(record)
+        }
+        IntegrationUpsertRecord::Stocktake(record) => {
+            StocktakeRowRepository::new(con).upsert_one(record)
+        }
+        IntegrationUpsertRecord::StocktakeLine(record) => {
+            StocktakeLineRowRepository::new(con).upsert_one(record)
+        }
+    }
+}
+
+fn store_integration_records(
+    connection: &StorageConnection,
+    integration_records: &IntegrationRecord,
+) -> Result<(), SyncImportError> {
+    connection
+        .transaction_sync(|con| {
+            for record in &integration_records.upserts {
+                // Integrate every record in a sub transaction. This is mainly for Postgres where the
+                // whole transaction fails when there is a DB error (not a problem in sqlite).
+                let sub_result =
+                    con.transaction_sync_etc(|sub_tx| integrate_record(record, sub_tx), false);
+                match sub_result {
+                    Ok(_) => Ok(()),
+                    Err(TransactionError::Inner(err @ RepositoryError::ForeignKeyViolation(_))) => {
+                        warn!("Failed to import ({}): {:?}", err, record);
+                        Ok(())
+                    }
+                    Err(err) => Err(SyncImportError::as_integration_error(
+                        RepositoryError::from(err),
+                        "",
+                    )),
+                }?;
+            }
+            Ok(())
+        })
+        .map_err(|error| match error {
+            TransactionError::Transaction { msg, level } => SyncImportError::as_integration_error(
+                RepositoryError::TransactionError { msg, level },
+                "",
+            ),
+            TransactionError::Inner(e) => e,
+        })
+}

--- a/server/src/sync/translation_remote/push.rs
+++ b/server/src/sync/translation_remote/push.rs
@@ -6,7 +6,8 @@ use repository::{
 
 use crate::sync::{
     translation_remote::{
-        name_store_join::NameStoreJoinTranslation, number::NumberTranslation, table_name_to_central,
+        name_store_join::NameStoreJoinTranslation, number::NumberTranslation,
+        stock_line::StockLineTranslation, stocktake::StocktakeTranslation, table_name_to_central,
     },
     SyncTranslationError,
 };
@@ -63,6 +64,8 @@ pub fn translate_changelog(
             let translations: Vec<Box<dyn RemotePushUpsertTranslation>> = vec![
                 Box::new(NumberTranslation {}),
                 Box::new(NameStoreJoinTranslation {}),
+                Box::new(StockLineTranslation {}),
+                Box::new(StocktakeTranslation {}),
             ];
             for translation in translations {
                 if let Some(records) = translation.try_translate_push(connection, changelog)? {

--- a/server/src/sync/translation_remote/push.rs
+++ b/server/src/sync/translation_remote/push.rs
@@ -6,9 +6,10 @@ use repository::{
 
 use crate::sync::{
     translation_remote::{
-        name_store_join::NameStoreJoinTranslation, number::NumberTranslation,
-        stock_line::StockLineTranslation, stocktake::StocktakeTranslation,
-        stocktake_line::StocktakeLineTranslation, table_name_to_central,
+        invoice::InvoiceTranslation, name_store_join::NameStoreJoinTranslation,
+        number::NumberTranslation, stock_line::StockLineTranslation,
+        stocktake::StocktakeTranslation, stocktake_line::StocktakeLineTranslation,
+        table_name_to_central,
     },
     SyncTranslationError,
 };
@@ -64,8 +65,9 @@ pub fn translate_changelog(
         ChangelogAction::Upsert => {
             let translations: Vec<Box<dyn RemotePushUpsertTranslation>> = vec![
                 Box::new(NumberTranslation {}),
-                Box::new(NameStoreJoinTranslation {}),
                 Box::new(StockLineTranslation {}),
+                Box::new(NameStoreJoinTranslation {}),
+                Box::new(InvoiceTranslation {}),
                 Box::new(StocktakeTranslation {}),
                 Box::new(StocktakeLineTranslation {}),
             ];

--- a/server/src/sync/translation_remote/push.rs
+++ b/server/src/sync/translation_remote/push.rs
@@ -5,7 +5,9 @@ use repository::{
 };
 
 use crate::sync::{
-    translation_remote::{number::NumberTranslation, table_name_to_central},
+    translation_remote::{
+        name_store_join::NameStoreJoinTranslation, number::NumberTranslation, table_name_to_central,
+    },
     SyncTranslationError,
 };
 
@@ -58,8 +60,10 @@ pub fn translate_changelog(
 ) -> Result<(), SyncTranslationError> {
     match changelog.row_action {
         ChangelogAction::Upsert => {
-            let translations: Vec<Box<dyn RemotePushUpsertTranslation>> =
-                vec![Box::new(NumberTranslation {})];
+            let translations: Vec<Box<dyn RemotePushUpsertTranslation>> = vec![
+                Box::new(NumberTranslation {}),
+                Box::new(NameStoreJoinTranslation {}),
+            ];
             for translation in translations {
                 if let Some(records) = translation.try_translate_push(connection, changelog)? {
                     for record in records {

--- a/server/src/sync/translation_remote/push.rs
+++ b/server/src/sync/translation_remote/push.rs
@@ -1,0 +1,84 @@
+use log::warn;
+use repository::{
+    schema::{ChangelogAction, ChangelogRow},
+    StorageConnection,
+};
+
+use crate::sync::{
+    translation_remote::{number::NumberTranslation, table_name_to_central},
+    SyncTranslationError,
+};
+
+// Translates push upserts
+pub trait RemotePushUpsertTranslation {
+    fn try_translate_push(
+        &self,
+        connection: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<Option<Vec<PushUpsertRecord>>, SyncTranslationError>;
+}
+
+pub struct PushUpsertRecord {
+    pub sync_id: i64,
+    pub store_id: Option<String>,
+    /// The translated table name
+    pub table_name: &'static str,
+    pub record_id: String,
+    pub data: serde_json::Value,
+}
+
+pub struct PushDeleteRecord {
+    pub sync_id: i64,
+    /// The translated table name
+    pub table_name: &'static str,
+    pub record_id: String,
+}
+
+pub enum PushRecord {
+    Upsert(PushUpsertRecord),
+    Delete(PushDeleteRecord),
+}
+
+pub fn to_push_translation_error(
+    table_name: &'static str,
+    err: anyhow::Error,
+    changelog: &ChangelogRow,
+) -> SyncTranslationError {
+    SyncTranslationError {
+        table_name,
+        source: err,
+        record: format!("{:?}", changelog),
+    }
+}
+
+pub fn translate_changelog(
+    connection: &StorageConnection,
+    changelog: &ChangelogRow,
+    results: &mut Vec<PushRecord>,
+) -> Result<(), SyncTranslationError> {
+    match changelog.row_action {
+        ChangelogAction::Upsert => {
+            let translations: Vec<Box<dyn RemotePushUpsertTranslation>> =
+                vec![Box::new(NumberTranslation {})];
+            for translation in translations {
+                if let Some(records) = translation.try_translate_push(connection, changelog)? {
+                    for record in records {
+                        results.push(PushRecord::Upsert(record));
+                    }
+                    return Ok(());
+                }
+            }
+        }
+        ChangelogAction::Delete => {
+            results.push(PushRecord::Delete(PushDeleteRecord {
+                sync_id: changelog.id,
+                table_name: table_name_to_central(&changelog.table_name),
+                record_id: changelog.row_id.clone(),
+            }));
+            return Ok(());
+        }
+    };
+
+    warn!("Unhandled push changlog: {:?}", changelog);
+    Ok(())
+}

--- a/server/src/sync/translation_remote/push.rs
+++ b/server/src/sync/translation_remote/push.rs
@@ -7,9 +7,9 @@ use repository::{
 use crate::sync::{
     translation_remote::{
         invoice::InvoiceTranslation, invoice_line::InvoiceLineTranslation,
-        name_store_join::NameStoreJoinTranslation, number::NumberTranslation,
-        stock_line::StockLineTranslation, stocktake::StocktakeTranslation,
-        stocktake_line::StocktakeLineTranslation, table_name_to_central,
+        number::NumberTranslation, stock_line::StockLineTranslation,
+        stocktake::StocktakeTranslation, stocktake_line::StocktakeLineTranslation,
+        table_name_to_central,
     },
     SyncTranslationError,
 };
@@ -66,7 +66,8 @@ pub fn translate_changelog(
             let translations: Vec<Box<dyn RemotePushUpsertTranslation>> = vec![
                 Box::new(NumberTranslation {}),
                 Box::new(StockLineTranslation {}),
-                Box::new(NameStoreJoinTranslation {}),
+                // Don't push name store joins for now
+                // Box::new(NameStoreJoinTranslation {}),
                 Box::new(InvoiceTranslation {}),
                 Box::new(InvoiceLineTranslation {}),
                 Box::new(StocktakeTranslation {}),

--- a/server/src/sync/translation_remote/push.rs
+++ b/server/src/sync/translation_remote/push.rs
@@ -6,10 +6,10 @@ use repository::{
 
 use crate::sync::{
     translation_remote::{
-        invoice::InvoiceTranslation, name_store_join::NameStoreJoinTranslation,
-        number::NumberTranslation, stock_line::StockLineTranslation,
-        stocktake::StocktakeTranslation, stocktake_line::StocktakeLineTranslation,
-        table_name_to_central,
+        invoice::InvoiceTranslation, invoice_line::InvoiceLineTranslation,
+        name_store_join::NameStoreJoinTranslation, number::NumberTranslation,
+        stock_line::StockLineTranslation, stocktake::StocktakeTranslation,
+        stocktake_line::StocktakeLineTranslation, table_name_to_central,
     },
     SyncTranslationError,
 };
@@ -68,6 +68,7 @@ pub fn translate_changelog(
                 Box::new(StockLineTranslation {}),
                 Box::new(NameStoreJoinTranslation {}),
                 Box::new(InvoiceTranslation {}),
+                Box::new(InvoiceLineTranslation {}),
                 Box::new(StocktakeTranslation {}),
                 Box::new(StocktakeLineTranslation {}),
             ];

--- a/server/src/sync/translation_remote/push.rs
+++ b/server/src/sync/translation_remote/push.rs
@@ -7,7 +7,8 @@ use repository::{
 use crate::sync::{
     translation_remote::{
         name_store_join::NameStoreJoinTranslation, number::NumberTranslation,
-        stock_line::StockLineTranslation, stocktake::StocktakeTranslation, table_name_to_central,
+        stock_line::StockLineTranslation, stocktake::StocktakeTranslation,
+        stocktake_line::StocktakeLineTranslation, table_name_to_central,
     },
     SyncTranslationError,
 };
@@ -66,6 +67,7 @@ pub fn translate_changelog(
                 Box::new(NameStoreJoinTranslation {}),
                 Box::new(StockLineTranslation {}),
                 Box::new(StocktakeTranslation {}),
+                Box::new(StocktakeLineTranslation {}),
             ];
             for translation in translations {
                 if let Some(records) = translation.try_translate_push(connection, changelog)? {

--- a/server/src/sync/translation_remote/shipment.rs
+++ b/server/src/sync/translation_remote/shipment.rs
@@ -9,8 +9,9 @@ use serde::Deserialize;
 use crate::sync::SyncTranslationError;
 
 use super::{
-    date_and_time_to_datatime, empty_str_as_option, zero_date_as_option, IntegrationRecord,
-    IntegrationUpsertRecord, RemotePullTranslation, TRANSLATION_RECORD_TRANSACT,
+    date_and_time_to_datatime, empty_str_as_option,
+    pull::{IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation},
+    zero_date_as_option, TRANSLATION_RECORD_TRANSACT,
 };
 
 #[derive(Deserialize, Debug)]
@@ -93,7 +94,7 @@ impl RemotePullTranslation for ShipmentTranslation {
         &self,
         connection: &StorageConnection,
         sync_record: &RemoteSyncBufferRow,
-    ) -> Result<Option<super::IntegrationRecord>, SyncTranslationError> {
+    ) -> Result<Option<IntegrationRecord>, SyncTranslationError> {
         let table_name = TRANSLATION_RECORD_TRANSACT;
         if sync_record.table_name != table_name {
             return Ok(None);

--- a/server/src/sync/translation_remote/shipment_line.rs
+++ b/server/src/sync/translation_remote/shipment_line.rs
@@ -6,11 +6,12 @@ use repository::{
 
 use serde::Deserialize;
 
-use crate::sync::{translation_remote::IntegrationUpsertRecord, SyncTranslationError};
+use crate::sync::SyncTranslationError;
 
 use super::{
-    empty_str_as_option, zero_date_as_option, IntegrationRecord, RemotePullTranslation,
-    TRANSLATION_RECORD_TRANS_LINE,
+    empty_str_as_option,
+    pull::{IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation},
+    zero_date_as_option, TRANSLATION_RECORD_TRANS_LINE,
 };
 
 #[derive(Deserialize, Debug)]
@@ -60,7 +61,7 @@ impl RemotePullTranslation for ShipmentLineTranslation {
         &self,
         connection: &StorageConnection,
         sync_record: &RemoteSyncBufferRow,
-    ) -> Result<Option<super::IntegrationRecord>, SyncTranslationError> {
+    ) -> Result<Option<IntegrationRecord>, SyncTranslationError> {
         let table_name = TRANSLATION_RECORD_TRANS_LINE;
         if sync_record.table_name != table_name {
             return Ok(None);

--- a/server/src/sync/translation_remote/stock_line.rs
+++ b/server/src/sync/translation_remote/stock_line.rs
@@ -9,8 +9,9 @@ use serde::Deserialize;
 use crate::sync::SyncTranslationError;
 
 use super::{
-    empty_str_as_option, zero_date_as_option, IntegrationRecord, IntegrationUpsertRecord,
-    RemotePullTranslation, TRANSLATION_RECORD_ITEM_LINE,
+    empty_str_as_option,
+    pull::{IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation},
+    zero_date_as_option, TRANSLATION_RECORD_ITEM_LINE,
 };
 
 #[allow(non_snake_case)]
@@ -40,7 +41,7 @@ impl RemotePullTranslation for StockLineTranslation {
         &self,
         _: &StorageConnection,
         sync_record: &RemoteSyncBufferRow,
-    ) -> Result<Option<super::IntegrationRecord>, SyncTranslationError> {
+    ) -> Result<Option<IntegrationRecord>, SyncTranslationError> {
         let table_name = TRANSLATION_RECORD_ITEM_LINE;
 
         if sync_record.table_name != table_name {

--- a/server/src/sync/translation_remote/stock_line.rs
+++ b/server/src/sync/translation_remote/stock_line.rs
@@ -1,38 +1,39 @@
 use chrono::NaiveDate;
 use repository::{
-    schema::{RemoteSyncBufferRow, StockLineRow},
-    StorageConnection,
+    schema::{ChangelogRow, ChangelogTableName, RemoteSyncBufferRow, StockLineRow},
+    StockLineRowRepository, StorageConnection,
 };
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::sync::SyncTranslationError;
 
 use super::{
     empty_str_as_option,
     pull::{IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation},
+    push::{to_push_translation_error, PushUpsertRecord, RemotePushUpsertTranslation},
     zero_date_as_option, TRANSLATION_RECORD_ITEM_LINE,
 };
 
 #[allow(non_snake_case)]
-#[derive(Deserialize)]
-struct LegacyStockLineRow {
-    ID: String,
-    store_ID: String,
-    item_ID: String,
+#[derive(Deserialize, Serialize)]
+pub struct LegacyStockLineRow {
+    pub ID: String,
+    pub store_ID: String,
+    pub item_ID: String,
     #[serde(deserialize_with = "empty_str_as_option")]
-    batch: Option<String>,
+    pub batch: Option<String>,
     #[serde(deserialize_with = "zero_date_as_option")]
-    expiry_date: Option<NaiveDate>,
-    hold: bool,
+    pub expiry_date: Option<NaiveDate>,
+    pub hold: bool,
     #[serde(deserialize_with = "empty_str_as_option")]
-    location_ID: Option<String>,
-    pack_size: i32,
-    available: i32,
-    quantity: i32,
-    cost_price: f64,
-    sell_price: f64,
-    note: Option<String>,
+    pub location_ID: Option<String>,
+    pub pack_size: i32,
+    pub available: i32,
+    pub quantity: i32,
+    pub cost_price: f64,
+    pub sell_price: f64,
+    pub note: Option<String>,
 }
 
 pub struct StockLineTranslation {}
@@ -74,5 +75,61 @@ impl RemotePullTranslation for StockLineTranslation {
                 note: data.note,
             }),
         )))
+    }
+}
+
+impl RemotePushUpsertTranslation for StockLineTranslation {
+    fn try_translate_push(
+        &self,
+        connection: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<Option<Vec<PushUpsertRecord>>, SyncTranslationError> {
+        if changelog.table_name != ChangelogTableName::StockLine {
+            return Ok(None);
+        }
+        let table_name = TRANSLATION_RECORD_ITEM_LINE;
+
+        let StockLineRow {
+            id,
+            item_id,
+            store_id,
+            location_id,
+            batch,
+            pack_size,
+            cost_price_per_pack,
+            sell_price_per_pack,
+            available_number_of_packs,
+            total_number_of_packs,
+            expiry_date,
+            on_hold,
+            note,
+        } = StockLineRowRepository::new(connection)
+            .find_one_by_id(&changelog.row_id)
+            .map_err(|err| to_push_translation_error(table_name, err.into(), changelog))?;
+
+        let legacy_row = LegacyStockLineRow {
+            ID: id.clone(),
+            store_ID: store_id.clone(),
+            item_ID: item_id,
+            batch,
+            expiry_date,
+            hold: on_hold,
+            location_ID: location_id,
+            pack_size,
+            available: available_number_of_packs,
+            quantity: total_number_of_packs,
+            cost_price: cost_price_per_pack,
+            sell_price: sell_price_per_pack,
+            note,
+        };
+
+        Ok(Some(vec![PushUpsertRecord {
+            sync_id: changelog.id,
+            store_id: Some(store_id),
+            table_name,
+            record_id: id,
+            data: serde_json::to_value(&legacy_row)
+                .map_err(|err| to_push_translation_error(table_name, err.into(), changelog))?,
+        }]))
     }
 }

--- a/server/src/sync/translation_remote/stocktake.rs
+++ b/server/src/sync/translation_remote/stocktake.rs
@@ -132,7 +132,7 @@ impl RemotePushUpsertTranslation for StocktakeTranslation {
             comment,
             invad_additions_ID: inventory_adjustment_id,
             serial_number: stocktake_number,
-            stock_take_created_date: date_from_date_time(created_datetime),
+            stock_take_created_date: date_from_date_time(&created_datetime),
         };
 
         Ok(Some(vec![PushUpsertRecord {

--- a/server/src/sync/translation_remote/stocktake.rs
+++ b/server/src/sync/translation_remote/stocktake.rs
@@ -1,20 +1,23 @@
 use chrono::NaiveDate;
 use repository::{
-    schema::{RemoteSyncBufferRow, StocktakeRow, StocktakeStatus},
-    StorageConnection,
+    schema::{
+        ChangelogRow, ChangelogTableName, RemoteSyncBufferRow, StocktakeRow, StocktakeStatus,
+    },
+    StocktakeRowRepository, StorageConnection,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::sync::SyncTranslationError;
 
 use super::{
-    date_and_time_to_datatime, empty_str_as_option,
+    date_and_time_to_datatime, date_from_date_time, empty_str_as_option,
     pull::{IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation},
+    push::{to_push_translation_error, PushUpsertRecord, RemotePushUpsertTranslation},
     TRANSLATION_RECORD_STOCKTAKE,
 };
 
-#[derive(Deserialize)]
-enum LegacyStocktakeStatus {
+#[derive(Deserialize, Serialize)]
+pub enum LegacyStocktakeStatus {
     /// From the 4d code this is used for new
     #[serde(rename = "sg")]
     Sg,
@@ -24,27 +27,24 @@ enum LegacyStocktakeStatus {
 }
 
 #[allow(non_snake_case)]
-#[derive(Deserialize)]
-struct LegacyStocktakeRow {
-    ID: String,
-    #[serde(rename = "type")]
+#[derive(Deserialize, Serialize)]
+pub struct LegacyStocktakeRow {
+    pub ID: String,
+    pub status: LegacyStocktakeStatus,
     #[serde(deserialize_with = "empty_str_as_option")]
-    _type: Option<String>,
-    status: LegacyStocktakeStatus,
+    pub Description: Option<String>,
     #[serde(deserialize_with = "empty_str_as_option")]
-    Description: Option<String>,
-    #[serde(deserialize_with = "empty_str_as_option")]
-    comment: Option<String>,
+    pub comment: Option<String>,
 
     #[serde(deserialize_with = "empty_str_as_option")]
-    invad_additions_ID: Option<String>,
+    pub invad_additions_ID: Option<String>,
 
     // Ignore invad_reductions_ID for V1
     // #[serde(deserialize_with = "empty_str_as_option")]
     // invad_reductions_ID: Option<String>,
-    serial_number: i64,
-    stock_take_created_date: NaiveDate,
-    store_ID: String,
+    pub serial_number: i64,
+    pub stock_take_created_date: NaiveDate,
+    pub store_ID: String,
 }
 
 pub struct StocktakeTranslation {}
@@ -91,5 +91,64 @@ fn stocktake_status(status: &LegacyStocktakeStatus) -> StocktakeStatus {
     match status {
         LegacyStocktakeStatus::Sg => StocktakeStatus::New,
         LegacyStocktakeStatus::Fn => StocktakeStatus::Finalised,
+    }
+}
+
+impl RemotePushUpsertTranslation for StocktakeTranslation {
+    fn try_translate_push(
+        &self,
+        connection: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<Option<Vec<PushUpsertRecord>>, SyncTranslationError> {
+        if changelog.table_name != ChangelogTableName::Stocktake {
+            return Ok(None);
+        }
+        let table_name = TRANSLATION_RECORD_STOCKTAKE;
+
+        let StocktakeRow {
+            id,
+            store_id,
+            stocktake_number,
+            comment,
+            description,
+            status,
+            created_datetime,
+            finalised_datetime: _,
+            inventory_adjustment_id,
+        } = StocktakeRowRepository::new(connection)
+            .find_one_by_id(&changelog.row_id)
+            .map_err(|err| to_push_translation_error(table_name, err.into(), changelog))?
+            .ok_or(to_push_translation_error(
+                table_name,
+                anyhow::Error::msg("Stocktake row not found"),
+                changelog,
+            ))?;
+
+        let legacy_row = LegacyStocktakeRow {
+            ID: id.clone(),
+            store_ID: store_id.clone(),
+            status: legacy_stocktake_status(&status),
+            Description: description,
+            comment,
+            invad_additions_ID: inventory_adjustment_id,
+            serial_number: stocktake_number,
+            stock_take_created_date: date_from_date_time(created_datetime),
+        };
+
+        Ok(Some(vec![PushUpsertRecord {
+            sync_id: changelog.id,
+            store_id: Some(store_id),
+            table_name,
+            record_id: id,
+            data: serde_json::to_value(&legacy_row)
+                .map_err(|err| to_push_translation_error(table_name, err.into(), changelog))?,
+        }]))
+    }
+}
+
+fn legacy_stocktake_status(status: &StocktakeStatus) -> LegacyStocktakeStatus {
+    match status {
+        StocktakeStatus::New => LegacyStocktakeStatus::Sg,
+        StocktakeStatus::Finalised => LegacyStocktakeStatus::Fn,
     }
 }

--- a/server/src/sync/translation_remote/stocktake.rs
+++ b/server/src/sync/translation_remote/stocktake.rs
@@ -8,8 +8,9 @@ use serde::Deserialize;
 use crate::sync::SyncTranslationError;
 
 use super::{
-    date_and_time_to_datatime, empty_str_as_option, IntegrationRecord, IntegrationUpsertRecord,
-    RemotePullTranslation, TRANSLATION_RECORD_STOCKTAKE,
+    date_and_time_to_datatime, empty_str_as_option,
+    pull::{IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation},
+    TRANSLATION_RECORD_STOCKTAKE,
 };
 
 #[derive(Deserialize)]
@@ -52,7 +53,7 @@ impl RemotePullTranslation for StocktakeTranslation {
         &self,
         _: &StorageConnection,
         sync_record: &RemoteSyncBufferRow,
-    ) -> Result<Option<super::IntegrationRecord>, SyncTranslationError> {
+    ) -> Result<Option<IntegrationRecord>, SyncTranslationError> {
         let table_name = TRANSLATION_RECORD_STOCKTAKE;
 
         if sync_record.table_name != table_name {

--- a/server/src/sync/translation_remote/stocktake_line.rs
+++ b/server/src/sync/translation_remote/stocktake_line.rs
@@ -1,42 +1,43 @@
 use chrono::NaiveDate;
 use repository::{
-    schema::{RemoteSyncBufferRow, StocktakeLineRow},
-    StorageConnection,
+    schema::{ChangelogRow, ChangelogTableName, RemoteSyncBufferRow, StocktakeLineRow},
+    StockLineRowRepository, StocktakeLineRowRepository, StorageConnection,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::sync::SyncTranslationError;
 
 use super::{
     empty_str_as_option,
     pull::{IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation},
+    push::{to_push_translation_error, PushUpsertRecord, RemotePushUpsertTranslation},
     zero_date_as_option, TRANSLATION_RECORD_STOCKTAKE_LINE,
 };
 
 #[allow(non_snake_case)]
-#[derive(Deserialize)]
-struct LegacyStocktakeLineRow {
-    ID: String,
-    stock_take_ID: String,
+#[derive(Deserialize, Serialize)]
+pub struct LegacyStocktakeLineRow {
+    pub ID: String,
+    pub stock_take_ID: String,
 
     #[serde(deserialize_with = "empty_str_as_option")]
-    location_id: Option<String>,
+    pub location_id: Option<String>,
     #[serde(deserialize_with = "empty_str_as_option")]
-    comment: Option<String>,
-    snapshot_qty: i32,
-    snapshot_packsize: i32,
-    stock_take_qty: i32,
-    is_edited: bool,
+    pub comment: Option<String>,
+    pub snapshot_qty: i32,
+    pub snapshot_packsize: i32,
+    pub stock_take_qty: i32,
+    pub is_edited: bool,
     // TODO is this optional?
     #[serde(deserialize_with = "empty_str_as_option")]
-    item_line_ID: Option<String>,
-    item_ID: String,
+    pub item_line_ID: Option<String>,
+    pub item_ID: String,
     #[serde(deserialize_with = "empty_str_as_option")]
-    Batch: Option<String>,
+    pub Batch: Option<String>,
     #[serde(deserialize_with = "zero_date_as_option")]
-    expiry: Option<NaiveDate>,
-    cost_price: f64,
-    sell_price: f64,
+    pub expiry: Option<NaiveDate>,
+    pub cost_price: f64,
+    pub sell_price: f64,
 }
 
 pub struct StocktakeLineTranslation {}
@@ -84,5 +85,93 @@ impl RemotePullTranslation for StocktakeLineTranslation {
                 note: None,
             }),
         )))
+    }
+}
+
+impl RemotePushUpsertTranslation for StocktakeLineTranslation {
+    fn try_translate_push(
+        &self,
+        connection: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<Option<Vec<PushUpsertRecord>>, SyncTranslationError> {
+        if changelog.table_name != ChangelogTableName::StocktakeLine {
+            return Ok(None);
+        }
+        let table_name = TRANSLATION_RECORD_STOCKTAKE_LINE;
+
+        let StocktakeLineRow {
+            id,
+            stocktake_id,
+            stock_line_id,
+            location_id,
+            comment,
+            snapshot_number_of_packs,
+            counted_number_of_packs,
+            item_id,
+            batch,
+            expiry_date,
+            pack_size,
+            cost_price_per_pack,
+            sell_price_per_pack,
+            note: _,
+        } = StocktakeLineRowRepository::new(connection)
+            .find_one_by_id(&changelog.row_id)
+            .map_err(|err| to_push_translation_error(table_name, err.into(), changelog))?
+            .ok_or(to_push_translation_error(
+                table_name,
+                anyhow::Error::msg("Stocktake row not found"),
+                changelog,
+            ))?;
+
+        let stock_line = match &stock_line_id {
+            Some(stock_line_id) => Some(
+                StockLineRowRepository::new(connection)
+                    .find_one_by_id(&stock_line_id)
+                    .map_err(|err| to_push_translation_error(table_name, err.into(), changelog))?,
+            ),
+            None => None,
+        };
+        let legacy_row = LegacyStocktakeLineRow {
+            ID: id.clone(),
+            stock_take_ID: stocktake_id,
+            location_id,
+            comment,
+            snapshot_qty: snapshot_number_of_packs,
+            stock_take_qty: counted_number_of_packs.unwrap_or(0),
+            is_edited: counted_number_of_packs.is_some(),
+            item_line_ID: stock_line_id,
+            item_ID: item_id,
+            snapshot_packsize: stock_line
+                .as_ref()
+                .map(|it| it.pack_size)
+                .or(pack_size)
+                .unwrap_or(0),
+            Batch: stock_line
+                .as_ref()
+                .and_then(|it| it.batch.clone())
+                .or(batch),
+            expiry: stock_line
+                .as_ref()
+                .and_then(|it| it.expiry_date)
+                .or(expiry_date),
+            cost_price: stock_line
+                .as_ref()
+                .map(|it| it.cost_price_per_pack)
+                .or(cost_price_per_pack)
+                .unwrap_or(0.0),
+            sell_price: stock_line
+                .map(|it| it.sell_price_per_pack)
+                .or(sell_price_per_pack)
+                .unwrap_or(0.0),
+        };
+
+        Ok(Some(vec![PushUpsertRecord {
+            sync_id: changelog.id,
+            store_id: None,
+            table_name,
+            record_id: id,
+            data: serde_json::to_value(&legacy_row)
+                .map_err(|err| to_push_translation_error(table_name, err.into(), changelog))?,
+        }]))
     }
 }

--- a/server/src/sync/translation_remote/stocktake_line.rs
+++ b/server/src/sync/translation_remote/stocktake_line.rs
@@ -8,8 +8,9 @@ use serde::Deserialize;
 use crate::sync::SyncTranslationError;
 
 use super::{
-    empty_str_as_option, zero_date_as_option, IntegrationRecord, IntegrationUpsertRecord,
-    RemotePullTranslation, TRANSLATION_RECORD_STOCKTAKE_LINE,
+    empty_str_as_option,
+    pull::{IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation},
+    zero_date_as_option, TRANSLATION_RECORD_STOCKTAKE_LINE,
 };
 
 #[allow(non_snake_case)]
@@ -44,7 +45,7 @@ impl RemotePullTranslation for StocktakeLineTranslation {
         &self,
         _: &StorageConnection,
         sync_record: &RemoteSyncBufferRow,
-    ) -> Result<Option<super::IntegrationRecord>, SyncTranslationError> {
+    ) -> Result<Option<IntegrationRecord>, SyncTranslationError> {
         let table_name = TRANSLATION_RECORD_STOCKTAKE_LINE;
 
         if sync_record.table_name != table_name {

--- a/server/src/sync/translation_remote/test_data/mod.rs
+++ b/server/src/sync/translation_remote/test_data/mod.rs
@@ -8,8 +8,8 @@ use repository::{
 use self::{
     name_store_join::{get_test_name_store_join_records, get_test_push_name_store_join_records},
     number::{get_test_number_records, get_test_push_number_records},
-    stock_line::get_test_stock_line_records,
-    stocktake::get_test_stocktake_records,
+    stock_line::{get_test_push_stock_line_records, get_test_stock_line_records},
+    stocktake::{get_test_push_stocktake_records, get_test_stocktake_records},
     stocktake_line::get_test_stocktake_line_records,
     trans_line::get_test_trans_line_records,
     transact::get_test_transact_records,
@@ -171,5 +171,7 @@ pub fn get_all_remote_push_test_records() -> Vec<TestSyncPushRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut get_test_push_number_records());
     test_records.append(&mut get_test_push_name_store_join_records());
+    test_records.append(&mut get_test_push_stock_line_records());
+    test_records.append(&mut get_test_push_stocktake_records());
     test_records
 }

--- a/server/src/sync/translation_remote/test_data/mod.rs
+++ b/server/src/sync/translation_remote/test_data/mod.rs
@@ -11,7 +11,7 @@ use self::{
     transact::get_test_transact_records,
 };
 
-use super::{IntegrationRecord, IntegrationUpsertRecord};
+use super::pull::{IntegrationRecord, IntegrationUpsertRecord};
 
 pub mod name_store_join;
 pub mod number;

--- a/server/src/sync/translation_remote/test_data/mod.rs
+++ b/server/src/sync/translation_remote/test_data/mod.rs
@@ -10,7 +10,7 @@ use self::{
     number::{get_test_number_records, get_test_push_number_records},
     stock_line::{get_test_push_stock_line_records, get_test_stock_line_records},
     stocktake::{get_test_push_stocktake_records, get_test_stocktake_records},
-    stocktake_line::get_test_stocktake_line_records,
+    stocktake_line::{get_test_push_stocktake_line_records, get_test_stocktake_line_records},
     trans_line::get_test_trans_line_records,
     transact::get_test_transact_records,
 };
@@ -173,5 +173,6 @@ pub fn get_all_remote_push_test_records() -> Vec<TestSyncPushRecord> {
     test_records.append(&mut get_test_push_name_store_join_records());
     test_records.append(&mut get_test_push_stock_line_records());
     test_records.append(&mut get_test_push_stocktake_records());
+    test_records.append(&mut get_test_push_stocktake_line_records());
     test_records
 }

--- a/server/src/sync/translation_remote/test_data/mod.rs
+++ b/server/src/sync/translation_remote/test_data/mod.rs
@@ -6,7 +6,7 @@ use repository::{
 };
 
 use self::{
-    name_store_join::get_test_name_store_join_records,
+    name_store_join::{get_test_name_store_join_records, get_test_push_name_store_join_records},
     number::{get_test_number_records, get_test_push_number_records},
     stock_line::get_test_stock_line_records,
     stocktake::get_test_stocktake_records,
@@ -170,5 +170,6 @@ pub fn get_all_remote_pull_test_records() -> Vec<TestSyncRecord> {
 pub fn get_all_remote_push_test_records() -> Vec<TestSyncPushRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut get_test_push_number_records());
+    test_records.append(&mut get_test_push_name_store_join_records());
     test_records
 }

--- a/server/src/sync/translation_remote/test_data/mod.rs
+++ b/server/src/sync/translation_remote/test_data/mod.rs
@@ -114,7 +114,7 @@ pub fn check_records_against_database(
                         comparison_record
                     )
                 }
-                IntegrationUpsertRecord::Shipment(comparison_record) => {
+                IntegrationUpsertRecord::Invoice(comparison_record) => {
                     assert_eq!(
                         InvoiceRepository::new(&connection)
                             .find_one_by_id(&comparison_record.id)
@@ -122,7 +122,7 @@ pub fn check_records_against_database(
                         comparison_record
                     )
                 }
-                IntegrationUpsertRecord::ShipmentLine(comparison_record) => {
+                IntegrationUpsertRecord::InvoiceLine(comparison_record) => {
                     assert_eq!(
                         InvoiceLineRowRepository::new(&connection)
                             .find_one_by_id(&comparison_record.id)

--- a/server/src/sync/translation_remote/test_data/mod.rs
+++ b/server/src/sync/translation_remote/test_data/mod.rs
@@ -1,13 +1,17 @@
 use repository::{
-    schema::RemoteSyncBufferRow, InvoiceLineRowRepository, InvoiceRepository,
-    NameStoreJoinRepository, NumberRowRepository, RepositoryError, StockLineRowRepository,
-    StocktakeLineRowRepository, StocktakeRowRepository, StorageConnection,
+    schema::{ChangelogRow, RemoteSyncBufferRow},
+    InvoiceLineRowRepository, InvoiceRepository, NameStoreJoinRepository, NumberRowRepository,
+    RepositoryError, StockLineRowRepository, StocktakeLineRowRepository, StocktakeRowRepository,
+    StorageConnection,
 };
 
 use self::{
-    name_store_join::get_test_name_store_join_records, number::get_test_number_records,
-    stock_line::get_test_stock_line_records, stocktake::get_test_stocktake_records,
-    stocktake_line::get_test_stocktake_line_records, trans_line::get_test_trans_line_records,
+    name_store_join::get_test_name_store_join_records,
+    number::{get_test_number_records, get_test_push_number_records},
+    stock_line::get_test_stock_line_records,
+    stocktake::get_test_stocktake_records,
+    stocktake_line::get_test_stocktake_line_records,
+    trans_line::get_test_trans_line_records,
     transact::get_test_transact_records,
 };
 
@@ -30,6 +34,18 @@ pub struct TestSyncRecord {
     pub identifier: &'static str,
     /// Row as stored in the remote sync buffer
     pub remote_sync_buffer_row: RemoteSyncBufferRow,
+}
+
+/// To be used in combination with TestSyncRecord.
+/// I.e. first run and integrate a row from TestSyncRecord and then try to push this record out
+#[allow(dead_code)]
+pub struct TestSyncPushRecord {
+    /// Change log event for the row to be pushed.
+    /// Its assumed the row exists, e.g. because it has been integrated before through a
+    /// TestSyncRecord
+    pub change_log: ChangelogRow,
+    /// Expected record as pushed out to the server
+    pub push_data: serde_json::Value,
 }
 
 #[allow(dead_code)]
@@ -147,5 +163,12 @@ pub fn get_all_remote_pull_test_records() -> Vec<TestSyncRecord> {
     test_records.append(&mut get_test_trans_line_records());
     test_records.append(&mut get_test_stocktake_records());
     test_records.append(&mut get_test_stocktake_line_records());
+    test_records
+}
+
+#[allow(dead_code)]
+pub fn get_all_remote_push_test_records() -> Vec<TestSyncPushRecord> {
+    let mut test_records = Vec::new();
+    test_records.append(&mut get_test_push_number_records());
     test_records
 }

--- a/server/src/sync/translation_remote/test_data/mod.rs
+++ b/server/src/sync/translation_remote/test_data/mod.rs
@@ -6,7 +6,6 @@ use repository::{
 };
 
 use self::{
-    name_store_join::{get_test_name_store_join_records, get_test_push_name_store_join_records},
     number::{get_test_number_records, get_test_push_number_records},
     stock_line::{get_test_push_stock_line_records, get_test_stock_line_records},
     stocktake::{get_test_push_stocktake_records, get_test_stocktake_records},
@@ -158,7 +157,7 @@ pub fn get_all_remote_pull_test_records() -> Vec<TestSyncRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut get_test_number_records());
     test_records.append(&mut get_test_stock_line_records());
-    test_records.append(&mut get_test_name_store_join_records());
+    //test_records.append(&mut get_test_name_store_join_records());
     test_records.append(&mut get_test_transact_records());
     test_records.append(&mut get_test_trans_line_records());
     test_records.append(&mut get_test_stocktake_records());
@@ -170,7 +169,7 @@ pub fn get_all_remote_pull_test_records() -> Vec<TestSyncRecord> {
 pub fn get_all_remote_push_test_records() -> Vec<TestSyncPushRecord> {
     let mut test_records = Vec::new();
     test_records.append(&mut get_test_push_number_records());
-    test_records.append(&mut get_test_push_name_store_join_records());
+    //test_records.append(&mut get_test_push_name_store_join_records());
     test_records.append(&mut get_test_push_stock_line_records());
     test_records.append(&mut get_test_push_transact_records());
     test_records.append(&mut get_test_push_trans_line_records());

--- a/server/src/sync/translation_remote/test_data/mod.rs
+++ b/server/src/sync/translation_remote/test_data/mod.rs
@@ -12,7 +12,7 @@ use self::{
     stocktake::{get_test_push_stocktake_records, get_test_stocktake_records},
     stocktake_line::{get_test_push_stocktake_line_records, get_test_stocktake_line_records},
     trans_line::get_test_trans_line_records,
-    transact::get_test_transact_records,
+    transact::{get_test_push_transact_records, get_test_transact_records},
 };
 
 use super::pull::{IntegrationRecord, IntegrationUpsertRecord};
@@ -172,6 +172,7 @@ pub fn get_all_remote_push_test_records() -> Vec<TestSyncPushRecord> {
     test_records.append(&mut get_test_push_number_records());
     test_records.append(&mut get_test_push_name_store_join_records());
     test_records.append(&mut get_test_push_stock_line_records());
+    test_records.append(&mut get_test_push_transact_records());
     test_records.append(&mut get_test_push_stocktake_records());
     test_records.append(&mut get_test_push_stocktake_line_records());
     test_records

--- a/server/src/sync/translation_remote/test_data/mod.rs
+++ b/server/src/sync/translation_remote/test_data/mod.rs
@@ -11,7 +11,7 @@ use self::{
     stock_line::{get_test_push_stock_line_records, get_test_stock_line_records},
     stocktake::{get_test_push_stocktake_records, get_test_stocktake_records},
     stocktake_line::{get_test_push_stocktake_line_records, get_test_stocktake_line_records},
-    trans_line::get_test_trans_line_records,
+    trans_line::{get_test_push_trans_line_records, get_test_trans_line_records},
     transact::{get_test_push_transact_records, get_test_transact_records},
 };
 
@@ -173,6 +173,7 @@ pub fn get_all_remote_push_test_records() -> Vec<TestSyncPushRecord> {
     test_records.append(&mut get_test_push_name_store_join_records());
     test_records.append(&mut get_test_push_stock_line_records());
     test_records.append(&mut get_test_push_transact_records());
+    test_records.append(&mut get_test_push_trans_line_records());
     test_records.append(&mut get_test_push_stocktake_records());
     test_records.append(&mut get_test_push_stocktake_line_records());
     test_records

--- a/server/src/sync/translation_remote/test_data/name_store_join.rs
+++ b/server/src/sync/translation_remote/test_data/name_store_join.rs
@@ -1,7 +1,8 @@
 use repository::schema::{NameStoreJoinRow, RemoteSyncBufferAction, RemoteSyncBufferRow};
 
 use crate::sync::translation_remote::{
-    test_data::TestSyncRecord, IntegrationRecord, IntegrationUpsertRecord,
+    pull::{IntegrationRecord, IntegrationUpsertRecord},
+    test_data::TestSyncRecord,
     TRANSLATION_RECORD_NAME_STORE_JOIN,
 };
 

--- a/server/src/sync/translation_remote/test_data/name_store_join.rs
+++ b/server/src/sync/translation_remote/test_data/name_store_join.rs
@@ -1,10 +1,17 @@
-use repository::schema::{NameStoreJoinRow, RemoteSyncBufferAction, RemoteSyncBufferRow};
+use repository::schema::{
+    ChangelogAction, ChangelogRow, ChangelogTableName, NameStoreJoinRow, RemoteSyncBufferAction,
+    RemoteSyncBufferRow,
+};
+use serde_json::json;
 
 use crate::sync::translation_remote::{
+    name_store_join::LegacyNameStoreJoinRow,
     pull::{IntegrationRecord, IntegrationUpsertRecord},
     test_data::TestSyncRecord,
     TRANSLATION_RECORD_NAME_STORE_JOIN,
 };
+
+use super::TestSyncPushRecord;
 
 const NAME_STORE_JOIN_1: (&'static str, &'static str) = (
     "66607B6E7F2A47E782B8AC6743F71A8A",
@@ -18,6 +25,42 @@ const NAME_STORE_JOIN_1: (&'static str, &'static str) = (
       "store_ID": "store_a"
   }"#,
 );
+fn name_store_join_1_pull_record() -> TestSyncRecord {
+    TestSyncRecord {
+        translated_record: Some(IntegrationRecord::from_upsert(
+            IntegrationUpsertRecord::NameStoreJoin(NameStoreJoinRow {
+                id: NAME_STORE_JOIN_1.0.to_string(),
+                store_id: "store_a".to_string(),
+                name_id: "name_store_a".to_string(),
+                name_is_customer: false,
+                name_is_supplier: true,
+            }),
+        )),
+        identifier: "Name store join 1",
+        remote_sync_buffer_row: RemoteSyncBufferRow {
+            id: "name_store_join_1".to_string(),
+            table_name: TRANSLATION_RECORD_NAME_STORE_JOIN.to_string(),
+            record_id: NAME_STORE_JOIN_1.0.to_string(),
+            data: NAME_STORE_JOIN_1.1.to_string(),
+            action: RemoteSyncBufferAction::Update,
+        },
+    }
+}
+fn name_store_join1_push_record() -> TestSyncPushRecord {
+    TestSyncPushRecord {
+        change_log: ChangelogRow {
+            id: 2,
+            table_name: ChangelogTableName::NameStoreJoin,
+            row_id: NAME_STORE_JOIN_1.0.to_string(),
+            row_action: ChangelogAction::Upsert,
+        },
+        push_data: json!(LegacyNameStoreJoinRow {
+            ID: NAME_STORE_JOIN_1.0.to_string(),
+            store_ID: "store_a".to_string(),
+            name_ID: "name_store_a".to_string()
+        }),
+    }
+}
 
 const NAME_STORE_JOIN_2: (&'static str, &'static str) = (
     "BE65A4A05E4D47E88303D6105A7872CC",
@@ -31,47 +74,55 @@ const NAME_STORE_JOIN_2: (&'static str, &'static str) = (
       "store_ID": "store_b"
   }"#,
 );
+fn name_store_join_2_pull_record() -> TestSyncRecord {
+    TestSyncRecord {
+        translated_record: Some(IntegrationRecord::from_upsert(
+            IntegrationUpsertRecord::NameStoreJoin(NameStoreJoinRow {
+                id: NAME_STORE_JOIN_2.0.to_string(),
+                store_id: "store_b".to_string(),
+                name_id: "name_store_b".to_string(),
+                name_is_customer: false,
+                name_is_supplier: false,
+            }),
+        )),
+        identifier: "Name store join 2",
+        remote_sync_buffer_row: RemoteSyncBufferRow {
+            id: "name_store_join_2".to_string(),
+            table_name: TRANSLATION_RECORD_NAME_STORE_JOIN.to_string(),
+            record_id: NAME_STORE_JOIN_2.0.to_string(),
+            data: NAME_STORE_JOIN_2.1.to_string(),
+            action: RemoteSyncBufferAction::Update,
+        },
+    }
+}
+fn name_store_join_2_push_record() -> TestSyncPushRecord {
+    TestSyncPushRecord {
+        change_log: ChangelogRow {
+            id: 2,
+            table_name: ChangelogTableName::NameStoreJoin,
+            row_id: NAME_STORE_JOIN_2.0.to_string(),
+            row_action: ChangelogAction::Upsert,
+        },
+        push_data: json!(LegacyNameStoreJoinRow {
+            ID: NAME_STORE_JOIN_2.0.to_string(),
+            store_ID: "store_b".to_string(),
+            name_ID: "name_store_b".to_string()
+        }),
+    }
+}
 
 #[allow(dead_code)]
 pub fn get_test_name_store_join_records() -> Vec<TestSyncRecord> {
     vec![
-        TestSyncRecord {
-            translated_record: Some(IntegrationRecord::from_upsert(
-                IntegrationUpsertRecord::NameStoreJoin(NameStoreJoinRow {
-                    id: NAME_STORE_JOIN_1.0.to_string(),
-                    store_id: "store_a".to_string(),
-                    name_id: "name_store_a".to_string(),
-                    name_is_customer: false,
-                    name_is_supplier: true,
-                }),
-            )),
-            identifier: "Name store join 1",
-            remote_sync_buffer_row: RemoteSyncBufferRow {
-                id: "name_store_join_1".to_string(),
-                table_name: TRANSLATION_RECORD_NAME_STORE_JOIN.to_string(),
-                record_id: NAME_STORE_JOIN_1.0.to_string(),
-                data: NAME_STORE_JOIN_1.1.to_string(),
-                action: RemoteSyncBufferAction::Update,
-            },
-        },
-        TestSyncRecord {
-            translated_record: Some(IntegrationRecord::from_upsert(
-                IntegrationUpsertRecord::NameStoreJoin(NameStoreJoinRow {
-                    id: NAME_STORE_JOIN_2.0.to_string(),
-                    store_id: "store_b".to_string(),
-                    name_id: "name_store_b".to_string(),
-                    name_is_customer: false,
-                    name_is_supplier: false,
-                }),
-            )),
-            identifier: "Name store join 2",
-            remote_sync_buffer_row: RemoteSyncBufferRow {
-                id: "name_store_join_2".to_string(),
-                table_name: TRANSLATION_RECORD_NAME_STORE_JOIN.to_string(),
-                record_id: NAME_STORE_JOIN_2.0.to_string(),
-                data: NAME_STORE_JOIN_2.1.to_string(),
-                action: RemoteSyncBufferAction::Update,
-            },
-        },
+        name_store_join_1_pull_record(),
+        name_store_join_2_pull_record(),
+    ]
+}
+
+#[allow(dead_code)]
+pub fn get_test_push_name_store_join_records() -> Vec<TestSyncPushRecord> {
+    vec![
+        name_store_join1_push_record(),
+        name_store_join_2_push_record(),
     ]
 }

--- a/server/src/sync/translation_remote/test_data/number.rs
+++ b/server/src/sync/translation_remote/test_data/number.rs
@@ -1,7 +1,8 @@
 use repository::schema::{NumberRow, NumberRowType, RemoteSyncBufferAction, RemoteSyncBufferRow};
 
 use crate::sync::translation_remote::{
-    test_data::TestSyncRecord, IntegrationRecord, IntegrationUpsertRecord,
+    pull::{IntegrationRecord, IntegrationUpsertRecord},
+    test_data::TestSyncRecord,
     TRANSLATION_RECORD_NUMBER,
 };
 

--- a/server/src/sync/translation_remote/test_data/number.rs
+++ b/server/src/sync/translation_remote/test_data/number.rs
@@ -1,8 +1,13 @@
-use repository::schema::{NumberRow, NumberRowType, RemoteSyncBufferAction, RemoteSyncBufferRow};
+use repository::schema::{
+    ChangelogAction, ChangelogRow, ChangelogTableName, NumberRow, NumberRowType,
+    RemoteSyncBufferAction, RemoteSyncBufferRow,
+};
+use serde_json::json;
 
 use crate::sync::translation_remote::{
+    number::LegacyNumberRow,
     pull::{IntegrationRecord, IntegrationUpsertRecord},
-    test_data::TestSyncRecord,
+    test_data::{TestSyncPushRecord, TestSyncRecord},
     TRANSLATION_RECORD_NUMBER,
 };
 
@@ -136,6 +141,64 @@ pub fn get_test_number_records() -> Vec<TestSyncRecord> {
                 data: PURCHASE_ORDER.1.to_string(),
                 action: RemoteSyncBufferAction::Update,
             },
+        },
+    ]
+}
+
+#[allow(dead_code)]
+pub fn get_test_push_number_records() -> Vec<TestSyncPushRecord> {
+    vec![
+        TestSyncPushRecord {
+            change_log: ChangelogRow {
+                id: 2,
+                table_name: ChangelogTableName::Number,
+                row_id: NUMBER_STOCK_TAKE.0.to_string(),
+                row_action: ChangelogAction::Upsert,
+            },
+            push_data: json!(LegacyNumberRow {
+                ID: NUMBER_STOCK_TAKE.0.to_string(),
+                name: "stock_take_number_for_store_store_remote_pull".to_string(),
+                value: 1,
+            }),
+        },
+        TestSyncPushRecord {
+            change_log: ChangelogRow {
+                id: 2,
+                table_name: ChangelogTableName::Number,
+                row_id: NUMBER_INVENTORY_ADJUSTMENT.0.to_string(),
+                row_action: ChangelogAction::Upsert,
+            },
+            push_data: json!(LegacyNumberRow {
+                ID: NUMBER_INVENTORY_ADJUSTMENT.0.to_string(),
+                name: "inventory_adjustment_serial_number_for_store_store_remote_pull".to_string(),
+                value: 2,
+            }),
+        },
+        TestSyncPushRecord {
+            change_log: ChangelogRow {
+                id: 2,
+                table_name: ChangelogTableName::Number,
+                row_id: CUSTOMER_INVOICE_ADJUSTMENT.0.to_string(),
+                row_action: ChangelogAction::Upsert,
+            },
+            push_data: json!(LegacyNumberRow {
+                ID: CUSTOMER_INVOICE_ADJUSTMENT.0.to_string(),
+                name: "customer_invoice_number_for_store_store_remote_pull".to_string(),
+                value: 8,
+            }),
+        },
+        TestSyncPushRecord {
+            change_log: ChangelogRow {
+                id: 2,
+                table_name: ChangelogTableName::Number,
+                row_id: SUPPLIER_INVOICE.0.to_string(),
+                row_action: ChangelogAction::Upsert,
+            },
+            push_data: json!(LegacyNumberRow {
+                ID: SUPPLIER_INVOICE.0.to_string(),
+                name: "supplier_invoice_number_for_store_store_remote_pull".to_string(),
+                value: 3,
+            }),
         },
     ]
 }

--- a/server/src/sync/translation_remote/test_data/number.rs
+++ b/server/src/sync/translation_remote/test_data/number.rs
@@ -19,6 +19,41 @@ const NUMBER_STOCK_TAKE: (&'static str, &'static str) = (
       "value": 1
     }"#,
 );
+fn number_stock_take_pull_record() -> TestSyncRecord {
+    TestSyncRecord {
+        translated_record: Some(IntegrationRecord::from_upsert(
+            IntegrationUpsertRecord::Number(NumberRow {
+                id: NUMBER_STOCK_TAKE.0.to_string(),
+                value: 1,
+                store_id: "store_remote_pull".to_string(),
+                r#type: NumberRowType::Stocktake,
+            }),
+        )),
+        identifier: "Stocktake",
+        remote_sync_buffer_row: RemoteSyncBufferRow {
+            id: "Number_10".to_string(),
+            table_name: TRANSLATION_RECORD_NUMBER.to_string(),
+            record_id: NUMBER_STOCK_TAKE.0.to_string(),
+            data: NUMBER_STOCK_TAKE.1.to_string(),
+            action: RemoteSyncBufferAction::Update,
+        },
+    }
+}
+fn number_stock_take_push_record() -> TestSyncPushRecord {
+    TestSyncPushRecord {
+        change_log: ChangelogRow {
+            id: 2,
+            table_name: ChangelogTableName::Number,
+            row_id: NUMBER_STOCK_TAKE.0.to_string(),
+            row_action: ChangelogAction::Upsert,
+        },
+        push_data: json!(LegacyNumberRow {
+            ID: NUMBER_STOCK_TAKE.0.to_string(),
+            name: "stock_take_number_for_store_store_remote_pull".to_string(),
+            value: 1,
+        }),
+    }
+}
 
 const NUMBER_INVENTORY_ADJUSTMENT: (&'static str, &'static str) = (
     "12e8d7e0f0d211eb8dddb54df6d741bc",
@@ -28,6 +63,41 @@ const NUMBER_INVENTORY_ADJUSTMENT: (&'static str, &'static str) = (
       "value": 2
     }"#,
 );
+fn number_inv_adjustment_pull_record() -> TestSyncRecord {
+    TestSyncRecord {
+        translated_record: Some(IntegrationRecord::from_upsert(
+            IntegrationUpsertRecord::Number(NumberRow {
+                id: NUMBER_INVENTORY_ADJUSTMENT.0.to_string(),
+                value: 2,
+                store_id: "store_remote_pull".to_string(),
+                r#type: NumberRowType::InventoryAdjustment,
+            }),
+        )),
+        identifier: "Inventory adjustment",
+        remote_sync_buffer_row: RemoteSyncBufferRow {
+            id: "Number_20".to_string(),
+            table_name: TRANSLATION_RECORD_NUMBER.to_string(),
+            record_id: NUMBER_INVENTORY_ADJUSTMENT.0.to_string(),
+            data: NUMBER_INVENTORY_ADJUSTMENT.1.to_string(),
+            action: RemoteSyncBufferAction::Update,
+        },
+    }
+}
+fn number_inv_adjustment_push_record() -> TestSyncPushRecord {
+    TestSyncPushRecord {
+        change_log: ChangelogRow {
+            id: 2,
+            table_name: ChangelogTableName::Number,
+            row_id: NUMBER_INVENTORY_ADJUSTMENT.0.to_string(),
+            row_action: ChangelogAction::Upsert,
+        },
+        push_data: json!(LegacyNumberRow {
+            ID: NUMBER_INVENTORY_ADJUSTMENT.0.to_string(),
+            name: "inventory_adjustment_serial_number_for_store_store_remote_pull".to_string(),
+            value: 2,
+        }),
+    }
+}
 
 const CUSTOMER_INVOICE_ADJUSTMENT: (&'static str, &'static str) = (
     "67f303f0f0d211eb8dddb54df6d741bc",
@@ -37,6 +107,41 @@ const CUSTOMER_INVOICE_ADJUSTMENT: (&'static str, &'static str) = (
       "value": 8
     }"#,
 );
+fn number_customer_invoice_pull_record() -> TestSyncRecord {
+    TestSyncRecord {
+        translated_record: Some(IntegrationRecord::from_upsert(
+            IntegrationUpsertRecord::Number(NumberRow {
+                id: CUSTOMER_INVOICE_ADJUSTMENT.0.to_string(),
+                value: 8,
+                store_id: "store_remote_pull".to_string(),
+                r#type: NumberRowType::OutboundShipment,
+            }),
+        )),
+        identifier: "Customer invoice",
+        remote_sync_buffer_row: RemoteSyncBufferRow {
+            id: "Number_30".to_string(),
+            table_name: TRANSLATION_RECORD_NUMBER.to_string(),
+            record_id: CUSTOMER_INVOICE_ADJUSTMENT.0.to_string(),
+            data: CUSTOMER_INVOICE_ADJUSTMENT.1.to_string(),
+            action: RemoteSyncBufferAction::Update,
+        },
+    }
+}
+fn number_customer_invoice_push_record() -> TestSyncPushRecord {
+    TestSyncPushRecord {
+        change_log: ChangelogRow {
+            id: 2,
+            table_name: ChangelogTableName::Number,
+            row_id: CUSTOMER_INVOICE_ADJUSTMENT.0.to_string(),
+            row_action: ChangelogAction::Upsert,
+        },
+        push_data: json!(LegacyNumberRow {
+            ID: CUSTOMER_INVOICE_ADJUSTMENT.0.to_string(),
+            name: "customer_invoice_number_for_store_store_remote_pull".to_string(),
+            value: 8,
+        }),
+    }
+}
 
 const PURCHASE_ORDER: (&'static str, &'static str) = (
     "772B973657F440089E4BFE7ADE013D28",
@@ -46,6 +151,19 @@ const PURCHASE_ORDER: (&'static str, &'static str) = (
       "value": 2
     }"#,
 );
+fn number_purchase_order_pull_record() -> TestSyncRecord {
+    TestSyncRecord {
+        translated_record: None,
+        identifier: "Purchase order",
+        remote_sync_buffer_row: RemoteSyncBufferRow {
+            id: "Number_50".to_string(),
+            table_name: TRANSLATION_RECORD_NUMBER.to_string(),
+            record_id: PURCHASE_ORDER.0.to_string(),
+            data: PURCHASE_ORDER.1.to_string(),
+            action: RemoteSyncBufferAction::Update,
+        },
+    }
+}
 
 const SUPPLIER_INVOICE: (&'static str, &'static str) = (
     "F16EC3CB735B4C8B8D441EDB9186A262",
@@ -55,150 +173,59 @@ const SUPPLIER_INVOICE: (&'static str, &'static str) = (
       "value": 3
     }"#,
 );
+fn number_supplier_invoice_pull_record() -> TestSyncRecord {
+    TestSyncRecord {
+        translated_record: Some(IntegrationRecord::from_upsert(
+            IntegrationUpsertRecord::Number(NumberRow {
+                id: SUPPLIER_INVOICE.0.to_string(),
+                value: 3,
+                store_id: "store_remote_pull".to_string(),
+                r#type: NumberRowType::InboundShipment,
+            }),
+        )),
+        identifier: "Supplier invoice",
+        remote_sync_buffer_row: RemoteSyncBufferRow {
+            id: "Number_40".to_string(),
+            table_name: TRANSLATION_RECORD_NUMBER.to_string(),
+            record_id: SUPPLIER_INVOICE.0.to_string(),
+            data: SUPPLIER_INVOICE.1.to_string(),
+            action: RemoteSyncBufferAction::Update,
+        },
+    }
+}
+fn number_supplier_invoice_push_record() -> TestSyncPushRecord {
+    TestSyncPushRecord {
+        change_log: ChangelogRow {
+            id: 2,
+            table_name: ChangelogTableName::Number,
+            row_id: SUPPLIER_INVOICE.0.to_string(),
+            row_action: ChangelogAction::Upsert,
+        },
+        push_data: json!(LegacyNumberRow {
+            ID: SUPPLIER_INVOICE.0.to_string(),
+            name: "supplier_invoice_number_for_store_store_remote_pull".to_string(),
+            value: 3,
+        }),
+    }
+}
 
 #[allow(dead_code)]
 pub fn get_test_number_records() -> Vec<TestSyncRecord> {
     vec![
-        TestSyncRecord {
-            translated_record: Some(IntegrationRecord::from_upsert(
-                IntegrationUpsertRecord::Number(NumberRow {
-                    id: NUMBER_STOCK_TAKE.0.to_string(),
-                    value: 1,
-                    store_id: "store_remote_pull".to_string(),
-                    r#type: NumberRowType::Stocktake,
-                }),
-            )),
-            identifier: "Stocktake",
-            remote_sync_buffer_row: RemoteSyncBufferRow {
-                id: "Number_10".to_string(),
-                table_name: TRANSLATION_RECORD_NUMBER.to_string(),
-                record_id: NUMBER_STOCK_TAKE.0.to_string(),
-                data: NUMBER_STOCK_TAKE.1.to_string(),
-                action: RemoteSyncBufferAction::Update,
-            },
-        },
-        TestSyncRecord {
-            translated_record: Some(IntegrationRecord::from_upsert(
-                IntegrationUpsertRecord::Number(NumberRow {
-                    id: NUMBER_INVENTORY_ADJUSTMENT.0.to_string(),
-                    value: 2,
-                    store_id: "store_remote_pull".to_string(),
-                    r#type: NumberRowType::InventoryAdjustment,
-                }),
-            )),
-            identifier: "Inventory adjustment",
-            remote_sync_buffer_row: RemoteSyncBufferRow {
-                id: "Number_20".to_string(),
-                table_name: TRANSLATION_RECORD_NUMBER.to_string(),
-                record_id: NUMBER_INVENTORY_ADJUSTMENT.0.to_string(),
-                data: NUMBER_INVENTORY_ADJUSTMENT.1.to_string(),
-                action: RemoteSyncBufferAction::Update,
-            },
-        },
-        TestSyncRecord {
-            translated_record: Some(IntegrationRecord::from_upsert(
-                IntegrationUpsertRecord::Number(NumberRow {
-                    id: CUSTOMER_INVOICE_ADJUSTMENT.0.to_string(),
-                    value: 8,
-                    store_id: "store_remote_pull".to_string(),
-                    r#type: NumberRowType::OutboundShipment,
-                }),
-            )),
-            identifier: "Customer invoice",
-            remote_sync_buffer_row: RemoteSyncBufferRow {
-                id: "Number_30".to_string(),
-                table_name: TRANSLATION_RECORD_NUMBER.to_string(),
-                record_id: CUSTOMER_INVOICE_ADJUSTMENT.0.to_string(),
-                data: CUSTOMER_INVOICE_ADJUSTMENT.1.to_string(),
-                action: RemoteSyncBufferAction::Update,
-            },
-        },
-        TestSyncRecord {
-            translated_record: Some(IntegrationRecord::from_upsert(
-                IntegrationUpsertRecord::Number(NumberRow {
-                    id: SUPPLIER_INVOICE.0.to_string(),
-                    value: 3,
-                    store_id: "store_remote_pull".to_string(),
-                    r#type: NumberRowType::InboundShipment,
-                }),
-            )),
-            identifier: "Supplier invoice",
-            remote_sync_buffer_row: RemoteSyncBufferRow {
-                id: "Number_40".to_string(),
-                table_name: TRANSLATION_RECORD_NUMBER.to_string(),
-                record_id: SUPPLIER_INVOICE.0.to_string(),
-                data: SUPPLIER_INVOICE.1.to_string(),
-                action: RemoteSyncBufferAction::Update,
-            },
-        },
-        TestSyncRecord {
-            translated_record: None,
-            identifier: "Purchase order",
-            remote_sync_buffer_row: RemoteSyncBufferRow {
-                id: "Number_50".to_string(),
-                table_name: TRANSLATION_RECORD_NUMBER.to_string(),
-                record_id: PURCHASE_ORDER.0.to_string(),
-                data: PURCHASE_ORDER.1.to_string(),
-                action: RemoteSyncBufferAction::Update,
-            },
-        },
+        number_stock_take_pull_record(),
+        number_inv_adjustment_pull_record(),
+        number_customer_invoice_pull_record(),
+        number_supplier_invoice_pull_record(),
+        number_purchase_order_pull_record(),
     ]
 }
 
 #[allow(dead_code)]
 pub fn get_test_push_number_records() -> Vec<TestSyncPushRecord> {
     vec![
-        TestSyncPushRecord {
-            change_log: ChangelogRow {
-                id: 2,
-                table_name: ChangelogTableName::Number,
-                row_id: NUMBER_STOCK_TAKE.0.to_string(),
-                row_action: ChangelogAction::Upsert,
-            },
-            push_data: json!(LegacyNumberRow {
-                ID: NUMBER_STOCK_TAKE.0.to_string(),
-                name: "stock_take_number_for_store_store_remote_pull".to_string(),
-                value: 1,
-            }),
-        },
-        TestSyncPushRecord {
-            change_log: ChangelogRow {
-                id: 2,
-                table_name: ChangelogTableName::Number,
-                row_id: NUMBER_INVENTORY_ADJUSTMENT.0.to_string(),
-                row_action: ChangelogAction::Upsert,
-            },
-            push_data: json!(LegacyNumberRow {
-                ID: NUMBER_INVENTORY_ADJUSTMENT.0.to_string(),
-                name: "inventory_adjustment_serial_number_for_store_store_remote_pull".to_string(),
-                value: 2,
-            }),
-        },
-        TestSyncPushRecord {
-            change_log: ChangelogRow {
-                id: 2,
-                table_name: ChangelogTableName::Number,
-                row_id: CUSTOMER_INVOICE_ADJUSTMENT.0.to_string(),
-                row_action: ChangelogAction::Upsert,
-            },
-            push_data: json!(LegacyNumberRow {
-                ID: CUSTOMER_INVOICE_ADJUSTMENT.0.to_string(),
-                name: "customer_invoice_number_for_store_store_remote_pull".to_string(),
-                value: 8,
-            }),
-        },
-        TestSyncPushRecord {
-            change_log: ChangelogRow {
-                id: 2,
-                table_name: ChangelogTableName::Number,
-                row_id: SUPPLIER_INVOICE.0.to_string(),
-                row_action: ChangelogAction::Upsert,
-            },
-            push_data: json!(LegacyNumberRow {
-                ID: SUPPLIER_INVOICE.0.to_string(),
-                name: "supplier_invoice_number_for_store_store_remote_pull".to_string(),
-                value: 3,
-            }),
-        },
+        number_stock_take_push_record(),
+        number_inv_adjustment_push_record(),
+        number_customer_invoice_push_record(),
+        number_supplier_invoice_push_record(),
     ]
 }

--- a/server/src/sync/translation_remote/test_data/stock_line.rs
+++ b/server/src/sync/translation_remote/test_data/stock_line.rs
@@ -1,11 +1,18 @@
 use chrono::NaiveDate;
-use repository::schema::{RemoteSyncBufferAction, RemoteSyncBufferRow, StockLineRow};
+use repository::schema::{
+    ChangelogAction, ChangelogRow, ChangelogTableName, RemoteSyncBufferAction, RemoteSyncBufferRow,
+    StockLineRow,
+};
+use serde_json::json;
 
 use crate::sync::translation_remote::{
     pull::{IntegrationRecord, IntegrationUpsertRecord},
+    stock_line::LegacyStockLineRow,
     test_data::TestSyncRecord,
     TRANSLATION_RECORD_ITEM_LINE,
 };
+
+use super::TestSyncPushRecord;
 
 const ITEM_LINE_1: (&'static str, &'static str) = (
     "0a3b02d0f0d211eb8dddb54df6d741bc",
@@ -50,6 +57,60 @@ const ITEM_LINE_1: (&'static str, &'static str) = (
       "weight_per_pack": 0
     }"#,
 );
+fn item_line_1_pull_record() -> TestSyncRecord {
+    TestSyncRecord {
+        translated_record: Some(IntegrationRecord::from_upsert(
+            IntegrationUpsertRecord::StockLine(StockLineRow {
+                id: ITEM_LINE_1.0.to_string(),
+                store_id: "store_a".to_string(),
+                item_id: "item_a".to_string(),
+                location_id: None,
+                batch: Some("stocktake_1".to_string()),
+                pack_size: 1,
+                cost_price_per_pack: 5.0,
+                sell_price_per_pack: 10.0,
+                available_number_of_packs: 694,
+                total_number_of_packs: 694,
+                expiry_date: Some(NaiveDate::from_ymd(2022, 2, 17)),
+                on_hold: false,
+                note: Some("test note".to_string()),
+            }),
+        )),
+        identifier: "Stock line 1",
+        remote_sync_buffer_row: RemoteSyncBufferRow {
+            id: "Stock_line_10".to_string(),
+            table_name: TRANSLATION_RECORD_ITEM_LINE.to_string(),
+            record_id: ITEM_LINE_1.0.to_string(),
+            data: ITEM_LINE_1.1.to_string(),
+            action: RemoteSyncBufferAction::Update,
+        },
+    }
+}
+fn item_line_1_push_record() -> TestSyncPushRecord {
+    TestSyncPushRecord {
+        change_log: ChangelogRow {
+            id: 2,
+            table_name: ChangelogTableName::StockLine,
+            row_id: ITEM_LINE_1.0.to_string(),
+            row_action: ChangelogAction::Upsert,
+        },
+        push_data: json!(LegacyStockLineRow {
+            ID: ITEM_LINE_1.0.to_string(),
+            store_ID: "store_a".to_string(),
+            item_ID: "item_a".to_string(),
+            batch: Some("stocktake_1".to_string()),
+            expiry_date: Some(NaiveDate::from_ymd(2022, 2, 17)),
+            hold: false,
+            location_ID: None,
+            pack_size: 1,
+            available: 694,
+            quantity: 694,
+            cost_price: 5.0,
+            sell_price: 10.0,
+            note: Some("test note".to_string())
+        }),
+    }
+}
 
 const ITEM_LINE_2: (&'static str, &'static str) = (
     "4E8AAB798EBA42819E24CC753C800242",
@@ -94,63 +155,67 @@ const ITEM_LINE_2: (&'static str, &'static str) = (
       "weight_per_pack": 0
   }"#,
 );
+fn item_line_2_pull_record() -> TestSyncRecord {
+    TestSyncRecord {
+        translated_record: Some(IntegrationRecord::from_upsert(
+            IntegrationUpsertRecord::StockLine(StockLineRow {
+                id: ITEM_LINE_2.0.to_string(),
+                store_id: "store_a".to_string(),
+                item_id: "item_b".to_string(),
+                location_id: None,
+                batch: Some("none".to_string()),
+                pack_size: 1,
+                cost_price_per_pack: 0.0,
+                sell_price_per_pack: 0.0,
+                available_number_of_packs: -1000,
+                total_number_of_packs: -1001,
+                expiry_date: None,
+                on_hold: false,
+                note: Some("".to_string()),
+            }),
+        )),
+        identifier: "Stock line 2",
+        remote_sync_buffer_row: RemoteSyncBufferRow {
+            id: "Stock_line_20".to_string(),
+            table_name: TRANSLATION_RECORD_ITEM_LINE.to_string(),
+            record_id: ITEM_LINE_2.0.to_string(),
+            data: ITEM_LINE_2.1.to_string(),
+            action: RemoteSyncBufferAction::Update,
+        },
+    }
+}
+fn item_line_2_push_record() -> TestSyncPushRecord {
+    TestSyncPushRecord {
+        change_log: ChangelogRow {
+            id: 2,
+            table_name: ChangelogTableName::StockLine,
+            row_id: ITEM_LINE_2.0.to_string(),
+            row_action: ChangelogAction::Upsert,
+        },
+        push_data: json!(LegacyStockLineRow {
+            ID: ITEM_LINE_2.0.to_string(),
+            store_ID: "store_a".to_string(),
+            item_ID: "item_b".to_string(),
+            batch: Some("none".to_string()),
+            expiry_date: None,
+            hold: false,
+            location_ID: None,
+            pack_size: 1,
+            available: -1000,
+            quantity: -1001,
+            cost_price: 0.0,
+            sell_price: 0.0,
+            note: Some("".to_string())
+        }),
+    }
+}
 
 #[allow(dead_code)]
 pub fn get_test_stock_line_records() -> Vec<TestSyncRecord> {
-    vec![
-        TestSyncRecord {
-            translated_record: Some(IntegrationRecord::from_upsert(
-                IntegrationUpsertRecord::StockLine(StockLineRow {
-                    id: ITEM_LINE_1.0.to_string(),
-                    store_id: "store_a".to_string(),
-                    item_id: "item_a".to_string(),
-                    location_id: None,
-                    batch: Some("stocktake_1".to_string()),
-                    pack_size: 1,
-                    cost_price_per_pack: 5.0,
-                    sell_price_per_pack: 10.0,
-                    available_number_of_packs: 694,
-                    total_number_of_packs: 694,
-                    expiry_date: Some(NaiveDate::from_ymd(2022, 2, 17)),
-                    on_hold: false,
-                    note: Some("test note".to_string()),
-                }),
-            )),
-            identifier: "Stock line 1",
-            remote_sync_buffer_row: RemoteSyncBufferRow {
-                id: "Stock_line_10".to_string(),
-                table_name: TRANSLATION_RECORD_ITEM_LINE.to_string(),
-                record_id: ITEM_LINE_1.0.to_string(),
-                data: ITEM_LINE_1.1.to_string(),
-                action: RemoteSyncBufferAction::Update,
-            },
-        },
-        TestSyncRecord {
-            translated_record: Some(IntegrationRecord::from_upsert(
-                IntegrationUpsertRecord::StockLine(StockLineRow {
-                    id: ITEM_LINE_2.0.to_string(),
-                    store_id: "store_a".to_string(),
-                    item_id: "item_b".to_string(),
-                    location_id: None,
-                    batch: Some("none".to_string()),
-                    pack_size: 1,
-                    cost_price_per_pack: 0.0,
-                    sell_price_per_pack: 0.0,
-                    available_number_of_packs: -1000,
-                    total_number_of_packs: -1001,
-                    expiry_date: None,
-                    on_hold: false,
-                    note: Some("".to_string()),
-                }),
-            )),
-            identifier: "Stock line 2",
-            remote_sync_buffer_row: RemoteSyncBufferRow {
-                id: "Stock_line_20".to_string(),
-                table_name: TRANSLATION_RECORD_ITEM_LINE.to_string(),
-                record_id: ITEM_LINE_2.0.to_string(),
-                data: ITEM_LINE_2.1.to_string(),
-                action: RemoteSyncBufferAction::Update,
-            },
-        },
-    ]
+    vec![item_line_1_pull_record(), item_line_2_pull_record()]
+}
+
+#[allow(dead_code)]
+pub fn get_test_push_stock_line_records() -> Vec<TestSyncPushRecord> {
+    vec![item_line_1_push_record(), item_line_2_push_record()]
 }

--- a/server/src/sync/translation_remote/test_data/stock_line.rs
+++ b/server/src/sync/translation_remote/test_data/stock_line.rs
@@ -2,7 +2,8 @@ use chrono::NaiveDate;
 use repository::schema::{RemoteSyncBufferAction, RemoteSyncBufferRow, StockLineRow};
 
 use crate::sync::translation_remote::{
-    test_data::TestSyncRecord, IntegrationRecord, IntegrationUpsertRecord,
+    pull::{IntegrationRecord, IntegrationUpsertRecord},
+    test_data::TestSyncRecord,
     TRANSLATION_RECORD_ITEM_LINE,
 };
 

--- a/server/src/sync/translation_remote/test_data/stocktake.rs
+++ b/server/src/sync/translation_remote/test_data/stocktake.rs
@@ -4,7 +4,8 @@ use repository::schema::{
 };
 
 use crate::sync::translation_remote::{
-    test_data::TestSyncRecord, IntegrationRecord, IntegrationUpsertRecord,
+    pull::{IntegrationRecord, IntegrationUpsertRecord},
+    test_data::TestSyncRecord,
     TRANSLATION_RECORD_STOCKTAKE,
 };
 

--- a/server/src/sync/translation_remote/test_data/stocktake.rs
+++ b/server/src/sync/translation_remote/test_data/stocktake.rs
@@ -1,13 +1,18 @@
 use chrono::NaiveDate;
 use repository::schema::{
-    RemoteSyncBufferAction, RemoteSyncBufferRow, StocktakeRow, StocktakeStatus,
+    ChangelogAction, ChangelogRow, ChangelogTableName, RemoteSyncBufferAction, RemoteSyncBufferRow,
+    StocktakeRow, StocktakeStatus,
 };
+use serde_json::json;
 
 use crate::sync::translation_remote::{
     pull::{IntegrationRecord, IntegrationUpsertRecord},
+    stocktake::{LegacyStocktakeRow, LegacyStocktakeStatus},
     test_data::TestSyncRecord,
     TRANSLATION_RECORD_STOCKTAKE,
 };
+
+use super::TestSyncPushRecord;
 
 const STOCKTAKE_1: (&'static str, &'static str) = (
     "0a375950f0d211eb8dddb54df6d741bc",
@@ -30,10 +35,8 @@ const STOCKTAKE_1: (&'static str, &'static str) = (
       "type": ""
     }"#,
 );
-
-#[allow(dead_code)]
-pub fn get_test_stocktake_records() -> Vec<TestSyncRecord> {
-    vec![TestSyncRecord {
+fn stocktake_pull_record() -> TestSyncRecord {
+    TestSyncRecord {
         translated_record: Some(IntegrationRecord::from_upsert(
             IntegrationUpsertRecord::Stocktake(StocktakeRow {
                 id: STOCKTAKE_1.0.to_string(),
@@ -55,5 +58,35 @@ pub fn get_test_stocktake_records() -> Vec<TestSyncRecord> {
             data: STOCKTAKE_1.1.to_string(),
             action: RemoteSyncBufferAction::Update,
         },
-    }]
+    }
+}
+fn stocktake_push_record() -> TestSyncPushRecord {
+    TestSyncPushRecord {
+        change_log: ChangelogRow {
+            id: 2,
+            table_name: ChangelogTableName::Stocktake,
+            row_id: STOCKTAKE_1.0.to_string(),
+            row_action: ChangelogAction::Upsert,
+        },
+        push_data: json!(LegacyStocktakeRow {
+            ID: STOCKTAKE_1.0.to_string(),
+            store_ID: "store_a".to_string(),
+            status: LegacyStocktakeStatus::Fn,
+            Description: Some("Test".to_string()),
+            comment: None,
+            invad_additions_ID: Some("inbound_shipment_a".to_string()),
+            serial_number: 3,
+            stock_take_created_date: NaiveDate::from_ymd(2021, 07, 30)
+        }),
+    }
+}
+
+#[allow(dead_code)]
+pub fn get_test_stocktake_records() -> Vec<TestSyncRecord> {
+    vec![stocktake_pull_record()]
+}
+
+#[allow(dead_code)]
+pub fn get_test_push_stocktake_records() -> Vec<TestSyncPushRecord> {
+    vec![stocktake_push_record()]
 }

--- a/server/src/sync/translation_remote/test_data/stocktake_line.rs
+++ b/server/src/sync/translation_remote/test_data/stocktake_line.rs
@@ -1,7 +1,8 @@
 use repository::schema::{RemoteSyncBufferAction, RemoteSyncBufferRow, StocktakeLineRow};
 
 use crate::sync::translation_remote::{
-    test_data::TestSyncRecord, IntegrationRecord, IntegrationUpsertRecord,
+    pull::{IntegrationRecord, IntegrationUpsertRecord},
+    test_data::TestSyncRecord,
     TRANSLATION_RECORD_STOCKTAKE_LINE,
 };
 

--- a/server/src/sync/translation_remote/test_data/trans_line.rs
+++ b/server/src/sync/translation_remote/test_data/trans_line.rs
@@ -5,7 +5,8 @@ use repository::{
 };
 
 use crate::sync::translation_remote::{
-    test_data::TestSyncRecord, IntegrationRecord, IntegrationUpsertRecord,
+    pull::{IntegrationRecord, IntegrationUpsertRecord},
+    test_data::TestSyncRecord,
     TRANSLATION_RECORD_TRANS_LINE,
 };
 

--- a/server/src/sync/translation_remote/test_data/trans_line.rs
+++ b/server/src/sync/translation_remote/test_data/trans_line.rs
@@ -131,7 +131,7 @@ pub fn get_test_trans_line_records() -> Vec<TestSyncRecord> {
     vec![
         TestSyncRecord {
             translated_record: Some(IntegrationRecord::from_upsert(
-                IntegrationUpsertRecord::ShipmentLine(InvoiceLineRow {
+                IntegrationUpsertRecord::InvoiceLine(InvoiceLineRow {
                     id: TRANS_LINE_1.0.to_string(),
                     invoice_id: "outbound_shipment_a".to_string(),
                     item_id: mock_item_a().id,
@@ -163,7 +163,7 @@ pub fn get_test_trans_line_records() -> Vec<TestSyncRecord> {
         },
         TestSyncRecord {
             translated_record: Some(IntegrationRecord::from_upsert(
-                IntegrationUpsertRecord::ShipmentLine(InvoiceLineRow {
+                IntegrationUpsertRecord::InvoiceLine(InvoiceLineRow {
                     id: TRANS_LINE_2.0.to_string(),
                     invoice_id: "outbound_shipment_a".to_string(),
                     item_id: mock_item_a().id,

--- a/server/src/sync/translation_remote/test_data/trans_line.rs
+++ b/server/src/sync/translation_remote/test_data/trans_line.rs
@@ -1,14 +1,21 @@
 use chrono::NaiveDate;
 use repository::{
     mock::{mock_item_a, mock_stock_line_a},
-    schema::{InvoiceLineRow, InvoiceLineRowType, RemoteSyncBufferAction, RemoteSyncBufferRow},
+    schema::{
+        ChangelogAction, ChangelogRow, ChangelogTableName, InvoiceLineRow, InvoiceLineRowType,
+        RemoteSyncBufferAction, RemoteSyncBufferRow,
+    },
 };
+use serde_json::json;
 
 use crate::sync::translation_remote::{
+    invoice_line::{LegacyTransLineRow, LegacyTransLineType},
     pull::{IntegrationRecord, IntegrationUpsertRecord},
     test_data::TestSyncRecord,
     TRANSLATION_RECORD_TRANS_LINE,
 };
+
+use super::TestSyncPushRecord;
 
 const TRANS_LINE_1: (&'static str, &'static str) = (
     "12ee2f10f0d211eb8dddb54df6d741bc",
@@ -67,6 +74,66 @@ const TRANS_LINE_1: (&'static str, &'static str) = (
         }
     "#,
 );
+fn trans_line_1_pull_record() -> TestSyncRecord {
+    TestSyncRecord {
+        translated_record: Some(IntegrationRecord::from_upsert(
+            IntegrationUpsertRecord::InvoiceLine(InvoiceLineRow {
+                id: TRANS_LINE_1.0.to_string(),
+                invoice_id: "outbound_shipment_a".to_string(),
+                item_id: mock_item_a().id,
+                item_name: mock_item_a().name,
+                item_code: mock_item_a().code,
+                stock_line_id: Some(mock_stock_line_a().id),
+                location_id: None,
+                batch: Some("stocktake_1".to_string()),
+                expiry_date: None,
+                pack_size: 1,
+                cost_price_per_pack: 0.0,
+                sell_price_per_pack: 0.0,
+                total_before_tax: 0.0,
+                total_after_tax: 0.0,
+                tax: None,
+                r#type: InvoiceLineRowType::StockIn,
+                number_of_packs: 700,
+                note: None,
+            }),
+        )),
+        identifier: "Transact line 1",
+        remote_sync_buffer_row: RemoteSyncBufferRow {
+            id: "Transact_line_10".to_string(),
+            table_name: TRANSLATION_RECORD_TRANS_LINE.to_string(),
+            record_id: TRANS_LINE_1.0.to_string(),
+            data: TRANS_LINE_1.1.to_string(),
+            action: RemoteSyncBufferAction::Update,
+        },
+    }
+}
+fn trans_line_1_push_record() -> TestSyncPushRecord {
+    TestSyncPushRecord {
+        change_log: ChangelogRow {
+            id: 2,
+            table_name: ChangelogTableName::InvoiceLine,
+            row_id: TRANS_LINE_1.0.to_string(),
+            row_action: ChangelogAction::Upsert,
+        },
+        push_data: json!(LegacyTransLineRow {
+            ID: TRANS_LINE_1.0.to_string(),
+            transaction_ID: "outbound_shipment_a".to_string(),
+            item_ID: mock_item_a().id,
+            item_name: mock_item_a().name,
+            item_line_ID: Some(mock_stock_line_a().id),
+            location_ID: None,
+            batch: Some("stocktake_1".to_string()),
+            expiry_date: None,
+            pack_size: 1,
+            cost_price: 0.0,
+            sell_price: 0.0,
+            _type: LegacyTransLineType::StockIn,
+            quantity: 700,
+            note: None
+        }),
+    }
+}
 
 // placeholder
 const TRANS_LINE_2: (&'static str, &'static str) = (
@@ -99,7 +166,7 @@ const TRANS_LINE_2: (&'static str, &'static str) = (
         "optionID": "",
         "order_lines_ID": "",
         "pack_inners_in_outer": 0,
-        "pack_size": 1,
+        "pack_size": 5,
         "pack_size_inner": 0,
         "prescribedQuantity": 0,
         "price_extension": 0,
@@ -125,73 +192,73 @@ const TRANS_LINE_2: (&'static str, &'static str) = (
         "volume_per_pack": 0
     }"#,
 );
+fn trans_line_2_pull_record() -> TestSyncRecord {
+    TestSyncRecord {
+        translated_record: Some(IntegrationRecord::from_upsert(
+            IntegrationUpsertRecord::InvoiceLine(InvoiceLineRow {
+                id: TRANS_LINE_2.0.to_string(),
+                invoice_id: "outbound_shipment_a".to_string(),
+                item_id: mock_item_a().id,
+                item_name: mock_item_a().name,
+                item_code: mock_item_a().code,
+                stock_line_id: Some(mock_stock_line_a().id),
+                location_id: None,
+                batch: None,
+                expiry_date: Some(NaiveDate::from_ymd(2022, 02, 22)),
+                pack_size: 5,
+                cost_price_per_pack: 5.0,
+                sell_price_per_pack: 10.0,
+                total_before_tax: 5.0 * 1000.0,
+                total_after_tax: 5.0 * 1000.0,
+                tax: None,
+                r#type: InvoiceLineRowType::UnallocatedStock,
+                number_of_packs: 200,
+                note: Some("every FOUR to SIX hours when necessary ".to_string()),
+            }),
+        )),
+        identifier: "Transact line (Placeholder)",
+        remote_sync_buffer_row: RemoteSyncBufferRow {
+            id: "Transact_line_20".to_string(),
+            table_name: TRANSLATION_RECORD_TRANS_LINE.to_string(),
+            record_id: TRANS_LINE_2.0.to_string(),
+            data: TRANS_LINE_2.1.to_string(),
+            action: RemoteSyncBufferAction::Update,
+        },
+    }
+}
+fn trans_line_2_push_record() -> TestSyncPushRecord {
+    TestSyncPushRecord {
+        change_log: ChangelogRow {
+            id: 2,
+            table_name: ChangelogTableName::InvoiceLine,
+            row_id: TRANS_LINE_2.0.to_string(),
+            row_action: ChangelogAction::Upsert,
+        },
+        push_data: json!(LegacyTransLineRow {
+            ID: TRANS_LINE_2.0.to_string(),
+            transaction_ID: "outbound_shipment_a".to_string(),
+            item_ID: mock_item_a().id,
+            item_name: mock_item_a().name,
+            item_line_ID: Some(mock_stock_line_a().id),
+            location_ID: None,
+            batch: None,
+            expiry_date: Some(NaiveDate::from_ymd(2022, 02, 22)),
+            pack_size: 5,
+            cost_price: 5.0,
+            sell_price: 10.0,
+            _type: LegacyTransLineType::Placeholder,
+            quantity: 1000,
+            note: Some("every FOUR to SIX hours when necessary ".to_string()),
+        }),
+    }
+}
 
 #[allow(dead_code)]
 pub fn get_test_trans_line_records() -> Vec<TestSyncRecord> {
-    vec![
-        TestSyncRecord {
-            translated_record: Some(IntegrationRecord::from_upsert(
-                IntegrationUpsertRecord::InvoiceLine(InvoiceLineRow {
-                    id: TRANS_LINE_1.0.to_string(),
-                    invoice_id: "outbound_shipment_a".to_string(),
-                    item_id: mock_item_a().id,
-                    item_name: mock_item_a().name,
-                    item_code: mock_item_a().code,
-                    stock_line_id: Some(mock_stock_line_a().id),
-                    location_id: None,
-                    batch: Some("stocktake_1".to_string()),
-                    expiry_date: None,
-                    pack_size: 1,
-                    cost_price_per_pack: 0.0,
-                    sell_price_per_pack: 0.0,
-                    total_before_tax: 0.0,
-                    total_after_tax: 0.0,
-                    tax: None,
-                    r#type: InvoiceLineRowType::StockIn,
-                    number_of_packs: 700,
-                    note: None,
-                }),
-            )),
-            identifier: "Transact line 1",
-            remote_sync_buffer_row: RemoteSyncBufferRow {
-                id: "Transact_line_10".to_string(),
-                table_name: TRANSLATION_RECORD_TRANS_LINE.to_string(),
-                record_id: TRANS_LINE_1.0.to_string(),
-                data: TRANS_LINE_1.1.to_string(),
-                action: RemoteSyncBufferAction::Update,
-            },
-        },
-        TestSyncRecord {
-            translated_record: Some(IntegrationRecord::from_upsert(
-                IntegrationUpsertRecord::InvoiceLine(InvoiceLineRow {
-                    id: TRANS_LINE_2.0.to_string(),
-                    invoice_id: "outbound_shipment_a".to_string(),
-                    item_id: mock_item_a().id,
-                    item_name: mock_item_a().name,
-                    item_code: mock_item_a().code,
-                    stock_line_id: Some(mock_stock_line_a().id),
-                    location_id: None,
-                    batch: None,
-                    expiry_date: Some(NaiveDate::from_ymd(2022, 02, 22)),
-                    pack_size: 1,
-                    cost_price_per_pack: 5.0,
-                    sell_price_per_pack: 10.0,
-                    total_before_tax: 5.0 * 1000.0,
-                    total_after_tax: 5.0 * 1000.0,
-                    tax: None,
-                    r#type: InvoiceLineRowType::UnallocatedStock,
-                    number_of_packs: 1000,
-                    note: Some("every FOUR to SIX hours when necessary ".to_string()),
-                }),
-            )),
-            identifier: "Transact line (Placeholder)",
-            remote_sync_buffer_row: RemoteSyncBufferRow {
-                id: "Transact_line_20".to_string(),
-                table_name: TRANSLATION_RECORD_TRANS_LINE.to_string(),
-                record_id: TRANS_LINE_2.0.to_string(),
-                data: TRANS_LINE_2.1.to_string(),
-                action: RemoteSyncBufferAction::Update,
-            },
-        },
-    ]
+    vec![trans_line_1_pull_record(), trans_line_2_pull_record()]
+}
+
+#[allow(dead_code)]
+pub fn get_test_push_trans_line_records() -> Vec<TestSyncPushRecord> {
+    vec![trans_line_1_push_record(), trans_line_2_push_record()]
 }

--- a/server/src/sync/translation_remote/test_data/transact.rs
+++ b/server/src/sync/translation_remote/test_data/transact.rs
@@ -109,10 +109,10 @@ fn transact_1_pull_record() -> TestSyncRecord {
                 allocated_datetime: None,
                 picked_datetime: None,
                 shipped_datetime: None,
-                delivered_datetime: None,
-                verified_datetime: Some(
+                delivered_datetime: Some(
                     NaiveDate::from_ymd(2021, 7, 30).and_hms(0, 0, 0) + Duration::seconds(47046),
                 ),
+                verified_datetime: None,
                 colour: Some("#000000".to_string()),
                 requisition_id: None,
                 linked_invoice_id: None,
@@ -152,7 +152,7 @@ fn transact_1_push_record() -> TestSyncPushRecord {
             entry_date: NaiveDate::from_ymd(2021, 7, 30),
             entry_time: 47046,
             ship_date: None,
-            arrival_date_actual: None,
+            arrival_date_actual: Some(NaiveDate::from_ymd(2021, 7, 30)),
             confirm_date: Some(NaiveDate::from_ymd(2021, 7, 30)),
             confirm_time: 47046
         }),

--- a/server/src/sync/translation_remote/test_data/transact.rs
+++ b/server/src/sync/translation_remote/test_data/transact.rs
@@ -1,13 +1,18 @@
 use chrono::{Duration, NaiveDate};
 use repository::schema::{
-    InvoiceRow, InvoiceRowStatus, InvoiceRowType, RemoteSyncBufferAction, RemoteSyncBufferRow,
+    ChangelogAction, ChangelogRow, ChangelogTableName, InvoiceRow, InvoiceRowStatus,
+    InvoiceRowType, RemoteSyncBufferAction, RemoteSyncBufferRow,
 };
+use serde_json::json;
 
 use crate::sync::translation_remote::{
+    invoice::{LegacyTransactRow, LegacyTransactStatus, LegacyTransactType},
     pull::{IntegrationRecord, IntegrationUpsertRecord},
     test_data::TestSyncRecord,
     TRANSLATION_RECORD_TRANSACT,
 };
+
+use super::TestSyncPushRecord;
 
 const TRANSACT_1: (&'static str, &'static str) = (
     "12e889c0f0d211eb8dddb54df6d741bc",
@@ -85,6 +90,74 @@ const TRANSACT_1: (&'static str, &'static str) = (
       "waybill_number": ""
   }"#,
 );
+fn transact_1_pull_record() -> TestSyncRecord {
+    TestSyncRecord {
+        translated_record: Some(IntegrationRecord::from_upsert(
+            IntegrationUpsertRecord::Invoice(InvoiceRow {
+                id: TRANSACT_1.0.to_string(),
+                store_id: "store_a".to_string(),
+                name_id: "name_store_a".to_string(),
+                name_store_id: Some("store_a".to_string()),
+                invoice_number: 1,
+                r#type: InvoiceRowType::InboundShipment,
+                status: InvoiceRowStatus::Delivered,
+                on_hold: false,
+                comment: None,
+                their_reference: None,
+                created_datetime: NaiveDate::from_ymd(2021, 7, 30).and_hms(0, 0, 0)
+                    + Duration::seconds(47046),
+                allocated_datetime: None,
+                picked_datetime: None,
+                shipped_datetime: None,
+                delivered_datetime: None,
+                verified_datetime: Some(
+                    NaiveDate::from_ymd(2021, 7, 30).and_hms(0, 0, 0) + Duration::seconds(47046),
+                ),
+                colour: Some("#000000".to_string()),
+                requisition_id: None,
+                linked_invoice_id: None,
+            }),
+        )),
+        identifier: "Transact 1",
+        remote_sync_buffer_row: RemoteSyncBufferRow {
+            id: "Transact_10".to_string(),
+            table_name: TRANSLATION_RECORD_TRANSACT.to_string(),
+            record_id: TRANSACT_1.0.to_string(),
+            data: TRANSACT_1.1.to_string(),
+            action: RemoteSyncBufferAction::Update,
+        },
+    }
+}
+fn transact_1_push_record() -> TestSyncPushRecord {
+    TestSyncPushRecord {
+        change_log: ChangelogRow {
+            id: 2,
+            table_name: ChangelogTableName::Invoice,
+            row_id: TRANSACT_1.0.to_string(),
+            row_action: ChangelogAction::Upsert,
+        },
+        push_data: json!(LegacyTransactRow {
+            ID: TRANSACT_1.0.to_string(),
+            name_ID: "name_store_a".to_string(),
+            store_ID: "store_a".to_string(),
+            invoice_num: 1,
+            _type: LegacyTransactType::Si,
+            status: LegacyTransactStatus::Cn,
+            hold: false,
+            comment: None,
+            their_ref: None,
+            Colour: 0,
+            requisition_ID: None,
+            linked_transaction_id: None,
+            entry_date: NaiveDate::from_ymd(2021, 7, 30),
+            entry_time: 47046,
+            ship_date: None,
+            arrival_date_actual: None,
+            confirm_date: Some(NaiveDate::from_ymd(2021, 7, 30)),
+            confirm_time: 47046
+        }),
+    }
+}
 
 const TRANSACT_2: (&'static str, &'static str) = (
     "7c860d40f3f111eb9647790fe8518386",
@@ -162,80 +235,79 @@ const TRANSACT_2: (&'static str, &'static str) = (
         "waybill_number": ""
     }"#,
 );
+fn transact_2_pull_record() -> TestSyncRecord {
+    TestSyncRecord {
+        translated_record: Some(IntegrationRecord::from_upsert(
+            IntegrationUpsertRecord::Invoice(InvoiceRow {
+                id: TRANSACT_2.0.to_string(),
+                store_id: "store_b".to_string(),
+                name_id: "name_store_b".to_string(),
+                name_store_id: Some("store_b".to_string()),
+                invoice_number: 4,
+                r#type: InvoiceRowType::OutboundShipment,
+                status: InvoiceRowStatus::Verified,
+                on_hold: false,
+                comment: None,
+                their_reference: None,
+                created_datetime: NaiveDate::from_ymd(2021, 8, 3).and_hms(0, 0, 0)
+                    + Duration::seconds(44806),
+                allocated_datetime: None,
+                picked_datetime: None,
+                shipped_datetime: None,
+                delivered_datetime: None,
+                verified_datetime: None,
+                colour: Some("#1A1919".to_string()),
+                requisition_id: None,
+                linked_invoice_id: None,
+            }),
+        )),
+        identifier: "Transact 2",
+        remote_sync_buffer_row: RemoteSyncBufferRow {
+            id: "Transact_20".to_string(),
+            table_name: TRANSLATION_RECORD_TRANSACT.to_string(),
+            record_id: TRANSACT_2.0.to_string(),
+            data: TRANSACT_2.1.to_string(),
+            action: RemoteSyncBufferAction::Update,
+        },
+    }
+}
+fn transact_2_push_record() -> TestSyncPushRecord {
+    TestSyncPushRecord {
+        change_log: ChangelogRow {
+            id: 2,
+            table_name: ChangelogTableName::Invoice,
+            row_id: TRANSACT_2.0.to_string(),
+            row_action: ChangelogAction::Upsert,
+        },
+        push_data: json!(LegacyTransactRow {
+            ID: TRANSACT_2.0.to_string(),
+            name_ID: "name_store_b".to_string(),
+            store_ID: "store_b".to_string(),
+            invoice_num: 4,
+            _type: LegacyTransactType::Ci,
+            status: LegacyTransactStatus::Fn,
+            hold: false,
+            comment: None,
+            their_ref: None,
+            Colour: 1710361,
+            requisition_ID: None,
+            linked_transaction_id: None,
+            entry_date: NaiveDate::from_ymd(2021, 8, 3),
+            entry_time: 44806,
+            ship_date: None,
+            arrival_date_actual: None,
+            confirm_date: None,
+            confirm_time: 0
+        }),
+    }
+}
 
 #[allow(dead_code)]
 pub fn get_test_transact_records() -> Vec<TestSyncRecord> {
-    vec![
-        TestSyncRecord {
-            translated_record: Some(IntegrationRecord::from_upsert(
-                IntegrationUpsertRecord::Invoice(InvoiceRow {
-                    id: TRANSACT_1.0.to_string(),
-                    store_id: "store_a".to_string(),
-                    name_id: "name_store_a".to_string(),
-                    name_store_id: Some("store_a".to_string()),
-                    invoice_number: 1,
-                    r#type: InvoiceRowType::InboundShipment,
-                    status: InvoiceRowStatus::Delivered,
-                    on_hold: false,
-                    comment: None,
-                    their_reference: None,
-                    created_datetime: NaiveDate::from_ymd(2021, 7, 30).and_hms(0, 0, 0)
-                        + Duration::seconds(47046),
-                    allocated_datetime: None,
-                    picked_datetime: None,
-                    shipped_datetime: None,
-                    delivered_datetime: None,
-                    verified_datetime: Some(
-                        NaiveDate::from_ymd(2021, 7, 30).and_hms(0, 0, 0)
-                            + Duration::seconds(47046),
-                    ),
-                    colour: Some("#000000".to_string()),
-                    requisition_id: None,
-                    linked_invoice_id: None,
-                }),
-            )),
-            identifier: "Transact 1",
-            remote_sync_buffer_row: RemoteSyncBufferRow {
-                id: "Transact_10".to_string(),
-                table_name: TRANSLATION_RECORD_TRANSACT.to_string(),
-                record_id: TRANSACT_1.0.to_string(),
-                data: TRANSACT_1.1.to_string(),
-                action: RemoteSyncBufferAction::Update,
-            },
-        },
-        TestSyncRecord {
-            translated_record: Some(IntegrationRecord::from_upsert(
-                IntegrationUpsertRecord::Invoice(InvoiceRow {
-                    id: TRANSACT_2.0.to_string(),
-                    store_id: "store_b".to_string(),
-                    name_id: "name_store_b".to_string(),
-                    name_store_id: Some("store_b".to_string()),
-                    invoice_number: 4,
-                    r#type: InvoiceRowType::OutboundShipment,
-                    status: InvoiceRowStatus::Verified,
-                    on_hold: false,
-                    comment: None,
-                    their_reference: None,
-                    created_datetime: NaiveDate::from_ymd(2021, 8, 3).and_hms(0, 0, 0)
-                        + Duration::seconds(44806),
-                    allocated_datetime: None,
-                    picked_datetime: None,
-                    shipped_datetime: None,
-                    delivered_datetime: None,
-                    verified_datetime: None,
-                    colour: Some("#1A1919".to_string()),
-                    requisition_id: None,
-                    linked_invoice_id: None,
-                }),
-            )),
-            identifier: "Transact 2",
-            remote_sync_buffer_row: RemoteSyncBufferRow {
-                id: "Transact_20".to_string(),
-                table_name: TRANSLATION_RECORD_TRANSACT.to_string(),
-                record_id: TRANSACT_2.0.to_string(),
-                data: TRANSACT_2.1.to_string(),
-                action: RemoteSyncBufferAction::Update,
-            },
-        },
-    ]
+    vec![transact_1_pull_record(), transact_2_pull_record()]
+}
+
+#[allow(dead_code)]
+pub fn get_test_push_transact_records() -> Vec<TestSyncPushRecord> {
+    vec![transact_1_push_record(), transact_2_push_record()]
 }

--- a/server/src/sync/translation_remote/test_data/transact.rs
+++ b/server/src/sync/translation_remote/test_data/transact.rs
@@ -4,7 +4,8 @@ use repository::schema::{
 };
 
 use crate::sync::translation_remote::{
-    test_data::TestSyncRecord, IntegrationRecord, IntegrationUpsertRecord,
+    pull::{IntegrationRecord, IntegrationUpsertRecord},
+    test_data::TestSyncRecord,
     TRANSLATION_RECORD_TRANSACT,
 };
 

--- a/server/src/sync/translation_remote/test_data/transact.rs
+++ b/server/src/sync/translation_remote/test_data/transact.rs
@@ -168,7 +168,7 @@ pub fn get_test_transact_records() -> Vec<TestSyncRecord> {
     vec![
         TestSyncRecord {
             translated_record: Some(IntegrationRecord::from_upsert(
-                IntegrationUpsertRecord::Shipment(InvoiceRow {
+                IntegrationUpsertRecord::Invoice(InvoiceRow {
                     id: TRANSACT_1.0.to_string(),
                     store_id: "store_a".to_string(),
                     name_id: "name_store_a".to_string(),
@@ -205,7 +205,7 @@ pub fn get_test_transact_records() -> Vec<TestSyncRecord> {
         },
         TestSyncRecord {
             translated_record: Some(IntegrationRecord::from_upsert(
-                IntegrationUpsertRecord::Shipment(InvoiceRow {
+                IntegrationUpsertRecord::Invoice(InvoiceRow {
                     id: TRANSACT_2.0.to_string(),
                     store_id: "store_b".to_string(),
                     name_id: "name_store_b".to_string(),

--- a/server/src/test_utils.rs
+++ b/server/src/test_utils.rs
@@ -22,6 +22,7 @@ pub fn get_test_settings(db_name: &str) -> Settings {
             interval: 100000000,
             central_server_site_id: 0,
             site_id: 1,
+            site_hardware_id: "".to_string(),
         },
         auth: AuthSettings {
             token_secret: "testtokensecret".to_string(),

--- a/server/src/test_utils.rs
+++ b/server/src/test_utils.rs
@@ -20,6 +20,8 @@ pub fn get_test_settings(db_name: &str) -> Settings {
             password: "password".to_string(),
             url: "http://localhost:5432".to_string(),
             interval: 100000000,
+            central_server_site_id: 0,
+            site_id: 1,
         },
         auth: AuthSettings {
             token_secret: "testtokensecret".to_string(),


### PR DESCRIPTION
Some initial (untested) push implementation

- After the initial pull the push cursor is set to the end of the changelog so that push starts from this point.
- Push translation for Numbers
- Some push tests that build upon existing pull test data. Pull and push test data could be merged at a later stage but I didn't want to edit all existing test data definitions in one go.

#714 