### PR TITLE
714 date time fixes

### DIFF
--- a/server/src/sync/translation_remote/invoice_line.rs
+++ b/server/src/sync/translation_remote/invoice_line.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use crate::sync::SyncTranslationError;
 
 use super::{
-    empty_str_as_option,
+    date_option_to_isostring, empty_str_as_option,
     pull::{IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation},
     push::{to_push_translation_error, PushUpsertRecord, RemotePushUpsertTranslation},
     zero_date_as_option, TRANSLATION_RECORD_TRANS_LINE,
@@ -46,6 +46,7 @@ pub struct LegacyTransLineRow {
     #[serde(deserialize_with = "empty_str_as_option")]
     pub batch: Option<String>,
     #[serde(deserialize_with = "zero_date_as_option")]
+    #[serde(serialize_with = "date_option_to_isostring")]
     pub expiry_date: Option<NaiveDate>,
     pub pack_size: i32,
     pub cost_price: f64,

--- a/server/src/sync/translation_remote/mod.rs
+++ b/server/src/sync/translation_remote/mod.rs
@@ -1,4 +1,4 @@
-use chrono::{Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
+use chrono::{Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime};
 use repository::schema::ChangelogTableName;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -79,19 +79,19 @@ pub fn date_from_date_time(date_time: &NaiveDateTime) -> NaiveDate {
     NaiveDate::from_ymd(date_time.year(), date_time.month(), date_time.day())
 }
 
-/// returns the time part in seconds
-pub fn time_sec_from_date_time(date_time: &NaiveDateTime) -> i64 {
-    let time = date_time.time();
-    let seconds = 60 * 60 * time.hour() + 60 * time.minute() + time.second();
-    seconds as i64
-}
-
 /// V5 gives us a NaiveDate but V3 receives a NaiveDateTime
 fn date_to_isostring<S>(x: &NaiveDate, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
     x.and_hms(0, 0, 0).serialize(s)
+}
+
+fn date_option_to_isostring<S>(x: &Option<NaiveDate>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    x.map(|date| date.and_hms(0, 0, 0)).serialize(s)
 }
 
 /// Currently v5 returns times in sec and v3 expects a time string when posting. To make it more

--- a/server/src/sync/translation_remote/mod.rs
+++ b/server/src/sync/translation_remote/mod.rs
@@ -1,6 +1,6 @@
 use chrono::{Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 use repository::schema::ChangelogTableName;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 mod invoice;
 mod invoice_line;
@@ -84,4 +84,20 @@ pub fn time_sec_from_date_time(date_time: &NaiveDateTime) -> i64 {
     let time = date_time.time();
     let seconds = 60 * 60 * time.hour() + 60 * time.minute() + time.second();
     seconds as i64
+}
+
+/// V5 gives us a NaiveDate but V3 receives a NaiveDateTime
+fn date_to_isostring<S>(x: &NaiveDate, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    x.and_hms(0, 0, 0).serialize(s)
+}
+
+/// Currently v5 returns times in sec and v3 expects a time string when posting. To make it more
+/// consistent v5 behaviour might change in the future. This helper will make it easy to do the
+/// change on our side.
+pub fn naive_time<'de, D: Deserializer<'de>>(d: D) -> Result<NaiveTime, D::Error> {
+    let secs = u32::deserialize(d)?;
+    Ok(NaiveTime::from_num_seconds_from_midnight(secs, 0))
 }

--- a/server/src/sync/translation_remote/requisition.rs
+++ b/server/src/sync/translation_remote/requisition.rs
@@ -12,7 +12,8 @@ use serde::{Deserialize, Serialize};
 use crate::sync::SyncTranslationError;
 
 use super::{
-    date_and_time_to_datatime, date_from_date_time, empty_str_as_option,
+    date_and_time_to_datatime, date_from_date_time, date_option_to_isostring, date_to_isostring,
+    empty_str_as_option,
     pull::{IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation},
     push::{to_push_translation_error, PushUpsertRecord, RemotePushUpsertTranslation},
     zero_date_as_option, TRANSLATION_RECORD_REQUISITION,
@@ -72,10 +73,13 @@ pub struct LegacyRequisitionRow {
     pub r#type: LegacyRequisitionType,
     pub status: LegacyRequisitionStatus,
     // created_datetime
+    #[serde(serialize_with = "date_to_isostring")]
     pub date_entered: NaiveDate,
     #[serde(deserialize_with = "zero_date_as_option")]
+    #[serde(serialize_with = "date_option_to_isostring")]
     pub date_stock_take: Option<NaiveDate>,
     #[serde(deserialize_with = "zero_date_as_option")]
+    #[serde(serialize_with = "date_option_to_isostring")]
     pub date_order_received: Option<NaiveDate>,
     #[serde(deserialize_with = "empty_str_as_option")]
     pub requester_reference: Option<String>,

--- a/server/src/sync/translation_remote/stock_line.rs
+++ b/server/src/sync/translation_remote/stock_line.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::sync::SyncTranslationError;
 
 use super::{
-    empty_str_as_option,
+    date_option_to_isostring, empty_str_as_option,
     pull::{IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation},
     push::{to_push_translation_error, PushUpsertRecord, RemotePushUpsertTranslation},
     zero_date_as_option, TRANSLATION_RECORD_ITEM_LINE,
@@ -24,6 +24,7 @@ pub struct LegacyStockLineRow {
     #[serde(deserialize_with = "empty_str_as_option")]
     pub batch: Option<String>,
     #[serde(deserialize_with = "zero_date_as_option")]
+    #[serde(serialize_with = "date_option_to_isostring")]
     pub expiry_date: Option<NaiveDate>,
     pub hold: bool,
     #[serde(deserialize_with = "empty_str_as_option")]

--- a/server/src/sync/translation_remote/stocktake.rs
+++ b/server/src/sync/translation_remote/stocktake.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::sync::SyncTranslationError;
 
 use super::{
-    date_and_time_to_datatime, date_from_date_time, empty_str_as_option,
+    date_and_time_to_datatime, date_from_date_time, date_to_isostring, empty_str_as_option,
     pull::{IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation},
     push::{to_push_translation_error, PushUpsertRecord, RemotePushUpsertTranslation},
     TRANSLATION_RECORD_STOCKTAKE,
@@ -43,6 +43,7 @@ pub struct LegacyStocktakeRow {
     // #[serde(deserialize_with = "empty_str_as_option")]
     // invad_reductions_ID: Option<String>,
     pub serial_number: i64,
+    #[serde(serialize_with = "date_to_isostring")]
     pub stock_take_created_date: NaiveDate,
     pub store_ID: String,
 }

--- a/server/src/sync/translation_remote/stocktake_line.rs
+++ b/server/src/sync/translation_remote/stocktake_line.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::sync::SyncTranslationError;
 
 use super::{
-    empty_str_as_option,
+    date_option_to_isostring, empty_str_as_option,
     pull::{IntegrationRecord, IntegrationUpsertRecord, RemotePullTranslation},
     push::{to_push_translation_error, PushUpsertRecord, RemotePushUpsertTranslation},
     zero_date_as_option, TRANSLATION_RECORD_STOCKTAKE_LINE,
@@ -35,6 +35,7 @@ pub struct LegacyStocktakeLineRow {
     #[serde(deserialize_with = "empty_str_as_option")]
     pub Batch: Option<String>,
     #[serde(deserialize_with = "zero_date_as_option")]
+    #[serde(serialize_with = "date_option_to_isostring")]
     pub expiry: Option<NaiveDate>,
     pub cost_price: f64,
     pub sell_price: f64,

--- a/server/src/sync/translation_remote/test_data/transact.rs
+++ b/server/src/sync/translation_remote/test_data/transact.rs
@@ -154,7 +154,7 @@ fn transact_1_push_record() -> TestSyncPushRecord {
             ship_date: None,
             arrival_date_actual: Some(NaiveDate::from_ymd(2021, 7, 30)),
             confirm_date: Some(NaiveDate::from_ymd(2021, 7, 30)),
-            confirm_time: 47046
+            confirm_time: NaiveTime::from_hms(13, 4, 6)
         }),
     }
 }
@@ -297,7 +297,8 @@ fn transact_2_push_record() -> TestSyncPushRecord {
             ship_date: None,
             arrival_date_actual: None,
             confirm_date: None,
-            confirm_time: 0
+            // Note: we are loosing this value when date is None
+            confirm_time: NaiveTime::from_hms(0, 0, 0)
         }),
     }
 }

--- a/server/src/sync/translation_remote/test_data/transact.rs
+++ b/server/src/sync/translation_remote/test_data/transact.rs
@@ -1,4 +1,4 @@
-use chrono::{Duration, NaiveDate};
+use chrono::{Duration, NaiveDate, NaiveTime};
 use repository::schema::{
     ChangelogAction, ChangelogRow, ChangelogTableName, InvoiceRow, InvoiceRowStatus,
     InvoiceRowType, RemoteSyncBufferAction, RemoteSyncBufferRow,
@@ -150,7 +150,7 @@ fn transact_1_push_record() -> TestSyncPushRecord {
             requisition_ID: None,
             linked_transaction_id: None,
             entry_date: NaiveDate::from_ymd(2021, 7, 30),
-            entry_time: 47046,
+            entry_time: NaiveTime::from_hms(13, 4, 6),
             ship_date: None,
             arrival_date_actual: Some(NaiveDate::from_ymd(2021, 7, 30)),
             confirm_date: Some(NaiveDate::from_ymd(2021, 7, 30)),
@@ -293,7 +293,7 @@ fn transact_2_push_record() -> TestSyncPushRecord {
             requisition_ID: None,
             linked_transaction_id: None,
             entry_date: NaiveDate::from_ymd(2021, 8, 3),
-            entry_time: 44806,
+            entry_time: NaiveTime::from_hms(12, 26, 46),
             ship_date: None,
             arrival_date_actual: None,
             confirm_date: None,


### PR DESCRIPTION
Date/time coming in from v5 are different from what the POST v3 endpoints expects. This fixes the ser/de of date and time values.