### PR TITLE
850 batch mutation as service for inbound shipment

### DIFF
--- a/graphql/batch_mutations/src/batch_inbound_shipment.rs
+++ b/graphql/batch_mutations/src/batch_inbound_shipment.rs
@@ -1,349 +1,664 @@
-// use async_graphql::*;
-// use graphql_invoice::mutations::inbound_shipment::{
-//     get_delete_inbound_shipment_response, get_insert_inbound_shipment_response,
-//     get_update_inbound_shipment_response, DeleteInboundShipmentInput,
-//     DeleteInboundShipmentResponse, InsertInboundShipmentInput, InsertInboundShipmentResponse,
-//     UpdateInboundShipmentInput, UpdateInboundShipmentResponse,
-// };
-// use graphql_invoice_line::mutations::inbound_shipment_line::{
-//     get_delete_inbound_shipment_line_response, get_insert_inbound_shipment_line_response,
-//     get_update_inbound_shipment_line_response, DeleteInboundShipmentLineInput,
-//     DeleteInboundShipmentLineResponse, InsertInboundShipmentLineInput,
-//     InsertInboundShipmentLineResponse, UpdateInboundShipmentLineInput,
-//     UpdateInboundShipmentLineResponse,
-// };
-// use repository::StorageConnectionManager;
+use async_graphql::*;
+use graphql_core::ContextExt;
+use graphql_invoice::mutations::inbound_shipment;
+use graphql_invoice_line::mutations::inbound_shipment_line;
+use repository::Invoice;
+use repository::InvoiceLine;
+use service::invoice::inbound_shipment::DeleteInboundShipment;
+use service::invoice::inbound_shipment::DeleteInboundShipmentError;
+use service::invoice_line::inbound_shipment_line::InsertInboundShipmentLine;
+use service::invoice_line::inbound_shipment_line::InsertInboundShipmentLineError;
+use service::invoice_line::inbound_shipment_line::UpdateInboundShipmentLine;
+use service::invoice_line::inbound_shipment_line::UpdateInboundShipmentLineError;
+use service::{
+    invoice::inbound_shipment::{
+        BatchInboundShipment, BatchInboundShipmentResult, InputWithResult, InsertInboundShipment,
+        InsertInboundShipmentError, UpdateInboundShipment, UpdateInboundShipmentError,
+    },
+    invoice_line::inbound_shipment_line::{
+        DeleteInboundShipmentLine, DeleteInboundShipmentLineError,
+    },
+};
 
-// #[derive(SimpleObject)]
-// #[graphql(concrete(
-//     name = "InsertInboundShipmentResponseWithId",
-//     params(InsertInboundShipmentResponse)
-// ))]
-// #[graphql(concrete(
-//     name = "UpdateInboundShipmentResponseWithId",
-//     params(UpdateInboundShipmentResponse)
-// ))]
-// #[graphql(concrete(
-//     name = "DeleteInboundShipmentResponseWithId",
-//     params(DeleteInboundShipmentResponse)
-// ))]
-// #[graphql(concrete(
-//     name = "InsertInboundShipmentLineResponseWithId",
-//     params(InsertInboundShipmentLineResponse)
-// ))]
-// #[graphql(concrete(
-//     name = "UpdateInboundShipmentLineResponseWithId",
-//     params(UpdateInboundShipmentLineResponse)
-// ))]
-// #[graphql(concrete(
-//     name = "DeleteInboundShipmentLineResponseWithId",
-//     params(DeleteInboundShipmentLineResponse)
-// ))]
-// pub struct MutationWithId<T: OutputType> {
-//     pub id: String,
-//     pub response: T,
-// }
+#[derive(SimpleObject)]
+#[graphql(concrete(
+    name = "InsertInboundShipmentResponseWithId",
+    params(inbound_shipment::InsertResponse)
+))]
+#[graphql(concrete(
+    name = "UpdateInboundShipmentResponseWithId",
+    params(inbound_shipment::UpdateResponse)
+))]
+#[graphql(concrete(
+    name = "DeleteInboundShipmentResponseWithId",
+    params(inbound_shipment::DeleteResponse)
+))]
+#[graphql(concrete(
+    name = "InsertInboundShipmentLineResponseWithId",
+    params(inbound_shipment_line::InsertResponse)
+))]
+#[graphql(concrete(
+    name = "UpdateInboundShipmentLineResponseWithId",
+    params(inbound_shipment_line::UpdateResponse)
+))]
+#[graphql(concrete(
+    name = "DeleteInboundShipmentLineResponseWithId",
+    params(inbound_shipment_line::DeleteResponse)
+))]
+pub struct MutationWithId<T: OutputType> {
+    pub id: String,
+    pub response: T,
+}
 
-// #[derive(SimpleObject)]
-// pub struct BatchInboundShipmentResponse {
-//     insert_inbound_shipments: Option<Vec<MutationWithId<InsertInboundShipmentResponse>>>,
-//     insert_inbound_shipment_lines: Option<Vec<MutationWithId<InsertInboundShipmentLineResponse>>>,
-//     update_inbound_shipment_lines: Option<Vec<MutationWithId<UpdateInboundShipmentLineResponse>>>,
-//     delete_inbound_shipment_lines: Option<Vec<MutationWithId<DeleteInboundShipmentLineResponse>>>,
-//     update_inbound_shipments: Option<Vec<MutationWithId<UpdateInboundShipmentResponse>>>,
-//     delete_inbound_shipments: Option<Vec<MutationWithId<DeleteInboundShipmentResponse>>>,
-// }
+#[derive(SimpleObject)]
+pub struct BatchInboundShipmentResponse {
+    insert_inbound_shipments: Option<Vec<MutationWithId<inbound_shipment::InsertResponse>>>,
+    insert_inbound_shipment_lines:
+        Option<Vec<MutationWithId<inbound_shipment_line::InsertResponse>>>,
+    update_inbound_shipment_lines:
+        Option<Vec<MutationWithId<inbound_shipment_line::UpdateResponse>>>,
+    delete_inbound_shipment_lines:
+        Option<Vec<MutationWithId<inbound_shipment_line::DeleteResponse>>>,
+    update_inbound_shipments: Option<Vec<MutationWithId<inbound_shipment::UpdateResponse>>>,
+    delete_inbound_shipments: Option<Vec<MutationWithId<inbound_shipment::DeleteResponse>>>,
+}
 
-// #[derive(InputObject)]
-// pub struct BatchInboundShipmentInput {
-//     pub insert_inbound_shipments: Option<Vec<InsertInboundShipmentInput>>,
-//     pub insert_inbound_shipment_lines: Option<Vec<InsertInboundShipmentLineInput>>,
-//     pub update_inbound_shipment_lines: Option<Vec<UpdateInboundShipmentLineInput>>,
-//     pub delete_inbound_shipment_lines: Option<Vec<DeleteInboundShipmentLineInput>>,
-//     pub update_inbound_shipments: Option<Vec<UpdateInboundShipmentInput>>,
-//     pub delete_inbound_shipments: Option<Vec<DeleteInboundShipmentInput>>,
-// }
+#[derive(InputObject)]
+pub struct BatchInboundShipmentInput {
+    pub insert_inbound_shipments: Option<Vec<inbound_shipment::InsertInput>>,
+    pub insert_inbound_shipment_lines: Option<Vec<inbound_shipment_line::InsertInput>>,
+    pub update_inbound_shipment_lines: Option<Vec<inbound_shipment_line::UpdateInput>>,
+    pub delete_inbound_shipment_lines: Option<Vec<inbound_shipment_line::DeleteInput>>,
+    pub update_inbound_shipments: Option<Vec<inbound_shipment::UpdateInput>>,
+    pub delete_inbound_shipments: Option<Vec<inbound_shipment::DeleteInput>>,
+    pub continue_on_error: Option<bool>,
+}
 
-// pub fn get_batch_inbound_shipment_response(
-//     connection_manager: &StorageConnectionManager,
-//     store_id: &str,
-//     input: BatchInboundShipmentInput,
-// ) -> BatchInboundShipmentResponse {
-//     let mut result = BatchInboundShipmentResponse {
-//         insert_inbound_shipments: None,
-//         insert_inbound_shipment_lines: None,
-//         update_inbound_shipment_lines: None,
-//         delete_inbound_shipment_lines: None,
-//         update_inbound_shipments: None,
-//         delete_inbound_shipments: None,
-//     };
+pub fn batch_inbound_shipment(
+    ctx: &Context<'_>,
+    store_id: &str,
+    input: BatchInboundShipmentInput,
+) -> Result<BatchInboundShipmentResponse> {
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.context()?;
 
-//     if let Some(inputs) = input.insert_inbound_shipments {
-//         let (has_errors, responses) =
-//             do_insert_inbound_shipments(connection_manager, store_id, inputs);
-//         result.insert_inbound_shipments = Some(responses);
-//         if has_errors {
-//             return result;
-//         }
-//     }
+    let response = service_provider.invoice_service.batch_inbound_shipment(
+        &service_context,
+        store_id,
+        input.to_domain(),
+    )?;
 
-//     if let Some(inputs) = input.insert_inbound_shipment_lines {
-//         let (has_errors, responses) = do_insert_inbound_shipment_lines(connection_manager, inputs);
-//         result.insert_inbound_shipment_lines = Some(responses);
-//         if has_errors {
-//             return result;
-//         }
-//     }
+    Ok(BatchInboundShipmentResponse::from_domain(response)?)
+}
 
-//     if let Some(inputs) = input.update_inbound_shipment_lines {
-//         let (has_errors, responses) = do_update_inbound_shipment_lines(connection_manager, inputs);
-//         result.update_inbound_shipment_lines = Some(responses);
-//         if has_errors {
-//             return result;
-//         }
-//     }
+impl BatchInboundShipmentInput {
+    fn to_domain(self) -> BatchInboundShipment {
+        let BatchInboundShipmentInput {
+            insert_inbound_shipments,
+            insert_inbound_shipment_lines,
+            update_inbound_shipment_lines,
+            delete_inbound_shipment_lines,
+            update_inbound_shipments,
+            delete_inbound_shipments,
+            continue_on_error,
+        } = self;
 
-//     if let Some(inputs) = input.delete_inbound_shipment_lines {
-//         let (has_errors, responses) = do_delete_inbound_shipment_lines(connection_manager, inputs);
-//         result.delete_inbound_shipment_lines = Some(responses);
-//         if has_errors {
-//             return result;
-//         }
-//     }
+        BatchInboundShipment {
+            insert_shipment: insert_inbound_shipments
+                .map(|inputs| inputs.into_iter().map(|input| input.to_domain()).collect()),
+            insert_line: insert_inbound_shipment_lines
+                .map(|inputs| inputs.into_iter().map(|input| input.to_domain()).collect()),
+            update_line: update_inbound_shipment_lines
+                .map(|inputs| inputs.into_iter().map(|input| input.to_domain()).collect()),
+            delete_line: delete_inbound_shipment_lines
+                .map(|inputs| inputs.into_iter().map(|input| input.to_domain()).collect()),
+            update_shipment: update_inbound_shipments
+                .map(|inputs| inputs.into_iter().map(|input| input.to_domain()).collect()),
+            delete_shipment: delete_inbound_shipments
+                .map(|inputs| inputs.into_iter().map(|input| input.to_domain()).collect()),
+            continue_on_error,
+        }
+    }
+}
 
-//     if let Some(inputs) = input.update_inbound_shipments {
-//         let (has_errors, responses) = do_update_inbound_shipments(connection_manager, inputs);
-//         result.update_inbound_shipments = Some(responses);
-//         if has_errors {
-//             return result;
-//         }
-//     }
+pub trait VecOrNone<T> {
+    fn vec_or_none(self) -> Option<Vec<T>>;
+}
 
-//     if let Some(inputs) = input.delete_inbound_shipments {
-//         let (has_errors, responses) = do_delete_inbound_shipments(connection_manager, inputs);
-//         result.delete_inbound_shipments = Some(responses);
-//         if has_errors {
-//             return result;
-//         }
-//     }
+impl<T> VecOrNone<T> for Vec<T> {
+    fn vec_or_none(self) -> Option<Vec<T>> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(self)
+        }
+    }
+}
 
-//     result
-// }
+impl BatchInboundShipmentResponse {
+    fn from_domain(
+        BatchInboundShipmentResult {
+            insert_shipment,
+            insert_line,
+            update_line,
+            delete_line,
+            update_shipment,
+            delete_shipment,
+        }: BatchInboundShipmentResult,
+    ) -> Result<BatchInboundShipmentResponse> {
+        let insert_inbound_shipments_result: Result<
+            Vec<MutationWithId<inbound_shipment::InsertResponse>>,
+        > = insert_shipment
+            .into_iter()
+            .map(map_insert_shipment)
+            .collect();
 
-// pub fn do_insert_inbound_shipments(
-//     connection: &StorageConnectionManager,
-//     store_id: &str,
-//     inputs: Vec<InsertInboundShipmentInput>,
-// ) -> (bool, Vec<MutationWithId<InsertInboundShipmentResponse>>) {
-//     let mut responses = Vec::new();
-//     for input in inputs.into_iter() {
-//         let id = input.id.clone();
-//         responses.push(MutationWithId {
-//             id,
-//             response: get_insert_inbound_shipment_response(connection, store_id, input),
-//         });
-//     }
-//     let has_errors = responses.iter().any(|mutation_with_id| {
-//         matches!(
-//             mutation_with_id.response,
-//             InsertInboundShipmentResponse::Error(_)
-//         )
-//     });
+        let insert_inbound_shipment_lines_result: Result<
+            Vec<MutationWithId<inbound_shipment_line::InsertResponse>>,
+        > = insert_line.into_iter().map(map_insert_line).collect();
 
-//     (has_errors, responses)
-// }
+        let update_inbound_shipment_lines_result: Result<
+            Vec<MutationWithId<inbound_shipment_line::UpdateResponse>>,
+        > = update_line.into_iter().map(map_update_line).collect();
 
-// pub fn do_update_inbound_shipments(
-//     connection: &StorageConnectionManager,
-//     inputs: Vec<UpdateInboundShipmentInput>,
-// ) -> (bool, Vec<MutationWithId<UpdateInboundShipmentResponse>>) {
-//     let mut responses = Vec::new();
-//     for input in inputs.into_iter() {
-//         let id = input.id.clone();
-//         responses.push(MutationWithId {
-//             id,
-//             response: get_update_inbound_shipment_response(connection, input),
-//         });
-//     }
-//     let has_errors = responses.iter().any(|mutation_with_id| {
-//         matches!(
-//             mutation_with_id.response,
-//             UpdateInboundShipmentResponse::Error(_)
-//         )
-//     });
+        let delete_inbound_shipment_lines_result: Result<
+            Vec<MutationWithId<inbound_shipment_line::DeleteResponse>>,
+        > = delete_line.into_iter().map(map_delete_line).collect();
 
-//     (has_errors, responses)
-// }
+        let update_inbound_shipments_result: Result<
+            Vec<MutationWithId<inbound_shipment::UpdateResponse>>,
+        > = update_shipment
+            .into_iter()
+            .map(map_update_shipment)
+            .collect();
 
-// pub fn do_delete_inbound_shipments(
-//     connection: &StorageConnectionManager,
-//     inputs: Vec<DeleteInboundShipmentInput>,
-// ) -> (bool, Vec<MutationWithId<DeleteInboundShipmentResponse>>) {
-//     let mut responses = Vec::new();
-//     for input in inputs.into_iter() {
-//         let id = input.id.clone();
-//         responses.push(MutationWithId {
-//             id,
-//             response: get_delete_inbound_shipment_response(connection, input),
-//         });
-//     }
-//     let has_errors = responses.iter().any(|mutation_with_id| {
-//         matches!(
-//             mutation_with_id.response,
-//             DeleteInboundShipmentResponse::Error(_)
-//         )
-//     });
+        let delete_inbound_shipments_result: Result<
+            Vec<MutationWithId<inbound_shipment::DeleteResponse>>,
+        > = delete_shipment
+            .into_iter()
+            .map(map_delete_shipment)
+            .collect();
 
-//     (has_errors, responses)
-// }
+        let result = BatchInboundShipmentResponse {
+            insert_inbound_shipments: insert_inbound_shipments_result?.vec_or_none(),
+            insert_inbound_shipment_lines: insert_inbound_shipment_lines_result?.vec_or_none(),
+            update_inbound_shipment_lines: update_inbound_shipment_lines_result?.vec_or_none(),
+            delete_inbound_shipment_lines: delete_inbound_shipment_lines_result?.vec_or_none(),
+            update_inbound_shipments: update_inbound_shipments_result?.vec_or_none(),
+            delete_inbound_shipments: delete_inbound_shipments_result?.vec_or_none(),
+        };
 
-// pub fn do_insert_inbound_shipment_lines(
-//     connection: &StorageConnectionManager,
-//     inputs: Vec<InsertInboundShipmentLineInput>,
-// ) -> (bool, Vec<MutationWithId<InsertInboundShipmentLineResponse>>) {
-//     let mut responses = Vec::new();
-//     for input in inputs.into_iter() {
-//         let id = input.id.clone();
-//         responses.push(MutationWithId {
-//             id,
-//             response: get_insert_inbound_shipment_line_response(connection, input),
-//         });
-//     }
-//     let has_errors = responses.iter().any(|mutation_with_id| {
-//         matches!(
-//             mutation_with_id.response,
-//             InsertInboundShipmentLineResponse::Error(_)
-//         )
-//     });
+        Ok(result)
+    }
+}
 
-//     (has_errors, responses)
-// }
+fn map_insert_shipment(
+    from: InputWithResult<InsertInboundShipment, Result<Invoice, InsertInboundShipmentError>>,
+) -> Result<MutationWithId<inbound_shipment::InsertResponse>> {
+    let response = match inbound_shipment::insert::map_response(from.result) {
+        Ok(response) => response,
+        Err(standard_error) => {
+            let input_string = format!("{:#?}", from.input);
+            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
+        }
+    };
 
-// pub fn do_update_inbound_shipment_lines(
-//     connection: &StorageConnectionManager,
-//     inputs: Vec<UpdateInboundShipmentLineInput>,
-// ) -> (bool, Vec<MutationWithId<UpdateInboundShipmentLineResponse>>) {
-//     let mut responses = Vec::new();
-//     for input in inputs.into_iter() {
-//         let id = input.id.clone();
-//         responses.push(MutationWithId {
-//             id,
-//             response: get_update_inbound_shipment_line_response(connection, input),
-//         });
-//     }
-//     let has_errors = responses.iter().any(|mutation_with_id| {
-//         matches!(
-//             mutation_with_id.response,
-//             UpdateInboundShipmentLineResponse::Error(_)
-//         )
-//     });
+    Ok(MutationWithId {
+        id: from.input.id.clone(),
+        response,
+    })
+}
 
-//     (has_errors, responses)
-// }
+fn map_update_shipment(
+    from: InputWithResult<UpdateInboundShipment, Result<Invoice, UpdateInboundShipmentError>>,
+) -> Result<MutationWithId<inbound_shipment::UpdateResponse>> {
+    let response = match inbound_shipment::update::map_response(from.result) {
+        Ok(response) => response,
+        Err(standard_error) => {
+            let input_string = format!("{:#?}", from.input);
+            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
+        }
+    };
 
-// pub fn do_delete_inbound_shipment_lines(
-//     connection: &StorageConnectionManager,
-//     inputs: Vec<DeleteInboundShipmentLineInput>,
-// ) -> (bool, Vec<MutationWithId<DeleteInboundShipmentLineResponse>>) {
-//     let mut responses = Vec::new();
-//     for input in inputs.into_iter() {
-//         let id = input.id.clone();
-//         responses.push(MutationWithId {
-//             id,
-//             response: get_delete_inbound_shipment_line_response(connection, input),
-//         });
-//     }
-//     let has_errors = responses.iter().any(|mutation_with_id| {
-//         matches!(
-//             mutation_with_id.response,
-//             DeleteInboundShipmentLineResponse::Error(_)
-//         )
-//     });
+    Ok(MutationWithId {
+        id: from.input.id.clone(),
+        response,
+    })
+}
 
-//     (has_errors, responses)
-// }
+fn map_delete_shipment(
+    from: InputWithResult<DeleteInboundShipment, Result<String, DeleteInboundShipmentError>>,
+) -> Result<MutationWithId<inbound_shipment::DeleteResponse>> {
+    let response = match inbound_shipment::delete::map_response(from.result) {
+        Ok(response) => response,
+        Err(standard_error) => {
+            let input_string = format!("{:#?}", from.input);
+            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
+        }
+    };
 
-// mod graphql {
-//     use crate::graphql::assert_graphql_query;
-//     use repository::{
-//         mock::{mock_stock_line_a, mock_stock_line_b, mock_store_a, MockDataInserts},
-//         InboundShipmentLineRowRepository,
-//     };
-//     use serde_json::json;
-//     use server::test_utils::setup_all;
+    Ok(MutationWithId {
+        id: from.input.id.clone(),
+        response,
+    })
+}
 
-//     #[actix_rt::test]
-//     async fn test_graphql_inboundshipment_batch() {
-//         let (_, connection, _, settings) = setup_all(
-//             "omsupply-database-gql-inboundshipment_batch",
-//             MockDataInserts::all(),
-//         )
-//         .await;
+fn map_insert_line(
+    from: InputWithResult<
+        InsertInboundShipmentLine,
+        Result<InvoiceLine, InsertInboundShipmentLineError>,
+    >,
+) -> Result<MutationWithId<inbound_shipment_line::InsertResponse>> {
+    let response = match inbound_shipment_line::insert::map_response(from.result) {
+        Ok(response) => response,
+        Err(standard_error) => {
+            let input_string = format!("{:#?}", from.input);
+            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
+        }
+    };
 
-//         let query = r#"mutation BatchInboundShipment($storeId: String, $input: BatchInboundShipmentInput!) {
-//           batchInboundShipment(input: $input) {
-//             __typename
-//             ... on BatchInboundShipmentResponses {
-//               insertInboundShipments {
-//                 id
-//                 response {
-//                   ... on InvoiceNod {
-//                     id
-//                   }
-//                 }
-//               }
-//           }
-//         }"#;
+    Ok(MutationWithId {
+        id: from.input.id.clone(),
+        response,
+    })
+}
 
-//         // success
+fn map_update_line(
+    from: InputWithResult<
+        UpdateInboundShipmentLine,
+        Result<InvoiceLine, UpdateInboundShipmentLineError>,
+    >,
+) -> Result<MutationWithId<inbound_shipment_line::UpdateResponse>> {
+    let response = match inbound_shipment_line::update::map_response(from.result) {
+        Ok(response) => response,
+        Err(standard_error) => {
+            let input_string = format!("{:#?}", from.input);
+            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
+        }
+    };
 
-//         let variables = Some(json!({
-//             "input": {
-//               "insertInboundShipments": [
-//                 {
-//                   "id": "batch_inboundshipment_1",
-//                   "createdDatetime": "2022-02-09T15:16:00",
-//                 },
-//               ],
-//               "insertInboundShipmentLines": [
-//                 {
-//                   "id": "batch_inboundshipment_line_1",
-//                   "inboundshipmentId": "batch_inboundshipment_1",
-//                   "stockLineId": stock_line_a.id,
-//                 },
-//                 {
-//                   "id": "batch_inboundshipment_line_2",
-//                   "inboundshipmentId": "batch_inboundshipment_1",
-//                   "stockLineId": stock_line_b.id,
-//                 }
-//               ],
-//             }
-//         }));
-//         let expected = json!({
-//           "batchInboundShipment": {
-//               "__typename": "BatchInboundShipmentResponses",
-//               "insertInboundShipments": [
-//                 {
-//                   "id": "batch_inboundshipment_1",
-//                 }
-//               ],
-//               "insertInboundShipmentLines": [
-//                 {
-//                   "id": "batch_inboundshipment_line_1",
-//                   "response": {
-//                     "id": "batch_inboundshipment_line_1",
-//                   }
-//                 },
-//                 {
-//                   "id": "batch_inboundshipment_line_2",
-//                   "response": {
-//                     "id": "batch_inboundshipment_line_2",
-//                   }
-//                 }
-//               ],
-//             }
-//           }
-//         );
-//         assert_graphql_query!(&settings, query, &variables, &expected, None);
-//     }
-// }
+    Ok(MutationWithId {
+        id: from.input.id.clone(),
+        response,
+    })
+}
+
+fn map_delete_line(
+    from: InputWithResult<
+        DeleteInboundShipmentLine,
+        Result<String, DeleteInboundShipmentLineError>,
+    >,
+) -> Result<MutationWithId<inbound_shipment_line::DeleteResponse>> {
+    let response = match inbound_shipment_line::delete::map_response(from.result) {
+        Ok(response) => response,
+        Err(standard_error) => {
+            let input_string = format!("{:#?}", from.input);
+            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
+        }
+    };
+
+    Ok(MutationWithId {
+        id: from.input.id.clone(),
+        response,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use async_graphql::EmptyMutation;
+    use graphql_core::{
+        assert_graphql_query, assert_standard_graphql_error, test_helpers::setup_graphl_test,
+    };
+    use repository::{
+        mock::MockDataInserts, InvoiceLine, Name, RepositoryError, StorageConnectionManager,
+    };
+    use serde_json::json;
+    use service::{
+        invoice::{
+            inbound_shipment::{
+                BatchInboundShipment, BatchInboundShipmentResult, DeleteInboundShipment,
+                DeleteInboundShipmentError, InputWithResult, InsertInboundShipment,
+                InsertInboundShipmentError, UpdateInboundShipment, UpdateInboundShipmentError,
+            },
+            InvoiceServiceTrait,
+        },
+        invoice_line::inbound_shipment_line::{
+            DeleteInboundShipmentLine, DeleteInboundShipmentLineError, InsertInboundShipmentLine,
+            InsertInboundShipmentLineError, UpdateInboundShipmentLine,
+            UpdateInboundShipmentLineError,
+        },
+        service_provider::{ServiceContext, ServiceProvider},
+    };
+    use util::inline_init;
+
+    use crate::BatchMutations;
+
+    type ServiceInput = BatchInboundShipment;
+    type ServiceResponse = BatchInboundShipmentResult;
+
+    type Method =
+        dyn Fn(&str, ServiceInput) -> Result<ServiceResponse, RepositoryError> + Sync + Send;
+
+    pub struct TestService(pub Box<Method>);
+
+    impl InvoiceServiceTrait for TestService {
+        fn batch_inbound_shipment(
+            &self,
+            _: &ServiceContext,
+            store_id: &str,
+            input: ServiceInput,
+        ) -> Result<ServiceResponse, RepositoryError> {
+            self.0(store_id, input)
+        }
+    }
+
+    fn service_provider(
+        test_service: TestService,
+        connection_manager: &StorageConnectionManager,
+    ) -> ServiceProvider {
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
+        service_provider.invoice_service = Box::new(test_service);
+        service_provider
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_batch_inbound_shipment() {
+        let (_, _, connection_manager, settings) = setup_graphl_test(
+            EmptyMutation,
+            BatchMutations,
+            "test_graphql_batch_inbound_shipment",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation mut($input: BatchInboundShipmentInput!, $storeId: String!) {
+            batchInboundShipment(input: $input, storeId: $storeId) {
+              insertInboundShipments {
+                id
+                response {
+                  ... on InsertInboundShipmentError {
+                    error {
+                      __typename
+                    }
+                  }
+                }
+              }
+              insertInboundShipmentLines {
+                id
+                response {
+                  ... on InsertInboundShipmentLineError {
+                    error {
+                      __typename
+                    }
+                  }
+                }
+              }
+              updateInboundShipmentLines {
+                id
+                response {
+                  ... on UpdateInboundShipmentLineError {
+                    error {
+                      __typename
+                    }
+                  }
+                  ... on InvoiceLineNode {
+                      id
+                  }
+                }
+              }
+              deleteInboundShipmentLines {
+                response {
+                  ... on DeleteInboundShipmentLineError {
+                    error {
+                      __typename
+                    }
+                  }
+                }
+                id
+              }
+              updateInboundShipments {
+                id
+                response {
+                  ... on UpdateInboundShipmentError {
+                    error {
+                      __typename
+                    }
+                  }
+                }
+              }
+              deleteInboundShipments {
+                id
+                response {
+                  ... on DeleteInboundShipmentError {
+                    error {
+                      __typename
+                    }
+                  }
+                }
+              }
+            }
+          }
+          
+        "#;
+
+        let expected = json!({
+            "batchInboundShipment": {
+              "insertInboundShipments": [
+                {
+                  "id": "id1",
+                  "response": {
+                    "error": {
+                      "__typename": "OtherPartyNotASupplier"
+                    }
+                  }
+                }
+              ],
+
+              "insertInboundShipmentLines": [
+                {
+                  "id": "id2",
+                  "response": {
+                    "error": {
+                      "__typename": "ForeignKeyError"
+                    }
+                  }
+                }
+              ],
+              "updateInboundShipmentLines": [
+                {
+                  "id": "id3",
+                  "response": {
+                    "error": {
+                      "__typename": "RecordNotFound"
+                    }
+                  }
+                }
+              ],
+              "deleteInboundShipmentLines": [
+                {
+                  "id": "id4",
+                  "response": {
+                    "error": {
+                      "__typename": "RecordNotFound"
+                    }
+                  }
+                }
+              ],
+              "updateInboundShipments": [
+                {
+                  "id": "id5",
+                  "response": {
+                    "error": {
+                      "__typename": "RecordNotFound"
+                    }
+                  }
+                }
+              ],
+              "deleteInboundShipments": [
+                {
+                  "id": "id6",
+                  "response": {
+                    "error": {
+                      "__typename": "RecordNotFound"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        );
+
+        let variables = Some(json!({
+            "storeId": "n/a",
+            "input": {}
+        }
+        ));
+
+        // Structured Errors
+        let test_service = TestService(Box::new(|_, _| {
+            Ok(BatchInboundShipmentResult {
+                insert_shipment: vec![InputWithResult {
+                    input: inline_init(|input: &mut InsertInboundShipment| {
+                        input.id = "id1".to_string()
+                    }),
+                    result: Err(InsertInboundShipmentError::OtherPartyNotASupplier(
+                        Name::default(),
+                    )),
+                }],
+                insert_line: vec![InputWithResult {
+                    input: inline_init(|input: &mut InsertInboundShipmentLine| {
+                        input.id = "id2".to_string()
+                    }),
+                    result: Err(InsertInboundShipmentLineError::InvoiceDoesNotExist {}),
+                }],
+                update_line: vec![InputWithResult {
+                    input: inline_init(|input: &mut UpdateInboundShipmentLine| {
+                        input.id = "id3".to_string()
+                    }),
+                    result: Err(UpdateInboundShipmentLineError::LineDoesNotExist {}),
+                }],
+                delete_line: vec![InputWithResult {
+                    input: inline_init(|input: &mut DeleteInboundShipmentLine| {
+                        input.id = "id4".to_string()
+                    }),
+                    result: Err(DeleteInboundShipmentLineError::LineDoesNotExist {}),
+                }],
+                update_shipment: vec![InputWithResult {
+                    input: inline_init(|input: &mut UpdateInboundShipment| {
+                        input.id = "id5".to_string()
+                    }),
+                    result: Err(UpdateInboundShipmentError::InvoiceDoesNotExist {}),
+                }],
+                delete_shipment: vec![InputWithResult {
+                    input: inline_init(|input: &mut DeleteInboundShipment| {
+                        input.id = "id6".to_string()
+                    }),
+                    result: Err(DeleteInboundShipmentError::InvoiceDoesNotExist {}),
+                }],
+            })
+        }));
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &variables,
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // Standard Error
+        let test_service = TestService(Box::new(|_, _| {
+            Ok(BatchInboundShipmentResult {
+                insert_shipment: vec![InputWithResult {
+                    input: inline_init(|input: &mut InsertInboundShipment| {
+                        input.id = "id1".to_string()
+                    }),
+                    result: Err(InsertInboundShipmentError::OtherPartyNotASupplier(
+                        Name::default(),
+                    )),
+                }],
+                insert_line: vec![InputWithResult {
+                    input: inline_init(|input: &mut InsertInboundShipmentLine| {
+                        input.id = "id2".to_string()
+                    }),
+                    result: Err(InsertInboundShipmentLineError::InvoiceDoesNotExist {}),
+                }],
+                update_line: vec![],
+                delete_line: vec![],
+                update_shipment: vec![],
+                delete_shipment: vec![InputWithResult {
+                    input: inline_init(|input: &mut DeleteInboundShipment| {
+                        input.id = "id6".to_string()
+                    }),
+                    result: Err(DeleteInboundShipmentError::NotAnInboundShipment {}),
+                }],
+            })
+        }));
+        let expected_message = "Bad user input";
+        let expected_extensions = json!({
+            "input":
+                format!(
+                    "{:#?}",
+                    inline_init(|input: &mut DeleteInboundShipment| {
+                        input.id = "id6".to_string()
+                    })
+                )
+        });
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &variables,
+            &expected_message,
+            Some(expected_extensions),
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // Success
+
+        let expected = json!({
+            "batchInboundShipment": {
+              "deleteInboundShipmentLines": null,
+              "deleteInboundShipments": null,
+              "insertInboundShipmentLines": null,
+              "insertInboundShipments": null,
+              "updateInboundShipmentLines": [
+                {
+                  "id": "id3",
+                  "response": {
+                    "id": "id3"
+                  }
+                }
+              ],
+              "updateInboundShipments": null
+            }
+          }
+        );
+
+        let test_service = TestService(Box::new(|_, _| {
+            Ok(BatchInboundShipmentResult {
+                insert_shipment: vec![],
+                insert_line: vec![],
+                update_line: vec![InputWithResult {
+                    input: inline_init(|input: &mut UpdateInboundShipmentLine| {
+                        input.id = "id3".to_string()
+                    }),
+                    result: Ok(inline_init(|input: &mut InvoiceLine| {
+                        input.invoice_line_row.id = "id3".to_string()
+                    })),
+                }],
+                delete_line: vec![],
+                update_shipment: vec![],
+                delete_shipment: vec![],
+            })
+        }));
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &variables,
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+}

--- a/graphql/batch_mutations/src/lib.rs
+++ b/graphql/batch_mutations/src/lib.rs
@@ -3,22 +3,23 @@ mod batch_outbound_shipment;
 mod batch_stocktake;
 use self::batch_stocktake::*;
 use async_graphql::*;
+use batch_inbound_shipment::{
+    batch_inbound_shipment, BatchInboundShipmentInput, BatchInboundShipmentResponse,
+};
 
 #[derive(Default, Clone)]
 pub struct BatchMutations;
 
 #[Object]
 impl BatchMutations {
-    // async fn batch_inbound_shipment(
-    //     &self,
-    //     ctx: &Context<'_>,
-    //     store_id: String,
-    //     input: BatchInboundShipmentInput,
-    // ) -> BatchInboundShipmentResponse {
-    //     let connection_manager = ctx.get_connection_manager();
-
-    //     get_batch_inbound_shipment_response(connection_manager, &store_id, input)
-    // }
+    async fn batch_inbound_shipment(
+        &self,
+        ctx: &Context<'_>,
+        store_id: String,
+        input: BatchInboundShipmentInput,
+    ) -> Result<BatchInboundShipmentResponse> {
+        batch_inbound_shipment(ctx, &store_id, input)
+    }
 
     // async fn batch_outbound_shipment(
     //     &self,

--- a/graphql/invoice/src/lib.rs
+++ b/graphql/invoice/src/lib.rs
@@ -5,7 +5,7 @@ use graphql_types::types::*;
 mod invoice_queries;
 use self::invoice_queries::*;
 
-mod mutations;
+pub mod mutations;
 use self::mutations::{inbound_shipment, outbound_shipment};
 
 #[cfg(test)]

--- a/graphql/invoice/src/mutations/inbound_shipment/delete.rs
+++ b/graphql/invoice/src/mutations/inbound_shipment/delete.rs
@@ -32,18 +32,11 @@ pub fn delete(ctx: &Context<'_>, store_id: &str, input: DeleteInput) -> Result<D
     let service_provider = ctx.service_provider();
     let service_context = service_provider.context()?;
 
-    let response = match service_provider.invoice_service.delete_inbound_shipment(
+    map_response(service_provider.invoice_service.delete_inbound_shipment(
         &service_context,
         store_id,
         input.to_domain(),
-    ) {
-        Ok(deleted_id) => DeleteResponse::Response(GenericDeleteResponse(deleted_id)),
-        Err(error) => DeleteResponse::Error(DeleteError {
-            error: map_error(error)?,
-        }),
-    };
-
-    Ok(response)
+    ))
 }
 
 #[derive(Interface)]
@@ -56,10 +49,21 @@ pub enum DeleteErrorInterface {
 }
 
 impl DeleteInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let DeleteInput { id } = self;
         ServiceInput { id }
     }
+}
+
+pub fn map_response(from: Result<String, ServiceError>) -> Result<DeleteResponse> {
+    let result = match from {
+        Ok(deleted_id) => DeleteResponse::Response(GenericDeleteResponse(deleted_id)),
+        Err(error) => DeleteResponse::Error(DeleteError {
+            error: map_error(error)?,
+        }),
+    };
+
+    Ok(result)
 }
 
 fn map_error(error: ServiceError) -> Result<DeleteErrorInterface> {

--- a/graphql/invoice/src/mutations/outbound_shipment/insert.rs
+++ b/graphql/invoice/src/mutations/outbound_shipment/insert.rs
@@ -54,7 +54,7 @@ pub fn insert(ctx: &Context<'_>, store_id: &str, input: InsertInput) -> Result<I
 }
 
 impl InsertInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let InsertInput {
             id,
             other_party_id,

--- a/graphql/invoice/src/mutations/outbound_shipment/update.rs
+++ b/graphql/invoice/src/mutations/outbound_shipment/update.rs
@@ -84,7 +84,7 @@ pub enum UpdateErrorInterface {
 }
 
 impl UpdateInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let UpdateInput {
             id,
             other_party_id,

--- a/graphql/invoice_line/src/lib.rs
+++ b/graphql/invoice_line/src/lib.rs
@@ -1,4 +1,4 @@
-mod mutations;
+pub mod mutations;
 use self::mutations::{inbound_shipment_line, outbound_shipment_line};
 use async_graphql::*;
 

--- a/graphql/invoice_line/src/mutations/inbound_shipment_line/delete.rs
+++ b/graphql/invoice_line/src/mutations/inbound_shipment_line/delete.rs
@@ -35,17 +35,11 @@ pub fn delete(ctx: &Context<'_>, store_id: &str, input: DeleteInput) -> Result<D
     let service_provider = ctx.service_provider();
     let service_context = service_provider.context()?;
 
-    let response = match service_provider
-        .invoice_line_service
-        .delete_inbound_shipment_line(&service_context, store_id, input.to_domain())
-    {
-        Ok(deleted_id) => DeleteResponse::Response(GenericDeleteResponse(deleted_id)),
-        Err(error) => DeleteResponse::Error(DeleteError {
-            error: map_error(error)?,
-        }),
-    };
-
-    Ok(response)
+    map_response(
+        service_provider
+            .invoice_line_service
+            .delete_inbound_shipment_line(&service_context, store_id, input.to_domain()),
+    )
 }
 
 #[derive(Interface)]
@@ -59,10 +53,21 @@ pub enum DeleteErrorInterface {
 }
 
 impl DeleteInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let DeleteInput { id, invoice_id } = self;
         ServiceInput { id, invoice_id }
     }
+}
+
+pub fn map_response(from: Result<String, ServiceError>) -> Result<DeleteResponse> {
+    let result = match from {
+        Ok(deleted_id) => DeleteResponse::Response(GenericDeleteResponse(deleted_id)),
+        Err(error) => DeleteResponse::Error(DeleteError {
+            error: map_error(error)?,
+        }),
+    };
+
+    Ok(result)
 }
 
 fn map_error(error: ServiceError) -> Result<DeleteErrorInterface> {

--- a/graphql/invoice_line/src/mutations/inbound_shipment_line/update.rs
+++ b/graphql/invoice_line/src/mutations/inbound_shipment_line/update.rs
@@ -7,6 +7,7 @@ use graphql_core::standard_graphql_error::StandardGraphqlError;
 use graphql_core::ContextExt;
 use graphql_types::types::InvoiceLineNode;
 
+use repository::InvoiceLine;
 use service::invoice_line::inbound_shipment_line::{
     UpdateInboundShipmentLine as ServiceInput, UpdateInboundShipmentLineError as ServiceError,
 };
@@ -70,7 +71,7 @@ pub enum UpdateErrorInterface {
 }
 
 impl UpdateInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let UpdateInput {
             id,
             invoice_id,
@@ -97,6 +98,17 @@ impl UpdateInput {
             number_of_packs,
         }
     }
+}
+
+pub fn map_response(from: Result<InvoiceLine, ServiceError>) -> Result<UpdateResponse> {
+    let result = match from {
+        Ok(invoice_line) => UpdateResponse::Response(InvoiceLineNode::from_domain(invoice_line)),
+        Err(error) => UpdateResponse::Error(UpdateError {
+            error: map_error(error)?,
+        }),
+    };
+
+    Ok(result)
 }
 
 fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {

--- a/graphql/invoice_line/src/mutations/outbound_shipment_line/line/delete.rs
+++ b/graphql/invoice_line/src/mutations/outbound_shipment_line/line/delete.rs
@@ -57,7 +57,7 @@ pub enum DeleteErrorInterface {
 }
 
 impl DeleteInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let DeleteInput { id, invoice_id } = self;
         ServiceInput { id, invoice_id }
     }

--- a/graphql/invoice_line/src/mutations/outbound_shipment_line/line/insert.rs
+++ b/graphql/invoice_line/src/mutations/outbound_shipment_line/line/insert.rs
@@ -71,7 +71,7 @@ pub enum InsertErrorInterface {
 }
 
 impl InsertInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let InsertInput {
             id,
             invoice_id,

--- a/graphql/invoice_line/src/mutations/outbound_shipment_line/line/update.rs
+++ b/graphql/invoice_line/src/mutations/outbound_shipment_line/line/update.rs
@@ -78,7 +78,7 @@ pub enum UpdateErrorInterface {
 }
 
 impl UpdateInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let UpdateInput {
             id,
             invoice_id,

--- a/graphql/invoice_line/src/mutations/outbound_shipment_line/service_line/delete.rs
+++ b/graphql/invoice_line/src/mutations/outbound_shipment_line/service_line/delete.rs
@@ -57,7 +57,7 @@ pub enum DeleteErrorInterface {
 }
 
 impl DeleteInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let DeleteInput { id, invoice_id } = self;
         ServiceInput { id, invoice_id }
     }

--- a/graphql/invoice_line/src/mutations/outbound_shipment_line/service_line/insert.rs
+++ b/graphql/invoice_line/src/mutations/outbound_shipment_line/service_line/insert.rs
@@ -64,7 +64,7 @@ pub enum InsertErrorInterface {
 }
 
 impl InsertInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let InsertInput {
             id,
             invoice_id,

--- a/graphql/invoice_line/src/mutations/outbound_shipment_line/service_line/update.rs
+++ b/graphql/invoice_line/src/mutations/outbound_shipment_line/service_line/update.rs
@@ -70,7 +70,7 @@ pub enum UpdateErrorInterface {
 }
 
 impl UpdateInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let UpdateInput {
             id,
             invoice_id,

--- a/graphql/requisition/src/mutations/request_requisition/add_from_master_list.rs
+++ b/graphql/requisition/src/mutations/request_requisition/add_from_master_list.rs
@@ -74,7 +74,7 @@ pub fn add_from_master_list(
 }
 
 impl AddFromMasterListInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let AddFromMasterListInput {
             request_requisition_id,
             master_list_id,

--- a/graphql/requisition/src/mutations/request_requisition/delete.rs
+++ b/graphql/requisition/src/mutations/request_requisition/delete.rs
@@ -69,7 +69,7 @@ pub fn delete(ctx: &Context<'_>, store_id: &str, input: DeleteInput) -> Result<D
 }
 
 impl DeleteInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let DeleteInput { id } = self;
         ServiceInput { id }
     }

--- a/graphql/requisition/src/mutations/request_requisition/insert.rs
+++ b/graphql/requisition/src/mutations/request_requisition/insert.rs
@@ -71,7 +71,7 @@ pub fn insert(ctx: &Context<'_>, store_id: &str, input: InsertInput) -> Result<I
 }
 
 impl InsertInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let InsertInput {
             id,
             other_party_id,

--- a/graphql/requisition/src/mutations/request_requisition/update.rs
+++ b/graphql/requisition/src/mutations/request_requisition/update.rs
@@ -78,7 +78,7 @@ pub fn update(ctx: &Context<'_>, store_id: &str, input: UpdateInput) -> Result<U
 }
 
 impl UpdateInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let UpdateInput {
             id,
             colour,

--- a/graphql/requisition/src/mutations/request_requisition/use_suggested_quantity.rs
+++ b/graphql/requisition/src/mutations/request_requisition/use_suggested_quantity.rs
@@ -72,7 +72,7 @@ pub fn use_suggested_quantity(
 }
 
 impl UseSuggestedQuantityInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let UseSuggestedQuantityInput {
             request_requisition_id,
         } = self;

--- a/graphql/requisition/src/mutations/response_requisition/create_requisition_shipment.rs
+++ b/graphql/requisition/src/mutations/response_requisition/create_requisition_shipment.rs
@@ -72,7 +72,7 @@ pub fn create_requisition_shipment(
 }
 
 impl CreateRequisitionShipmentInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let CreateRequisitionShipmentInput {
             response_requisition_id,
         } = self;

--- a/graphql/requisition/src/mutations/response_requisition/supply_requested_quantity.rs
+++ b/graphql/requisition/src/mutations/response_requisition/supply_requested_quantity.rs
@@ -71,7 +71,7 @@ pub fn supply_requested_quantity(
 }
 
 impl SupplyRequestedQuantityInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let SupplyRequestedQuantityInput {
             response_requisition_id,
         } = self;

--- a/graphql/requisition/src/mutations/response_requisition/update.rs
+++ b/graphql/requisition/src/mutations/response_requisition/update.rs
@@ -77,7 +77,7 @@ pub fn update(ctx: &Context<'_>, store_id: &str, input: UpdateInput) -> Result<U
 }
 
 impl UpdateInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let UpdateInput {
             id,
             colour,

--- a/graphql/requisition_line/src/mutations/request_requisition_line/delete.rs
+++ b/graphql/requisition_line/src/mutations/request_requisition_line/delete.rs
@@ -66,7 +66,7 @@ pub fn delete(ctx: &Context<'_>, store_id: &str, input: DeleteInput) -> Result<D
 }
 
 impl DeleteInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let DeleteInput { id } = self;
         ServiceInput { id }
     }

--- a/graphql/requisition_line/src/mutations/request_requisition_line/insert.rs
+++ b/graphql/requisition_line/src/mutations/request_requisition_line/insert.rs
@@ -71,7 +71,7 @@ pub fn insert(ctx: &Context<'_>, store_id: &str, input: InsertInput) -> Result<I
 }
 
 impl InsertInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let InsertInput {
             id,
             item_id,

--- a/graphql/requisition_line/src/mutations/request_requisition_line/update.rs
+++ b/graphql/requisition_line/src/mutations/request_requisition_line/update.rs
@@ -71,7 +71,7 @@ pub fn update(ctx: &Context<'_>, store_id: &str, input: UpdateInput) -> Result<U
 }
 
 impl UpdateInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let UpdateInput {
             id,
             requested_quantity,

--- a/graphql/requisition_line/src/mutations/response_requisition_line/update.rs
+++ b/graphql/requisition_line/src/mutations/response_requisition_line/update.rs
@@ -71,7 +71,7 @@ pub fn update(ctx: &Context<'_>, store_id: &str, input: UpdateInput) -> Result<U
 }
 
 impl UpdateInput {
-    fn to_domain(self) -> ServiceInput {
+    pub fn to_domain(self) -> ServiceInput {
         let UpdateInput {
             id,
             supply_quantity,

--- a/repository/src/db_diesel/invoice.rs
+++ b/repository/src/db_diesel/invoice.rs
@@ -51,6 +51,19 @@ impl<'a> InvoiceRepository<'a> {
         result.map_err(|err| RepositoryError::from(err))
     }
 
+    // TODO replace find_one_by_id with this one
+    pub fn find_one_by_id_option(
+        &self,
+        invoice_id: &str,
+    ) -> Result<Option<InvoiceRow>, RepositoryError> {
+        use crate::schema::diesel_schema::invoice::dsl::*;
+        let result = invoice
+            .filter(id.eq(invoice_id))
+            .first(&self.connection.connection)
+            .optional()?;
+        Ok(result)
+    }
+
     pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<InvoiceRow>, RepositoryError> {
         use crate::schema::diesel_schema::invoice::dsl::*;
         let result = invoice

--- a/repository/src/db_diesel/invoice_line.rs
+++ b/repository/src/db_diesel/invoice_line.rs
@@ -17,7 +17,7 @@ use diesel::{
     prelude::*,
 };
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone, Default)]
 pub struct InvoiceLine {
     pub invoice_line_row: InvoiceLineRow,
     pub invoice_row: InvoiceRow,

--- a/repository/src/db_diesel/invoice_line_row.rs
+++ b/repository/src/db_diesel/invoice_line_row.rs
@@ -58,6 +58,19 @@ impl<'a> InvoiceLineRowRepository<'a> {
         Ok(result)
     }
 
+    // TODO replace find_one_by_id with this one
+    pub fn find_one_by_id_option(
+        &self,
+        invoice_line_id: &str,
+    ) -> Result<Option<InvoiceLineRow>, RepositoryError> {
+        use crate::schema::diesel_schema::invoice_line::dsl::*;
+        let result = invoice_line
+            .filter(id.eq(invoice_line_id))
+            .first(&self.connection.connection)
+            .optional()?;
+        Ok(result)
+    }
+
     pub fn find_many_by_invoice_and_batch_id(
         &self,
         stock_line_id: &str,

--- a/repository/src/db_diesel/mod.rs
+++ b/repository/src/db_diesel/mod.rs
@@ -68,7 +68,7 @@ pub use stocktake::*;
 pub use stocktake_line::*;
 pub use stocktake_line_row::*;
 pub use stocktake_row::*;
-pub use storage_connection::{StorageConnection, StorageConnectionManager, TransactionError};
+pub use storage_connection::*;
 pub use store::*;
 pub use store_row::StoreRowRepository;
 pub use unit_row::UnitRowRepository;

--- a/repository/src/db_diesel/name_query.rs
+++ b/repository/src/db_diesel/name_query.rs
@@ -17,7 +17,7 @@ use diesel::{
     prelude::*,
 };
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone, Default)]
 pub struct Name {
     pub name_row: NameRow,
     pub name_store_join_row: Option<NameStoreJoinRow>,

--- a/repository/src/db_diesel/storage_connection.rs
+++ b/repository/src/db_diesel/storage_connection.rs
@@ -34,6 +34,11 @@ pub enum TransactionError<E> {
     Inner(E),
 }
 
+pub enum OkWithRollback<T> {
+    Ok(T),
+    OkWithRollback(T),
+}
+
 impl<E> TransactionError<E> {
     pub fn to_inner_error(self) -> E
     where
@@ -129,6 +134,18 @@ impl StorageConnection {
         self.transaction_sync_etc(f, true)
     }
 
+    /// Executes operations in transaction. A new transaction is only started if not already in a
+    /// transaction and can be manually rolled back
+    pub fn transaction_sync_with_rollback<'a, T, E, F>(
+        &'a self,
+        f: F,
+    ) -> Result<T, TransactionError<E>>
+    where
+        F: FnOnce(&'a StorageConnection) -> Result<OkWithRollback<T>, E>,
+    {
+        self.transaction_sync_etc_with_rollback(f, true)
+    }
+
     /// # Arguments
     /// * `reuse_tx` - if true and the connection is currently in a transaction no new nested
     /// transaction is started.
@@ -140,18 +157,41 @@ impl StorageConnection {
     where
         F: FnOnce(&'a StorageConnection) -> Result<T, E>,
     {
+        self.transaction_sync_etc_with_rollback(
+            |connection| match f(connection) {
+                Ok(ok) => Ok(OkWithRollback::Ok(ok)),
+                Err(error) => Err(error),
+            },
+            reuse_tx,
+        )
+    }
+
+    /// # Arguments
+    /// * `reuse_tx` - if true and the connection is currently in a transaction no new nested
+    /// transaction is started.
+    pub fn transaction_sync_etc_with_rollback<'a, T, E, F>(
+        &'a self,
+        f: F,
+        reuse_tx: bool,
+    ) -> Result<T, TransactionError<E>>
+    where
+        F: FnOnce(&'a StorageConnection) -> Result<OkWithRollback<T>, E>,
+    {
         let current_level = self.transaction_level.get();
         if current_level > 0 && reuse_tx {
+            // Can only rollback when returning from top level transaction callback
             return match f(self) {
-                Ok(ok) => Ok(ok),
+                Ok(OkWithRollback::Ok(ok)) => Ok(ok),
+                Ok(OkWithRollback::OkWithRollback(ok)) => Ok(ok),
                 Err(err) => Err(TransactionError::Inner(err)),
             };
         }
         let con = &self.connection;
         let transaction_manager = con.transaction_manager();
 
+        println!("starting transaction {}", current_level);
         transaction_manager.begin_transaction(con).map_err(|err| {
-            error!("Failed to rollback tx: {:?}", err);
+            error!("Failed to start tx: {:?}", err);
             TransactionError::Transaction {
                 msg: "Failed to start tx".to_string(),
                 level: current_level + 1,
@@ -161,9 +201,9 @@ impl StorageConnection {
         self.transaction_level.set(current_level + 1);
         let result = f(self);
         self.transaction_level.set(current_level);
-
+        println!("finished {}", current_level);
         match result {
-            Ok(value) => {
+            Ok(OkWithRollback::Ok(value)) => {
                 transaction_manager.commit_transaction(con).map_err(|err| {
                     error!("Failed to end tx: {:?}", err);
                     TransactionError::Transaction {
@@ -171,6 +211,18 @@ impl StorageConnection {
                         level: current_level + 1,
                     }
                 })?;
+                Ok(value)
+            }
+            Ok(OkWithRollback::OkWithRollback(value)) => {
+                transaction_manager
+                    .rollback_transaction(con)
+                    .map_err(|err| {
+                        error!("Failed to rollback tx: {:?}", err);
+                        TransactionError::Transaction {
+                            msg: "Failed to rollback tx".to_string(),
+                            level: current_level + 1,
+                        }
+                    })?;
                 Ok(value)
             }
             Err(e) => {

--- a/repository/src/schema/invoice.rs
+++ b/repository/src/schema/invoice.rs
@@ -1,5 +1,5 @@
 use super::diesel_schema::invoice;
-use chrono::NaiveDateTime;
+use chrono::{NaiveDate, NaiveDateTime};
 use diesel_derive_enum::DbEnum;
 
 #[derive(DbEnum, Debug, Clone, PartialEq, Eq)]
@@ -45,4 +45,30 @@ pub struct InvoiceRow {
     pub colour: Option<String>,
     pub requisition_id: Option<String>,
     pub linked_invoice_id: Option<String>,
+}
+
+impl Default for InvoiceRow {
+    fn default() -> Self {
+        Self {
+            id: String::default(),
+            name_id: String::default(),
+            name_store_id: None,
+            store_id: String::default(),
+            invoice_number: 0,
+            r#type: InvoiceRowType::InboundShipment,
+            status: InvoiceRowStatus::New,
+            on_hold: false,
+            comment: None,
+            their_reference: None,
+            created_datetime: NaiveDate::from_ymd(2022, 1, 22).and_hms(15, 16, 0),
+            allocated_datetime: None,
+            picked_datetime: None,
+            shipped_datetime: None,
+            delivered_datetime: None,
+            verified_datetime: None,
+            colour: None,
+            requisition_id: None,
+            linked_invoice_id: None,
+        }
+    }
 }

--- a/repository/src/schema/invoice_line.rs
+++ b/repository/src/schema/invoice_line.rs
@@ -12,7 +12,13 @@ pub enum InvoiceLineRowType {
     Service,
 }
 
-#[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq)]
+impl Default for InvoiceLineRowType {
+    fn default() -> Self {
+        Self::StockIn
+    }
+}
+
+#[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq, Default)]
 #[table_name = "invoice_line"]
 pub struct InvoiceLineRow {
     pub id: String,

--- a/repository/src/schema/name.rs
+++ b/repository/src/schema/name.rs
@@ -1,6 +1,6 @@
 use super::diesel_schema::name;
 
-#[derive(Clone, Queryable, Insertable, Debug, PartialEq, Eq, AsChangeset)]
+#[derive(Clone, Queryable, Insertable, Debug, PartialEq, Eq, AsChangeset, Default)]
 #[table_name = "name"]
 pub struct NameRow {
     pub id: String,

--- a/service/src/invoice/inbound_shipment/batch.rs
+++ b/service/src/invoice/inbound_shipment/batch.rs
@@ -1,0 +1,289 @@
+use repository::{Invoice, InvoiceLine, OkWithRollback, RepositoryError};
+
+use crate::{
+    invoice_line::inbound_shipment_line::{
+        delete_inbound_shipment_line, insert_inbound_shipment_line, update_inbound_shipment_line,
+        DeleteInboundShipmentLine, DeleteInboundShipmentLineError, InsertInboundShipmentLine,
+        InsertInboundShipmentLineError, UpdateInboundShipmentLine, UpdateInboundShipmentLineError,
+    },
+    service_provider::ServiceContext,
+};
+
+use super::{
+    delete_inbound_shipment, insert_inbound_shipment, update_inbound_shipment,
+    DeleteInboundShipment, DeleteInboundShipmentError, InsertInboundShipment,
+    InsertInboundShipmentError, UpdateInboundShipment, UpdateInboundShipmentError,
+};
+
+#[derive(Clone)]
+pub struct BatchInboundShipment {
+    pub insert_shipment: Option<Vec<InsertInboundShipment>>,
+    pub insert_line: Option<Vec<InsertInboundShipmentLine>>,
+    pub update_line: Option<Vec<UpdateInboundShipmentLine>>,
+    pub delete_line: Option<Vec<DeleteInboundShipmentLine>>,
+    pub update_shipment: Option<Vec<UpdateInboundShipment>>,
+    pub delete_shipment: Option<Vec<DeleteInboundShipment>>,
+    pub continue_on_error: Option<bool>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct InputWithResult<I, R> {
+    pub input: I,
+    pub result: R,
+}
+
+#[derive(Debug)]
+pub struct BatchInboundShipmentResult {
+    pub insert_shipment:
+        Vec<InputWithResult<InsertInboundShipment, Result<Invoice, InsertInboundShipmentError>>>,
+    pub insert_line: Vec<
+        InputWithResult<
+            InsertInboundShipmentLine,
+            Result<InvoiceLine, InsertInboundShipmentLineError>,
+        >,
+    >,
+    pub update_line: Vec<
+        InputWithResult<
+            UpdateInboundShipmentLine,
+            Result<InvoiceLine, UpdateInboundShipmentLineError>,
+        >,
+    >,
+    pub delete_line: Vec<
+        InputWithResult<DeleteInboundShipmentLine, Result<String, DeleteInboundShipmentLineError>>,
+    >,
+    pub update_shipment:
+        Vec<InputWithResult<UpdateInboundShipment, Result<Invoice, UpdateInboundShipmentError>>>,
+    pub delete_shipment:
+        Vec<InputWithResult<DeleteInboundShipment, Result<String, DeleteInboundShipmentError>>>,
+}
+
+pub struct DoMutationResult<T> {
+    pub has_errors: bool,
+    pub results: Vec<T>,
+}
+
+pub fn do_mutations<I, R, E, M>(
+    ctx: &ServiceContext,
+    store_id: &str,
+    inputs: Vec<I>,
+    mutation: M,
+) -> (bool, Vec<InputWithResult<I, Result<R, E>>>)
+where
+    I: Clone,
+    M: Fn(&ServiceContext, &str, I) -> Result<R, E>,
+{
+    let mut has_errors = false;
+    let mut results = vec![];
+
+    for input in inputs {
+        let mutation_result = mutation(ctx, store_id, input.clone());
+        has_errors = mutation_result.is_err();
+        results.push(InputWithResult {
+            input,
+            result: mutation_result,
+        });
+    }
+
+    (has_errors, results)
+}
+
+pub fn batch_inbound_shipment(
+    ctx: &ServiceContext,
+    store_id: &str,
+    input: BatchInboundShipment,
+) -> Result<BatchInboundShipmentResult, RepositoryError> {
+    let result = ctx
+        .connection
+        .transaction_sync_with_rollback(|_| {
+            let continue_on_error = input.continue_on_error.unwrap_or(false);
+            let mut result = BatchInboundShipmentResult {
+                insert_shipment: vec![],
+                insert_line: vec![],
+                update_line: vec![],
+                delete_line: vec![],
+                update_shipment: vec![],
+                delete_shipment: vec![],
+            };
+
+            let (has_error, results) = do_mutations(
+                ctx,
+                store_id,
+                input.insert_shipment.unwrap_or(vec![]),
+                insert_inbound_shipment,
+            );
+            result.insert_shipment = results;
+
+            if has_error && !continue_on_error {
+                return Ok(OkWithRollback::OkWithRollback(result));
+            }
+
+            let (has_error, results) = do_mutations(
+                ctx,
+                store_id,
+                input.insert_line.unwrap_or(vec![]),
+                insert_inbound_shipment_line,
+            );
+            result.insert_line = results;
+
+            if has_error && !continue_on_error {
+                return Ok(OkWithRollback::OkWithRollback(result));
+            }
+
+            let (has_error, results) = do_mutations(
+                ctx,
+                store_id,
+                input.update_line.unwrap_or(vec![]),
+                update_inbound_shipment_line,
+            );
+            result.update_line = results;
+
+            if has_error && !continue_on_error {
+                return Ok(OkWithRollback::OkWithRollback(result));
+            }
+
+            let (has_error, results) = do_mutations(
+                ctx,
+                store_id,
+                input.delete_line.unwrap_or(vec![]),
+                delete_inbound_shipment_line,
+            );
+            result.delete_line = results;
+
+            if has_error && !continue_on_error {
+                return Ok(OkWithRollback::OkWithRollback(result));
+            }
+            let (has_error, results) = do_mutations(
+                ctx,
+                store_id,
+                input.update_shipment.unwrap_or(vec![]),
+                update_inbound_shipment,
+            );
+            result.update_shipment = results;
+
+            if has_error && !continue_on_error {
+                return Ok(OkWithRollback::OkWithRollback(result));
+            }
+
+            let (has_error, results) = do_mutations(
+                ctx,
+                store_id,
+                input.delete_shipment.unwrap_or(vec![]),
+                delete_inbound_shipment,
+            );
+            result.delete_shipment = results;
+
+            let result: Result<OkWithRollback<BatchInboundShipmentResult>, RepositoryError> =
+                if has_error && !continue_on_error {
+                    Ok(OkWithRollback::OkWithRollback(result))
+                } else {
+                    Ok(OkWithRollback::Ok(result))
+                };
+
+            result
+        })
+        .map_err(|error| error.to_inner_error())?;
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod test {
+    use repository::{
+        mock::{mock_item_a, mock_name_a, mock_outbound_shipment_b, MockDataInserts},
+        test_db::setup_all,
+        InvoiceLineRowRepository, InvoiceRepository,
+    };
+    use util::inline_init;
+
+    use crate::{
+        invoice::inbound_shipment::{
+            BatchInboundShipment, DeleteInboundShipment, DeleteInboundShipmentError,
+            InputWithResult, InsertInboundShipment,
+        },
+        invoice_line::inbound_shipment_line::InsertInboundShipmentLine,
+        service_provider::ServiceProvider,
+    };
+
+    #[actix_rt::test]
+    async fn batch_inbound_shipment_service() {
+        let (_, connection, connection_manager, _) =
+            setup_all("batch_inbound_shipment_service", MockDataInserts::all()).await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider.context().unwrap();
+        let service = service_provider.invoice_service;
+
+        let delete_shipment_input = inline_init(|input: &mut DeleteInboundShipment| {
+            input.id = mock_outbound_shipment_b().id;
+        });
+
+        let mut input = BatchInboundShipment {
+            insert_shipment: Some(vec![inline_init(|input: &mut InsertInboundShipment| {
+                input.id = "new_id".to_string();
+                input.other_party_id = mock_name_a().id;
+            })]),
+            insert_line: Some(vec![inline_init(
+                |input: &mut InsertInboundShipmentLine| {
+                    input.invoice_id = "new_id".to_string();
+                    input.id = "new_line_id".to_string();
+                    input.item_id = mock_item_a().id;
+                    input.pack_size = 1;
+                    input.number_of_packs = 1;
+                },
+            )]),
+            update_line: None,
+            delete_line: None,
+            update_shipment: None,
+            delete_shipment: Some(vec![delete_shipment_input.clone()]),
+            continue_on_error: None,
+        };
+
+        // Test rollback
+        let result = service
+            .batch_inbound_shipment(&context, "store_a", input.clone())
+            .unwrap();
+
+        assert_eq!(
+            result.delete_shipment,
+            vec![InputWithResult {
+                input: delete_shipment_input,
+                result: Err(DeleteInboundShipmentError::NotAnInboundShipment {})
+            }]
+        );
+
+        assert_eq!(
+            InvoiceRepository::new(&connection)
+                .find_one_by_id_option("new_id")
+                .unwrap(),
+            None
+        );
+
+        assert_eq!(
+            InvoiceLineRowRepository::new(&connection)
+                .find_one_by_id_option("new_line_id")
+                .unwrap(),
+            None
+        );
+
+        // Test no rollback
+        input.continue_on_error = Some(true);
+
+        service
+            .batch_inbound_shipment(&context, "store_a", input)
+            .unwrap();
+
+        assert_ne!(
+            InvoiceRepository::new(&connection)
+                .find_one_by_id_option("new_id")
+                .unwrap(),
+            None
+        );
+
+        assert_ne!(
+            InvoiceLineRowRepository::new(&connection)
+                .find_one_by_id_option("new_line_id")
+                .unwrap(),
+            None
+        );
+    }
+}

--- a/service/src/invoice/inbound_shipment/delete/mod.rs
+++ b/service/src/invoice/inbound_shipment/delete/mod.rs
@@ -6,6 +6,7 @@ use validate::validate;
 
 use crate::{service_provider::ServiceContext, WithDBError};
 
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct DeleteInboundShipment {
     pub id: String,
 }
@@ -31,7 +32,7 @@ pub fn delete_inbound_shipment(
     Ok(invoice_id)
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum DeleteInboundShipmentError {
     InvoiceDoesNotExist,
     DatabaseError(RepositoryError),

--- a/service/src/invoice/inbound_shipment/insert/mod.rs
+++ b/service/src/invoice/inbound_shipment/insert/mod.rs
@@ -10,6 +10,7 @@ mod validate;
 use generate::generate;
 use validate::validate;
 
+#[derive(Clone, Debug, Default)]
 pub struct InsertInboundShipment {
     pub id: String,
     pub other_party_id: String,

--- a/service/src/invoice/inbound_shipment/mod.rs
+++ b/service/src/invoice/inbound_shipment/mod.rs
@@ -6,3 +6,6 @@ pub use self::update::*;
 
 pub mod delete;
 pub use self::delete::*;
+
+pub mod batch;
+pub use self::batch::*;

--- a/service/src/invoice/inbound_shipment/update/mod.rs
+++ b/service/src/invoice/inbound_shipment/update/mod.rs
@@ -18,11 +18,13 @@ use validate::validate;
 
 use self::generate::LineAndStockLine;
 
+#[derive(Clone, Debug)]
 pub enum UpdateInboundShipmentStatus {
     Delivered,
     Verified,
 }
 
+#[derive(Clone, Debug, Default)]
 pub struct UpdateInboundShipment {
     pub id: String,
     pub other_party_id: Option<String>,

--- a/service/src/invoice/mod.rs
+++ b/service/src/invoice/mod.rs
@@ -105,6 +105,15 @@ pub trait InvoiceServiceTrait: Sync + Send {
     ) -> Result<String, DeleteOutboundShipmentError> {
         delete_outbound_shipment(ctx, store_id, id)
     }
+
+    fn batch_inbound_shipment(
+        &self,
+        ctx: &ServiceContext,
+        store_id: &str,
+        input: BatchInboundShipment,
+    ) -> Result<BatchInboundShipmentResult, RepositoryError> {
+        batch_inbound_shipment(ctx, store_id, input)
+    }
 }
 
 pub struct InvoiceService;

--- a/service/src/invoice_line/inbound_shipment_line/delete/mod.rs
+++ b/service/src/invoice_line/inbound_shipment_line/delete/mod.rs
@@ -4,6 +4,8 @@ use repository::{InvoiceLineRowRepository, RepositoryError, StockLineRowReposito
 mod validate;
 
 use validate::validate;
+
+#[derive(Clone, Debug, Default)]
 pub struct DeleteInboundShipmentLine {
     pub id: String,
     pub invoice_id: String,

--- a/service/src/invoice_line/inbound_shipment_line/insert/mod.rs
+++ b/service/src/invoice_line/inbound_shipment_line/insert/mod.rs
@@ -8,6 +8,7 @@ mod validate;
 use generate::generate;
 use validate::validate;
 
+#[derive(Clone, Debug, Default)]
 pub struct InsertInboundShipmentLine {
     pub id: String,
     pub invoice_id: String,

--- a/service/src/invoice_line/inbound_shipment_line/update/mod.rs
+++ b/service/src/invoice_line/inbound_shipment_line/update/mod.rs
@@ -8,6 +8,7 @@ mod validate;
 use generate::generate;
 use validate::validate;
 
+#[derive(Clone, Debug, Default)]
 pub struct UpdateInboundShipmentLine {
     pub id: String,
     pub invoice_id: String,

--- a/util/src/inline_init.rs
+++ b/util/src/inline_init.rs
@@ -1,0 +1,26 @@
+/// ```
+/// # use util::inline_init;
+///
+///  #[derive(Default, Debug, PartialEq)]
+/// struct Check {
+///   id: String,
+///   description: String
+/// }
+///
+/// assert_eq!(
+///     inline_init(|input: &mut Check| input.id = "id1".to_string()),
+///     Check {
+///         id: "id1".to_string(),
+///         description: "".to_string()
+///     }
+/// );
+/// ```
+pub fn inline_init<T, F>(mut f: F) -> T
+where
+    T: Default,
+    F: FnMut(&mut T) -> (),
+{
+    let mut t = T::default();
+    f(&mut t);
+    t
+}

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod constants;
 pub mod hash;
+mod inline_init;
 pub mod timezone;
 pub mod uuid;
+pub use inline_init::*;


### PR DESCRIPTION
https://github.com/openmsupply/remote-server/issues/850

* Added batch service for invoice
* Redone tests (for mapping just wanted to make sure all end points map correctly and are expose in gql, for service wanted to test rollback on/of)
* To use common mapping in individual gql's use `map_response`
* Added a way to roll back transaction with Ok result

Added `inline_init` which i am very happy with