### PR TITLE
823 name query by store

### DIFF
--- a/graphql/core/src/loader/loader_registry.rs
+++ b/graphql/core/src/loader/loader_registry.rs
@@ -74,7 +74,7 @@ pub async fn get_loaders(
     });
 
     let name_by_id_loader = DataLoader::new(NameByIdLoader {
-        connection_manager: connection_manager.clone(),
+        service_provider: service_provider.clone(),
     });
 
     let location_by_id_loader = DataLoader::new(LocationByIdLoader {

--- a/graphql/core/src/loader/mod.rs
+++ b/graphql/core/src/loader/mod.rs
@@ -70,6 +70,18 @@ impl std::hash::Hash for IdAndStoreId {
     }
 }
 
+impl IdAndStoreId {
+    pub fn get_store_id(vec: &[IdAndStoreId]) -> Option<&str> {
+        vec.first().map(|i| i.store_id.as_str())
+    }
+
+    pub fn get_ids(vec: &[IdAndStoreId]) -> Vec<String> {
+        vec.iter()
+            .map(|item_and_store_id| item_and_store_id.id.clone())
+            .collect()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ItemStatsLoaderInput {
     pub item_id: String,

--- a/graphql/core/src/loader/name.rs
+++ b/graphql/core/src/loader/name.rs
@@ -1,27 +1,60 @@
+use actix_web::web::Data;
 use async_graphql::dataloader::*;
 use repository::EqualFilter;
+use service::service_provider::ServiceProvider;
 use std::collections::HashMap;
 
 use repository::{Name, NameFilter};
-use repository::{NameQueryRepository, RepositoryError, StorageConnectionManager};
+
+use crate::standard_graphql_error::StandardGraphqlError;
+
+use super::IdAndStoreId;
 
 pub struct NameByIdLoader {
-    pub connection_manager: StorageConnectionManager,
+    pub service_provider: Data<ServiceProvider>,
 }
 
 #[async_trait::async_trait]
-impl Loader<String> for NameByIdLoader {
+impl Loader<IdAndStoreId> for NameByIdLoader {
     type Value = Name;
-    type Error = RepositoryError;
+    type Error = async_graphql::Error;
 
-    async fn load(&self, ids: &[String]) -> Result<HashMap<String, Self::Value>, Self::Error> {
-        let connection = self.connection_manager.connection()?;
-        let repo = NameQueryRepository::new(&connection);
+    async fn load(
+        &self,
+        ids_with_store_id: &[IdAndStoreId],
+    ) -> Result<HashMap<IdAndStoreId, Self::Value>, Self::Error> {
+        let service_context = self.service_provider.context()?;
 
-        Ok(repo
-            .query_by_filter(NameFilter::new().id(EqualFilter::equal_any(ids.to_owned())))?
+        let store_id = match IdAndStoreId::get_store_id(ids_with_store_id) {
+            Some(store_id) => store_id,
+            None => return Ok(HashMap::new()),
+        };
+
+        let filter = NameFilter::new()
+            // It's posible that historic name becomes invisible
+            .show_invisible_in_current_store(true)
+            .id(EqualFilter::equal_any(IdAndStoreId::get_ids(
+                ids_with_store_id,
+            )));
+
+        let names = self
+            .service_provider
+            .general_service
+            .get_names(&service_context, store_id, None, Some(filter), None)
+            .map_err(StandardGraphqlError::from_list_error)?;
+
+        Ok(names
+            .rows
             .into_iter()
-            .map(|name| (name.name_row.id.clone(), name))
+            .map(|name| {
+                (
+                    IdAndStoreId {
+                        id: name.name_row.id.clone(),
+                        store_id: store_id.to_string(),
+                    },
+                    name,
+                )
+            })
             .collect())
     }
 }

--- a/graphql/general/src/lib.rs
+++ b/graphql/general/src/lib.rs
@@ -46,13 +46,13 @@ impl GeneralQueries {
     pub async fn names(
         &self,
         ctx: &Context<'_>,
-        _store_id: String,
+        store_id: String,
         #[graphql(desc = "Pagination option (first and offset)")] page: Option<PaginationInput>,
         #[graphql(desc = "Filter option")] filter: Option<NameFilterInput>,
         #[graphql(desc = "Sort options (only first sort input is evaluated for this endpoint)")]
         sort: Option<Vec<NameSortInput>>,
     ) -> Result<NamesResponse> {
-        names(ctx, page, filter, sort)
+        get_names(ctx, &store_id, page, filter, sort)
     }
 
     pub async fn stores(

--- a/graphql/invoice/src/mutations/outbound_shipment/insert.rs
+++ b/graphql/invoice/src/mutations/outbound_shipment/insert.rs
@@ -113,11 +113,11 @@ mod graphql {
 
     use graphql_core::test_helpers::setup_graphl_test;
     use graphql_core::{assert_graphql_query, assert_standard_graphql_error};
-    use repository::mock::MockDataInserts;
     use repository::mock::{
         mock_name_linked_to_store, mock_name_not_linked_to_store,
         mock_outbound_shipment_number_store_a, mock_store_linked_to_name,
     };
+    use repository::mock::{mock_name_store_a, mock_name_store_c, MockDataInserts};
     use repository::InvoiceRepository;
     use serde_json::json;
     use util::uuid::uuid;
@@ -126,7 +126,7 @@ mod graphql {
 
     #[actix_rt::test]
     async fn test_graphql_outbound_shipment_insert() {
-        let (mock_data, connection, _, settings) = setup_graphl_test(
+        let (_, connection, _, settings) = setup_graphl_test(
             InvoiceQueries,
             InvoiceMutations,
             "omsupply-database-gql-outbound_shipment_insert",
@@ -134,8 +134,8 @@ mod graphql {
         )
         .await;
 
-        let other_party_supplier = &mock_data["base"].names[2];
-        let other_party_customer = &mock_data["base"].names[0];
+        let other_party_supplier = &mock_name_store_c();
+        let other_party_customer = &mock_name_store_a();
 
         let starting_invoice_number = mock_outbound_shipment_number_store_a().value;
 

--- a/graphql/invoice/src/mutations/outbound_shipment/update.rs
+++ b/graphql/invoice/src/mutations/outbound_shipment/update.rs
@@ -193,7 +193,7 @@ mod graphql {
 
     use graphql_core::test_helpers::setup_graphl_test;
     use graphql_core::{assert_graphql_query, assert_standard_graphql_error};
-    use repository::mock::MockDataInserts;
+    use repository::mock::{MockDataInserts, mock_name_store_c};
     use repository::mock::{
         mock_name_linked_to_store, mock_name_not_linked_to_store,
         mock_new_invoice_with_unallocated_line, mock_store_linked_to_name,
@@ -297,7 +297,7 @@ mod graphql {
             None
         );
         // OtherPartyNotACustomerError
-        let other_party_supplier = &mock_data["base"].names[2];
+        let other_party_supplier = mock_name_store_c();
         let variables = Some(json!({
           "input": {
             "id": "outbound_shipment_a",

--- a/graphql/requisition/src/query_tests/requisition_loaders.rs
+++ b/graphql/requisition/src/query_tests/requisition_loaders.rs
@@ -3,7 +3,7 @@ mod test {
     use graphql_core::{assert_graphql_query, test_helpers::setup_graphl_test};
     use repository::mock::{
         mock_invoice1_linked_to_requisition, mock_invoice2_linked_to_requisition,
-        mock_invoice3_linked_to_requisition, mock_name_a, mock_name_store_a,
+        mock_invoice3_linked_to_requisition, mock_name_a, mock_name_b,
         mock_request_draft_requisition_all_fields, mock_response_draft_requisition_all_fields,
         MockDataInserts,
     };
@@ -22,12 +22,12 @@ mod test {
         .await;
 
         let query = r#"
-        query($filter: RequisitionFilterInput) {
-          requisitions(filter: $filter, storeId: \"store_a\") {
+        query($storeId: String!, $filter: RequisitionFilterInput) {
+          requisitions(filter: $filter, storeId: $storeId) {
             ... on RequisitionConnector {
               nodes {
                 id
-                otherParty {
+                otherParty(storeId: $storeId) {
                     id
                 }
                 requestRequisition {
@@ -49,6 +49,7 @@ mod test {
         let response_requisition = mock_response_draft_requisition_all_fields();
 
         let variables = json!({
+        "storeId": "store_a",
           "filter": {
             "id": {
                 "equalAny": [&request_requisition.requisition.id, &response_requisition.requisition.id]
@@ -70,7 +71,7 @@ mod test {
                 {
                     "id": &response_requisition.requisition.id,
                     "otherParty": {
-                        "id": mock_name_store_a().id
+                        "id": mock_name_b().id
                     },
                 }]
             }

--- a/graphql/types/src/types/requisition.rs
+++ b/graphql/types/src/types/requisition.rs
@@ -3,8 +3,8 @@ use async_graphql::*;
 use chrono::{DateTime, Utc};
 use graphql_core::{
     loader::{
-        InvoiceByRequisitionIdLoader, NameByIdLoader, RequisitionLinesByRequisitionIdLoader,
-        RequisitionsByIdLoader,
+        IdAndStoreId, InvoiceByRequisitionIdLoader, NameByIdLoader,
+        RequisitionLinesByRequisitionIdLoader, RequisitionsByIdLoader,
     },
     standard_graphql_error::StandardGraphqlError,
     ContextExt,
@@ -14,7 +14,6 @@ use repository::{
     Requisition,
 };
 use service::ListResult;
-use StandardGraphqlError::*;
 
 use super::{InvoiceConnector, NameNode, RequisitionLineConnector};
 
@@ -99,13 +98,18 @@ impl RequisitionNode {
 
     /// Request Requisition: Supplying store (store that is supplying stock)
     /// Response Requisition: Customer store (store that is ordering stock)
-    pub async fn other_party(&self, ctx: &Context<'_>) -> Result<NameNode> {
+    pub async fn other_party(&self, ctx: &Context<'_>, store_id: String) -> Result<NameNode> {
         let loader = ctx.get_loader::<DataLoader<NameByIdLoader>>();
 
-        let response_option = loader.load_one(self.row().name_id.clone()).await?;
+        let response_option = loader
+            .load_one(IdAndStoreId {
+                id: self.row().name_id.clone(),
+                store_id,
+            })
+            .await?;
 
         response_option.map(NameNode::from_domain).ok_or(
-            InternalError(format!(
+            StandardGraphqlError::InternalError(format!(
                 "Cannot find name ({}) linked to requisition ({})",
                 &self.row().name_id,
                 &self.row().id

--- a/graphql/types/src/types/store.rs
+++ b/graphql/types/src/types/store.rs
@@ -1,6 +1,8 @@
-use async_graphql::{dataloader::DataLoader, Context, Object, Result, ErrorExtensions};
+use async_graphql::{dataloader::DataLoader, Context, ErrorExtensions, Object, Result};
 use graphql_core::{
-    loader::NameByIdLoader, standard_graphql_error::StandardGraphqlError, ContextExt,
+    loader::{IdAndStoreId, NameByIdLoader},
+    standard_graphql_error::StandardGraphqlError,
+    ContextExt,
 };
 use repository::schema::StoreRow;
 
@@ -21,10 +23,15 @@ impl StoreNode {
         &self.store.code
     }
 
-    pub async fn name(&self, ctx: &Context<'_>) -> Result<NameNode> {
+    pub async fn name(&self, ctx: &Context<'_>, store_id: String) -> Result<NameNode> {
         let loader = ctx.get_loader::<DataLoader<NameByIdLoader>>();
 
-        let response_option = loader.load_one(self.store.name_id.clone()).await?;
+        let response_option = loader
+            .load_one(IdAndStoreId {
+                id: self.store.name_id.clone(),
+                store_id,
+            })
+            .await?;
 
         response_option.map(NameNode::from_domain).ok_or(
             StandardGraphqlError::InternalError(format!(

--- a/repository/src/db_diesel/invoice_query.rs
+++ b/repository/src/db_diesel/invoice_query.rs
@@ -165,7 +165,7 @@ fn to_domain((invoice_row, name_row, store_row): InvoiceQueryJoin) -> Invoice {
 type BoxedInvoiceQuery =
     IntoBoxed<'static, InnerJoin<InnerJoin<invoice::table, name::table>, store::table>, DBType>;
 
-pub fn create_filtered_query<'a>(filter: Option<InvoiceFilter>) -> BoxedInvoiceQuery {
+fn create_filtered_query<'a>(filter: Option<InvoiceFilter>) -> BoxedInvoiceQuery {
     let mut query = invoice_dsl::invoice
         .inner_join(name_dsl::name)
         .inner_join(store_dsl::store)

--- a/repository/src/db_diesel/item_query.rs
+++ b/repository/src/db_diesel/item_query.rs
@@ -148,7 +148,7 @@ type BoxedItemQuery = IntoBoxed<
     DBType,
 >;
 
-pub fn create_filtered_query(filter: Option<ItemFilter>) -> BoxedItemQuery {
+fn create_filtered_query(filter: Option<ItemFilter>) -> BoxedItemQuery {
     // Join master_list_line
     let mut query = item_dsl::item
         .inner_join(item_is_visible_dsl::item_is_visible)

--- a/repository/src/db_diesel/name.rs
+++ b/repository/src/db_diesel/name.rs
@@ -51,6 +51,15 @@ impl<'a> NameRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_one_by_code(&self, name_code: &str) -> Result<Option<NameRow>, RepositoryError> {
+        use crate::schema::diesel_schema::name::dsl::*;
+        let result = name
+            .filter(code.eq(name_code))
+            .first(&self.connection.connection)
+            .optional()?;
+        Ok(result)
+    }
+
     pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<NameRow>, RepositoryError> {
         use crate::schema::diesel_schema::name::dsl::*;
         let result = name

--- a/repository/src/db_diesel/name_query.rs
+++ b/repository/src/db_diesel/name_query.rs
@@ -160,14 +160,12 @@ fn create_filtered_query(store_id: &str, filter: Option<NameFilter>) -> BoxedNam
 
     let show_invisible_in_current_store = filter
         .as_ref()
-        .map(|filter| filter.show_invisible_in_current_store)
-        .flatten()
+        .and_then(|filter| filter.show_invisible_in_current_store)
         .unwrap_or(false);
 
     let show_system_names = filter
         .as_ref()
-        .map(|filter| filter.show_system_names)
-        .flatten()
+        .and_then(|filter| filter.show_system_names)
         .unwrap_or(false);
 
     query = match (show_invisible_in_current_store, show_system_names) {

--- a/repository/src/db_diesel/stocktake.rs
+++ b/repository/src/db_diesel/stocktake.rs
@@ -76,7 +76,7 @@ pub type StocktakeSort = Sort<StocktakeSortField>;
 
 type BoxedStocktakeQuery = IntoBoxed<'static, stocktake::table, DBType>;
 
-pub fn create_filtered_query<'a>(filter: Option<StocktakeFilter>) -> BoxedStocktakeQuery {
+fn create_filtered_query<'a>(filter: Option<StocktakeFilter>) -> BoxedStocktakeQuery {
     let mut query = stocktake_dsl::stocktake.into_boxed();
 
     if let Some(f) = filter {

--- a/repository/src/db_diesel/store_row.rs
+++ b/repository/src/db_diesel/store_row.rs
@@ -51,6 +51,15 @@ impl<'a> StoreRowRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_one_by_name_id(&self, name_id: &str) -> Result<Option<StoreRow>, RepositoryError> {
+        use crate::schema::diesel_schema::store::dsl as store_dsl;
+        let result = store_dsl::store
+            .filter(store_dsl::name_id.eq(name_id))
+            .first(&self.connection.connection)
+            .optional()?;
+        Ok(result)
+    }
+
     pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<StoreRow>, RepositoryError> {
         use crate::schema::diesel_schema::store::dsl::*;
         let result = store

--- a/repository/src/mock/mod.rs
+++ b/repository/src/mock/mod.rs
@@ -18,6 +18,7 @@ mod test_invoice_count_service;
 mod test_invoice_loaders;
 mod test_item_stats_repository;
 mod test_master_list_repository;
+mod test_name_query;
 mod test_name_store_id;
 mod test_outbound_shipment_update;
 mod test_remote_pull;
@@ -51,6 +52,7 @@ pub use test_invoice_count_service::*;
 pub use test_invoice_loaders::*;
 pub use test_item_stats_repository::*;
 pub use test_master_list_repository::*;
+pub use test_name_query::*;
 pub use test_name_store_id::*;
 pub use test_outbound_shipment_update::*;
 pub use test_remote_pull::*;
@@ -327,6 +329,7 @@ fn all_mock_data() -> MockDataCollection {
     data.insert("mock_test_invoice_loaders", mock_test_invoice_loaders());
     data.insert("mock_test_remote_pull", mock_test_remote_pull());
     data.insert("mock_test_service_item", mock_test_service_item());
+    data.insert("mock_test_name_query", mock_test_name_query());
     data
 }
 

--- a/repository/src/mock/name.rs
+++ b/repository/src/mock/name.rs
@@ -1,3 +1,5 @@
+use util::constants::INVENTORY_ADJUSTMENT_NAME_CODE;
+
 use crate::schema::NameRow;
 
 pub fn mock_name_store_a() -> NameRow {
@@ -40,12 +42,23 @@ pub fn mock_name_a() -> NameRow {
     }
 }
 
+// Not visible in store_a
+pub fn mock_name_b() -> NameRow {
+    NameRow {
+        id: String::from("name_b"),
+        name: String::from("name_b"),
+        code: String::from("name_b"),
+        is_customer: false,
+        is_supplier: true,
+    }
+}
+
 // Inventory adjustment name
 pub fn mock_name_invad() -> NameRow {
     NameRow {
-        id: String::from("invad"),
+        id: INVENTORY_ADJUSTMENT_NAME_CODE.to_string(),
         name: String::from("Inventory adjustments"),
-        code: String::from("invad"),
+        code: INVENTORY_ADJUSTMENT_NAME_CODE.to_string(),
         is_customer: false,
         is_supplier: false,
     }
@@ -64,6 +77,7 @@ pub fn mock_name_master_list_filter_test() -> NameRow {
 pub fn mock_names() -> Vec<NameRow> {
     vec![
         mock_name_store_a(),
+        mock_name_b(),
         mock_name_store_b(),
         mock_name_store_c(),
         mock_name_a(),

--- a/repository/src/mock/name_store_join.rs
+++ b/repository/src/mock/name_store_join.rs
@@ -14,7 +14,7 @@ pub fn mock_name_store_join_b() -> NameStoreJoinRow {
     NameStoreJoinRow {
         id: String::from("name_store_join_b"),
         name_id: String::from("name_store_b"),
-        store_id: String::from("store_b"),
+        store_id: String::from("store_a"),
         name_is_customer: true,
         name_is_supplier: false,
     }
@@ -24,7 +24,7 @@ pub fn mock_name_store_join_c() -> NameStoreJoinRow {
     NameStoreJoinRow {
         id: String::from("name_store_join_c"),
         name_id: String::from("name_store_c"),
-        store_id: String::from("store_c"),
+        store_id: String::from("store_a"),
         name_is_customer: false,
         name_is_supplier: true,
     }
@@ -40,11 +40,22 @@ pub fn mock_name_store_join_d() -> NameStoreJoinRow {
     }
 }
 
+pub fn mock_name_store_join_e() -> NameStoreJoinRow {
+    NameStoreJoinRow {
+        id: String::from("mock_name_store_join_e"),
+        name_id: String::from("name_a"),
+        store_id: String::from("store_c"),
+        name_is_customer: false,
+        name_is_supplier: true,
+    }
+}
+
 pub fn mock_name_store_joins() -> Vec<NameStoreJoinRow> {
     vec![
         mock_name_store_join_a(),
         mock_name_store_join_b(),
         mock_name_store_join_c(),
         mock_name_store_join_d(),
+        mock_name_store_join_e(),
     ]
 }

--- a/repository/src/mock/test_name_query.rs
+++ b/repository/src/mock/test_name_query.rs
@@ -1,0 +1,120 @@
+use util::inline_init;
+
+use crate::schema::{NameRow, NameStoreJoinRow, StoreRow};
+
+use super::MockData;
+
+pub fn mock_test_name_query() -> MockData {
+    let mut result = MockData::default();
+    result.names = vec![mock_name_1(), mock_name_2(), mock_name_3(), name_a_umlaut()];
+    result.stores = vec![
+        mock_test_name_query_store_1(),
+        mock_test_name_query_store_2(),
+    ];
+    result.name_store_joins = vec![
+        mock_name_1_join(),
+        mock_name_2_join(),
+        mock_name_3_join(),
+        mock_name_3_join2(),
+        name_a_umlaut_join(),
+    ];
+    result
+}
+
+pub fn mock_test_name_query_store_1() -> StoreRow {
+    StoreRow {
+        id: "mock_test_name_query_store_1".to_string(),
+        name_id: mock_name_1().id,
+        code: "mock_test_name_query_store_1_code".to_string(),
+    }
+}
+
+pub fn mock_test_name_query_store_2() -> StoreRow {
+    StoreRow {
+        id: "mock_test_name_query_store_2".to_string(),
+        name_id: mock_name_2().id,
+        code: "mock_test_name_query_store_2_code".to_string(),
+    }
+}
+
+pub fn mock_name_1() -> NameRow {
+    inline_init(|r: &mut NameRow| {
+        r.id = "name1".to_string();
+        r.name = "name_1".to_string();
+        r.code = "code1".to_string();
+    })
+}
+
+pub fn mock_name_1_join() -> NameStoreJoinRow {
+    NameStoreJoinRow {
+        id: String::from("mock_name_1_join_id"),
+        name_id: mock_name_1().id,
+        store_id: mock_test_name_query_store_2().id,
+        name_is_customer: false,
+        name_is_supplier: true,
+    }
+}
+
+pub fn mock_name_2() -> NameRow {
+    inline_init(|r: &mut NameRow| {
+        r.id = "name2".to_string();
+        r.name = "name_2".to_string();
+        r.code = "code2".to_string();
+    })
+}
+
+pub fn mock_name_2_join() -> NameStoreJoinRow {
+    NameStoreJoinRow {
+        id: String::from("mock_name_2_join_id"),
+        name_id: mock_name_2().id,
+        store_id: mock_test_name_query_store_1().id,
+        name_is_customer: true,
+        name_is_supplier: true,
+    }
+}
+
+pub fn mock_name_3() -> NameRow {
+    inline_init(|r: &mut NameRow| {
+        r.id = "name3".to_string();
+        r.name = "name_3".to_string();
+        r.code = "code3".to_string();
+    })
+}
+
+pub fn mock_name_3_join() -> NameStoreJoinRow {
+    NameStoreJoinRow {
+        id: String::from("mock_name_3_join_id"),
+        name_id: mock_name_3().id,
+        store_id: mock_test_name_query_store_1().id,
+        name_is_customer: true,
+        name_is_supplier: true,
+    }
+}
+
+pub fn mock_name_3_join2() -> NameStoreJoinRow {
+    NameStoreJoinRow {
+        id: String::from("mock_name_3_join2_id"),
+        name_id: mock_name_3().id,
+        store_id: mock_test_name_query_store_2().id,
+        name_is_customer: false,
+        name_is_supplier: false,
+    }
+}
+
+pub fn name_a_umlaut() -> NameRow {
+    inline_init(|r: &mut NameRow| {
+        r.id = "name_äÄ_umlaut".to_string();
+        r.name = "a_umlaut_äÄ_name".to_string();
+        r.code = "a_umlaut_äÄ_code".to_string();
+    })
+}
+
+pub fn name_a_umlaut_join() -> NameStoreJoinRow {
+    NameStoreJoinRow {
+        id: String::from("name_a_umlaut_join_id"),
+        name_id: name_a_umlaut().id,
+        store_id: mock_test_name_query_store_1().id,
+        name_is_customer: true,
+        name_is_supplier: true,
+    }
+}

--- a/repository/src/mock/test_requisition_queries.rs
+++ b/repository/src/mock/test_requisition_queries.rs
@@ -8,7 +8,7 @@ use crate::schema::{
 
 use super::{
     common::{FullMockInvoice, FullMockInvoiceLine, FullMockRequisition},
-    mock_item_a, mock_item_b, mock_name_a, mock_name_store_a, MockData,
+    mock_item_a, mock_item_b, mock_name_a, mock_name_b, mock_store_a, MockData,
 };
 
 pub fn mock_test_requisition_queries() -> MockData {
@@ -59,7 +59,7 @@ pub fn mock_request_draft_requisition_all_fields() -> FullMockRequisition {
             id: requisition_id.clone(),
             requisition_number: 3,
             name_id: mock_name_a().id,
-            store_id: "store_a".to_owned(),
+            store_id: mock_store_a().id,
             r#type: RequisitionRowType::Request,
             status: RequisitionRowStatus::Draft,
             created_datetime: NaiveDate::from_ymd(2021, 01, 01).and_hms(0, 0, 0),
@@ -102,8 +102,9 @@ pub fn mock_response_draft_requisition_all_fields() -> FullMockRequisition {
         requisition: RequisitionRow {
             id: requisition_id.clone(),
             requisition_number: 3,
-            name_id: mock_name_store_a().id,
-            store_id: "store_a".to_owned(),
+            // not visible in store_c
+            name_id: mock_name_b().id,
+            store_id: mock_store_a().id,
             r#type: RequisitionRowType::Response,
             status: RequisitionRowStatus::Draft,
             created_datetime: NaiveDate::from_ymd(2021, 01, 01).and_hms(0, 0, 0),
@@ -137,7 +138,7 @@ pub fn mock_invoice1_linked_to_requisition() -> FullMockInvoice {
         invoice: InvoiceRow {
             id: invoice_id.clone(),
             name_id: mock_name_a().id,
-            store_id: "store_a".to_owned(),
+            store_id: mock_store_a().id,
             invoice_number: 20,
             name_store_id: None,
             r#type: InvoiceRowType::InboundShipment,
@@ -242,7 +243,7 @@ pub fn mock_invoice2_linked_to_requisition() -> FullMockInvoice {
         invoice: InvoiceRow {
             id: invoice_id.clone(),
             name_id: mock_name_a().id,
-            store_id: "store_a".to_owned(),
+            store_id: mock_store_a().id,
             invoice_number: 20,
             name_store_id: None,
             r#type: InvoiceRowType::InboundShipment,
@@ -308,7 +309,7 @@ pub fn mock_invoice3_linked_to_requisition() -> FullMockInvoice {
         invoice: InvoiceRow {
             id: invoice_id.clone(),
             name_id: mock_name_a().id,
-            store_id: "store_a".to_owned(),
+            store_id: mock_store_a().id,
             invoice_number: 20,
             name_store_id: None,
             r#type: InvoiceRowType::OutboundShipment,

--- a/repository/src/schema/name_store_join.rs
+++ b/repository/src/schema/name_store_join.rs
@@ -1,6 +1,6 @@
 use super::diesel_schema::name_store_join;
 
-#[derive(Queryable, Insertable, Debug, PartialEq, Eq, AsChangeset, Clone)]
+#[derive(Queryable, Insertable, Debug, PartialEq, Eq, AsChangeset, Clone, Default)]
 #[table_name = "name_store_join"]
 pub struct NameStoreJoinRow {
     pub id: String,

--- a/repository/src/tests.rs
+++ b/repository/src/tests.rs
@@ -15,36 +15,6 @@ mod repository_test {
             }
         }
 
-        pub fn name_2() -> NameRow {
-            NameRow {
-                id: "name2".to_string(),
-                name: "name_2".to_string(),
-                code: "code1".to_string(),
-                is_customer: false,
-                is_supplier: false,
-            }
-        }
-
-        pub fn name_3() -> NameRow {
-            NameRow {
-                id: "name3".to_string(),
-                name: "name_3".to_string(),
-                code: "code2".to_string(),
-                is_customer: true,
-                is_supplier: false,
-            }
-        }
-
-        pub fn name_a_umlaut() -> NameRow {
-            NameRow {
-                id: "name_äÄ_umlaut".to_string(),
-                name: "a_umlaut_äÄ_name".to_string(),
-                code: "a_umlaut_äÄ_code".to_string(),
-                is_customer: true,
-                is_supplier: false,
-            }
-        }
-
         pub fn store_1() -> StoreRow {
             StoreRow {
                 id: "store1".to_string(),
@@ -342,14 +312,13 @@ mod repository_test {
         InvoiceLineRowRepository, InvoiceRepository, ItemRepository, ItemStatsFilter,
         ItemStatsRepository, KeyValueStoreRepository, MasterListFilter, MasterListLineFilter,
         MasterListLineRepository, MasterListLineRowRepository, MasterListNameJoinRepository,
-        MasterListRepository, MasterListRowRepository, NameFilter, NameQueryRepository,
-        NameRepository, NameSort, NameSortField, NumberRowRepository, OutboundShipmentRepository,
-        RequisitionFilter, RequisitionLineFilter, RequisitionLineRepository,
-        RequisitionLineRowRepository, RequisitionRepository, RequisitionRowRepository,
-        StockLineFilter, StockLineRepository, StockLineRowRepository, StocktakeRowRepository,
-        StoreRowRepository, UserAccountRepository,
+        MasterListRepository, MasterListRowRepository, NameRepository, NumberRowRepository,
+        OutboundShipmentRepository, RequisitionFilter, RequisitionLineFilter,
+        RequisitionLineRepository, RequisitionLineRowRepository, RequisitionRepository,
+        RequisitionRowRepository, StockLineFilter, StockLineRepository, StockLineRowRepository,
+        StocktakeRowRepository, StoreRowRepository, UserAccountRepository,
     };
-    use crate::{DateFilter, EqualFilter, Pagination, SimpleStringFilter};
+    use crate::{DateFilter, EqualFilter, SimpleStringFilter};
     use chrono::{Duration, Utc};
     use diesel::{sql_query, sql_types::Text, RunQueryDsl};
     use util::constants::NUMBER_OF_DAYS_IN_A_MONTH;
@@ -366,168 +335,6 @@ mod repository_test {
         repo.insert_one(&name_1).await.unwrap();
         let loaded_item = repo.find_one_by_id(name_1.id.as_str()).unwrap().unwrap();
         assert_eq!(name_1, loaded_item);
-    }
-
-    #[actix_rt::test]
-    async fn test_name_query_repository_all_filter_sort() {
-        let settings = test_db::get_test_db_settings(
-            "omsupply-database-name-query-repository-all-filter-sort",
-        );
-        test_db::setup(&settings).await;
-        let connection_manager = get_storage_connection_manager(&settings);
-        let connection = connection_manager.connection().unwrap();
-
-        // setup
-        let name_repo = NameRepository::new(&connection);
-        name_repo.insert_one(&data::name_1()).await.unwrap();
-        name_repo.insert_one(&data::name_2()).await.unwrap();
-        name_repo.insert_one(&data::name_3()).await.unwrap();
-        name_repo.insert_one(&data::name_a_umlaut()).await.unwrap();
-
-        let repo = NameQueryRepository::new(&connection);
-        // test filter:
-        let result = repo
-            .query(
-                Pagination::new(),
-                Some(NameFilter {
-                    id: None,
-                    name: Some(SimpleStringFilter {
-                        equal_to: Some("name_1".to_string()),
-                        like: None,
-                    }),
-                    code: None,
-                    is_customer: None,
-                    is_supplier: None,
-                    store_id: None,
-                }),
-                None,
-            )
-            .unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result.get(0).unwrap().name_row.name, "name_1");
-
-        let result = repo
-            .query(
-                Pagination::new(),
-                Some(NameFilter {
-                    id: None,
-                    name: Some(SimpleStringFilter {
-                        equal_to: None,
-                        like: Some("me_".to_string()),
-                    }),
-                    code: None,
-                    is_customer: None,
-                    is_supplier: None,
-                    store_id: None,
-                }),
-                None,
-            )
-            .unwrap();
-        assert_eq!(result.len(), 3);
-
-        // case insensitive search
-        let result = repo
-            .query(
-                Pagination::new(),
-                Some(NameFilter {
-                    id: None,
-                    name: Some(SimpleStringFilter {
-                        equal_to: None,
-                        like: Some("mE_".to_string()),
-                    }),
-                    code: None,
-                    is_customer: None,
-                    is_supplier: None,
-                    store_id: None,
-                }),
-                None,
-            )
-            .unwrap();
-        assert_eq!(result.len(), 3);
-
-        // case insensitive search with umlaute
-        /* Works for postgres but not for sqlite:
-        let result = repo
-            .query(
-                Pagination::new(),
-                Some(NameFilter {
-                    id: None,
-                    name: Some(SimpleStringFilter {
-                        equal_to: None,
-                        // filter for "umlaut_äÄ_name"
-                        like: Some("T_Ää_N".to_string()),
-                    }),
-                    code: None,
-                    is_customer: None,
-                    is_supplier: None,
-                }),
-                None,
-            )
-            .unwrap();
-        assert_eq!(result.len(), 1);
-        */
-
-        let result = repo
-            .query(
-                Pagination::new(),
-                Some(NameFilter {
-                    id: None,
-                    name: None,
-                    code: Some(SimpleStringFilter {
-                        equal_to: Some("code1".to_string()),
-                        like: None,
-                    }),
-                    is_customer: None,
-                    is_supplier: None,
-                    store_id: None,
-                }),
-                None,
-            )
-            .unwrap();
-        assert_eq!(result.len(), 2);
-
-        /* TODO currently no way to add name_store_join rows for the following tests:
-        let result = repo
-            .query(
-                Pagination::new(),
-                Some(NameQueryFilter {
-                    name: None,
-                    code: None,
-                    is_customer: Some(true),
-                    is_supplier: None,
-                }),
-            )
-            .unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result.get(0).unwrap().name, "name_3");
-
-        let result = repo
-            .query(
-                Pagination::new(),
-                Some(NameQueryFilter {
-                    name: None,
-                    code: None,
-                    is_customer: None,
-                    is_supplier: Some(true),
-                }),
-            )
-            .unwrap();
-        assert!(result.len() == 1);
-        result.iter().find(|it| it.name == "name_1").unwrap();
-        result.iter().find(|it| it.name == "name_2").unwrap();
-        */
-
-        let result = repo
-            .query(
-                Pagination::new(),
-                None,
-                Some(NameSort {
-                    key: NameSortField::Code,
-                    desc: Some(true),
-                }),
-            )
-            .unwrap();
-        assert_eq!(result.get(0).unwrap().name_row.code, "code2");
     }
 
     #[actix_rt::test]

--- a/server/src/sync/translation_remote/invoice.rs
+++ b/server/src/sync/translation_remote/invoice.rs
@@ -4,7 +4,7 @@ use repository::{
         ChangelogRow, ChangelogTableName, InvoiceRow, InvoiceRowStatus, InvoiceRowType,
         RemoteSyncBufferRow,
     },
-    EqualFilter, InvoiceRepository, NameFilter, NameQueryRepository, StorageConnection,
+    InvoiceRepository, StorageConnection, StoreRowRepository,
 };
 
 use serde::{Deserialize, Serialize};
@@ -113,15 +113,14 @@ impl RemotePullTranslation for InvoiceTranslation {
                 }
             })?;
 
-        let name = NameQueryRepository::new(connection)
-            .query_one(NameFilter::new().id(EqualFilter::equal_to(&data.name_ID)))
+        let name_store_id = StoreRowRepository::new(connection)
+            .find_one_by_name_id(&data.name_ID)
             .map_err(|err| SyncTranslationError {
                 table_name,
                 source: err.into(),
                 record: sync_record.data.clone(),
-            })?;
-        let name_store_id =
-            name.and_then(|name| name.store_id().map(|store_id| store_id.to_string()));
+            })?
+            .map(|store_row| store_row.id);
 
         let invoice_type = invoice_type(&data._type).ok_or(SyncTranslationError {
             table_name,

--- a/service/src/invoice/inbound_shipment/insert/mod.rs
+++ b/service/src/invoice/inbound_shipment/insert/mod.rs
@@ -30,9 +30,9 @@ pub fn insert_inbound_shipment(
     let invoice = ctx
         .connection
         .transaction_sync(|connection| {
-            let other_party = validate(&input, &connection)?;
+            let other_party = validate(connection, store_id, &input)?;
             let new_invoice = generate(connection, store_id, input, other_party)?;
-            InvoiceRepository::new(&connection).upsert_one(&new_invoice)?;
+            InvoiceRepository::new(connection).upsert_one(&new_invoice)?;
             get_invoice(ctx, None, &new_invoice.id)
                 .map_err(|error| OutError::DatabaseError(error))?
                 .ok_or(OutError::NewlyCreatedInvoiceDoesNotExist)

--- a/service/src/invoice/inbound_shipment/insert/validate.rs
+++ b/service/src/invoice/inbound_shipment/insert/validate.rs
@@ -5,13 +5,14 @@ use repository::{InvoiceRepository, RepositoryError, StorageConnection};
 use super::{InsertInboundShipment, InsertInboundShipmentError};
 
 pub fn validate(
-    input: &InsertInboundShipment,
     connection: &StorageConnection,
+    store_id: &str,
+    input: &InsertInboundShipment,
 ) -> Result<Name, InsertInboundShipmentError> {
     use InsertInboundShipmentError::*;
     check_invoice_does_not_exists(&input.id, connection)?;
 
-    let other_party = check_other_party_id(connection, &input.other_party_id)?
+    let other_party = check_other_party_id(connection, store_id, &input.other_party_id)?
         .ok_or(OtherPartyDoesNotExist {})?;
 
     if !other_party.is_supplier() {

--- a/service/src/invoice/inbound_shipment/update/mod.rs
+++ b/service/src/invoice/inbound_shipment/update/mod.rs
@@ -39,21 +39,21 @@ type OutError = UpdateInboundShipmentError;
 
 pub fn update_inbound_shipment(
     ctx: &ServiceContext,
-    _store_id: &str,
+    store_id: &str,
     patch: UpdateInboundShipment,
 ) -> Result<Invoice, OutError> {
     let invoice = ctx
         .connection
         .transaction_sync(|connection| {
-            let (invoice, other_party) = validate(&patch, connection)?;
+            let (invoice, other_party) = validate(connection, store_id, &patch)?;
             let (lines_and_invoice_lines_option, update_invoice) =
                 generate(connection, invoice, other_party, patch)?;
 
-            InvoiceRepository::new(&connection).upsert_one(&update_invoice)?;
+            InvoiceRepository::new(connection).upsert_one(&update_invoice)?;
 
             if let Some(lines_and_invoice_lines) = lines_and_invoice_lines_option {
-                let stock_line_repository = StockLineRowRepository::new(&connection);
-                let invoice_line_respository = InvoiceLineRowRepository::new(&connection);
+                let stock_line_repository = StockLineRowRepository::new(connection);
+                let invoice_line_respository = InvoiceLineRowRepository::new(connection);
 
                 for LineAndStockLine { line, stock_line } in lines_and_invoice_lines.into_iter() {
                     stock_line_repository.upsert_one(&stock_line)?;

--- a/service/src/invoice/inbound_shipment/update/validate.rs
+++ b/service/src/invoice/inbound_shipment/update/validate.rs
@@ -12,8 +12,9 @@ use repository::{
 use super::{UpdateInboundShipment, UpdateInboundShipmentError};
 
 pub fn validate(
-    patch: &UpdateInboundShipment,
     connection: &StorageConnection,
+    store_id: &str,
+    patch: &UpdateInboundShipment,
 ) -> Result<(InvoiceRow, Option<Name>), UpdateInboundShipmentError> {
     use UpdateInboundShipmentError::*;
     let invoice = check_invoice_exists(&patch.id, connection)?;
@@ -25,7 +26,7 @@ pub fn validate(
 
     let other_party_option = match &patch.other_party_id {
         Some(other_party_id) => {
-            let other_party = check_other_party_id(connection, &other_party_id)?
+            let other_party = check_other_party_id(connection, store_id, &other_party_id)?
                 .ok_or(OtherPartyDoesNotExist {})?;
 
             if !other_party.is_supplier() {

--- a/service/src/invoice/outbound_shipment/insert/mod.rs
+++ b/service/src/invoice/outbound_shipment/insert/mod.rs
@@ -41,7 +41,7 @@ pub fn insert_outbound_shipment(
     let invoice = ctx
         .connection
         .transaction_sync(|connection| {
-            let other_party = validate(&input, connection)?;
+            let other_party = validate(connection, store_id, &input)?;
             let new_invoice = generate(connection, store_id, input, other_party)?;
 
             InvoiceRepository::new(&connection).upsert_one(&new_invoice)?;

--- a/service/src/invoice/outbound_shipment/insert/validate.rs
+++ b/service/src/invoice/outbound_shipment/insert/validate.rs
@@ -6,13 +6,14 @@ use crate::invoice::check_other_party_id;
 use super::{InsertOutboundShipment, InsertOutboundShipmentError};
 
 pub fn validate(
-    input: &InsertOutboundShipment,
     connection: &StorageConnection,
+    store_id: &str,
+    input: &InsertOutboundShipment,
 ) -> Result<Name, InsertOutboundShipmentError> {
     use InsertOutboundShipmentError::*;
     check_invoice_does_not_exists(&input.id, connection)?;
 
-    let other_party = check_other_party_id(connection, &input.other_party_id)?
+    let other_party = check_other_party_id(connection, store_id, &input.other_party_id)?
         .ok_or(OtherPartyIdNotFound(input.id.clone()))?;
 
     if !other_party.is_customer() {

--- a/service/src/invoice/outbound_shipment/update/mod.rs
+++ b/service/src/invoice/outbound_shipment/update/mod.rs
@@ -51,19 +51,19 @@ type OutError = UpdateOutboundShipmentError;
 
 pub fn update_outbound_shipment(
     ctx: &ServiceContext,
-    _store_id: &str,
+    store_id: &str,
     patch: UpdateOutboundShipment,
 ) -> Result<Invoice, OutError> {
     let invoice = ctx
         .connection
         .transaction_sync(|connection| {
-            let (invoice, other_party_option) = validate(&patch, &connection)?;
+            let (invoice, other_party_option) = validate(connection, store_id, &patch)?;
             let (stock_lines_option, update_invoice) =
-                generate(invoice, other_party_option, patch, &connection)?;
+                generate(invoice, other_party_option, patch, connection)?;
 
-            InvoiceRepository::new(&connection).upsert_one(&update_invoice)?;
+            InvoiceRepository::new(connection).upsert_one(&update_invoice)?;
             if let Some(stock_lines) = stock_lines_option {
-                let repository = StockLineRowRepository::new(&connection);
+                let repository = StockLineRowRepository::new(connection);
                 for stock_line in stock_lines {
                     repository.upsert_one(&stock_line)?;
                 }

--- a/service/src/invoice/outbound_shipment/update/validate.rs
+++ b/service/src/invoice/outbound_shipment/update/validate.rs
@@ -12,8 +12,9 @@ use repository::{
 use super::{UpdateOutboundShipment, UpdateOutboundShipmentError};
 
 pub fn validate(
-    patch: &UpdateOutboundShipment,
     connection: &StorageConnection,
+    store_id: &str,
+    patch: &UpdateOutboundShipment,
 ) -> Result<(InvoiceRow, Option<Name>), UpdateOutboundShipmentError> {
     use UpdateOutboundShipmentError::*;
     let invoice = check_invoice_exists(&patch.id, connection)?;
@@ -26,7 +27,7 @@ pub fn validate(
 
     let other_party_option = match &patch.other_party_id {
         Some(other_party_id) => {
-            let other_party = check_other_party_id(connection, &other_party_id)?
+            let other_party = check_other_party_id(connection, store_id, &other_party_id)?
                 .ok_or(OtherPartyDoesNotExists {})?;
 
             if !other_party.is_customer() {

--- a/service/src/invoice/validate.rs
+++ b/service/src/invoice/validate.rs
@@ -125,12 +125,15 @@ pub fn check_invoice_is_empty(
 
 pub fn check_other_party_id(
     connection: &StorageConnection,
+    store_id: &str,
     other_party_id: &str,
 ) -> Result<Option<Name>, RepositoryError> {
     let repository = NameQueryRepository::new(&connection);
 
-    let mut result =
-        repository.query_by_filter(NameFilter::new().id(EqualFilter::equal_to(other_party_id)))?;
+    let mut result = repository.query_by_filter(
+        store_id,
+        NameFilter::new().id(EqualFilter::equal_to(other_party_id)),
+    )?;
 
     Ok(result.pop())
 }

--- a/service/src/name.rs
+++ b/service/src/name.rs
@@ -1,6 +1,8 @@
+use repository::NameQueryRepository;
 use repository::PaginationOption;
 use repository::{Name, NameFilter, NameSort};
-use repository::{NameQueryRepository, StorageConnectionManager};
+
+use crate::service_provider::ServiceContext;
 
 use super::{get_default_pagination, i64_to_u32, ListError, ListResult};
 
@@ -8,17 +10,17 @@ pub const MAX_LIMIT: u32 = 1000;
 pub const MIN_LIMIT: u32 = 1;
 
 pub fn get_names(
-    connection_manager: &StorageConnectionManager,
+    ctx: &ServiceContext,
+    store_id: &str,
     pagination: Option<PaginationOption>,
     filter: Option<NameFilter>,
     sort: Option<NameSort>,
 ) -> Result<ListResult<Name>, ListError> {
     let pagination = get_default_pagination(pagination, MAX_LIMIT, MIN_LIMIT)?;
-    let connection = connection_manager.connection()?;
-    let repository = NameQueryRepository::new(&connection);
+    let repository = NameQueryRepository::new(&ctx.connection);
 
     Ok(ListResult {
-        rows: repository.query(pagination, filter.clone(), sort)?,
-        count: i64_to_u32(repository.count(filter)?),
+        rows: repository.query(store_id, pagination, filter.clone(), sort)?,
+        count: i64_to_u32(repository.count(store_id, filter)?),
     })
 }

--- a/service/src/requisition/request_requisition/insert.rs
+++ b/service/src/requisition/request_requisition/insert.rs
@@ -229,22 +229,23 @@ mod test_insert {
         );
 
         // OtherPartyIsThisStore
-        assert_eq!(
-            service.insert_request_requisition(
-                &context,
-                "store_c",
-                InsertRequestRequisition {
-                    id: "new_request_requisition".to_owned(),
-                    other_party_id: mock_name_store_c().id,
-                    colour: None,
-                    their_reference: None,
-                    comment: None,
-                    max_months_of_stock: 1.0,
-                    min_months_of_stock: 0.5,
-                },
-            ),
-            Err(ServiceError::OtherPartyIsThisStore)
-        );
+        // TODO cannot test this name store join should not exist for current store and name
+        // assert_eq!(
+        //     service.insert_request_requisition(
+        //         &context,
+        //         "store_c",
+        //         InsertRequestRequisition {
+        //             id: "new_request_requisition".to_owned(),
+        //             other_party_id: mock_name_store_c().id,
+        //             colour: None,
+        //             their_reference: None,
+        //             comment: None,
+        //             max_months_of_stock: 1.0,
+        //             min_months_of_stock: 0.5,
+        //         },
+        //     ),
+        //     Err(ServiceError::OtherPartyIsThisStore)
+        // );
     }
 
     #[actix_rt::test]

--- a/service/src/requisition/request_requisition/validate.rs
+++ b/service/src/requisition/request_requisition/validate.rs
@@ -16,7 +16,10 @@ pub fn check_other_party(
     other_party_id: &str,
 ) -> Result<(), OtherPartyErrors> {
     let other_party = NameQueryRepository::new(connection)
-        .query_by_filter(NameFilter::new().id(EqualFilter::equal_to(other_party_id)))?
+        .query_by_filter(
+            store_id,
+            NameFilter::new().id(EqualFilter::equal_to(other_party_id)),
+        )?
         .pop()
         .ok_or(OtherPartyErrors::OtherPartyDoesNotExist)?;
 

--- a/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
+++ b/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
@@ -16,7 +16,7 @@ pub fn generate(
     requisition_row: RequisitionRow,
     fullfilments: Vec<ItemFulFillment>,
 ) -> Result<(InvoiceRow, Vec<InvoiceLineRow>), OutError> {
-    let other_party = check_other_party_id(connection, &requisition_row.name_id)?
+    let other_party = check_other_party_id(connection, store_id, &requisition_row.name_id)?
         .ok_or(OutError::ProblemGettingOtherParty)?;
 
     let new_invoice = InvoiceRow {

--- a/service/src/service_provider.rs
+++ b/service/src/service_provider.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use repository::{RepositoryError, StorageConnection, StorageConnectionManager};
+use repository::{
+    Name, NameFilter, NameSort, PaginationOption, RepositoryError, StorageConnection,
+    StorageConnectionManager,
+};
 
 use crate::{
     dashboard::{
@@ -12,6 +15,7 @@ use crate::{
     item_stats::{ItemStatsService, ItemStatsServiceTrait},
     location::{LocationService, LocationServiceTrait},
     master_list::{MasterListService, MasterListServiceTrait},
+    name::get_names,
     permission_validation::{ValidationService, ValidationServiceTrait},
     permissions::{PermissionService, PermissionServiceTrait},
     requisition::{RequisitionService, RequisitionServiceTrait},
@@ -19,6 +23,7 @@ use crate::{
     stocktake::{StocktakeService, StocktakeServiceTrait},
     stocktake_line::{StocktakeLineService, StocktakeLineServiceTrait},
     store::{StoreService, StoreServiceTrait},
+    ListError, ListResult,
 };
 
 pub struct ServiceProvider {
@@ -35,6 +40,7 @@ pub struct ServiceProvider {
     pub invoice_line_service: Box<dyn InvoiceLineServiceTrait>,
     pub requisition_service: Box<dyn RequisitionServiceTrait>,
     pub requisition_line_service: Box<dyn RequisitionLineServiceTrait>,
+    pub general_service: Box<dyn GeneralServiceTrait>,
     // Dashboard:
     pub invoice_count_service: Box<dyn InvoiceCountServiceTrait>,
     pub stock_expiry_count_service: Box<dyn StockExpiryCountServiceTrait>,
@@ -65,6 +71,7 @@ impl ServiceProvider {
             requisition_service: Box::new(RequisitionService {}),
             requisition_line_service: Box::new(RequisitionLineService {}),
             item_stats_service: Box::new(ItemStatsService {}),
+            general_service: Box::new(GeneralService {}),
         }
     }
 
@@ -80,3 +87,20 @@ impl ServiceProvider {
         self.connection_manager.connection()
     }
 }
+
+pub trait GeneralServiceTrait: Sync + Send {
+    fn get_names(
+        &self,
+        ctx: &ServiceContext,
+        store_id: &str,
+        pagination: Option<PaginationOption>,
+        filter: Option<NameFilter>,
+        sort: Option<NameSort>,
+    ) -> Result<ListResult<Name>, ListError> {
+        get_names(ctx, store_id, pagination, filter, sort)
+    }
+}
+
+pub struct GeneralService;
+
+impl GeneralServiceTrait for GeneralService {}

--- a/service/src/stocktake/update.rs
+++ b/service/src/stocktake/update.rs
@@ -1,14 +1,14 @@
 use chrono::{NaiveDate, Utc};
+use repository::EqualFilter;
 use repository::{
     schema::{
         InvoiceLineRow, InvoiceLineRowType, InvoiceRow, InvoiceRowStatus, InvoiceRowType,
         NumberRowType, StockLineRow, StocktakeRow, StocktakeStatus,
     },
-    InvoiceLineRowRepository, InvoiceRepository, ItemRepository, NameFilter, NameQueryRepository,
-    RepositoryError, StockLineRowRepository, Stocktake, StocktakeLine, StocktakeLineFilter,
-    StocktakeLineRepository, StocktakeRowRepository, StorageConnection,
+    InvoiceLineRowRepository, InvoiceRepository, ItemRepository, NameRepository, RepositoryError,
+    StockLineRowRepository, Stocktake, StocktakeLine, StocktakeLineFilter, StocktakeLineRepository,
+    StocktakeRowRepository, StorageConnection,
 };
-use repository::{EqualFilter, SimpleStringFilter};
 use util::{constants::INVENTORY_ADJUSTMENT_NAME_CODE, inline_edit, uuid::uuid};
 
 use crate::{
@@ -317,11 +317,8 @@ fn generate(
     }
 
     // find inventory adjustment name:
-    let name_result = NameQueryRepository::new(connection).query_by_filter(
-        NameFilter::new().code(SimpleStringFilter::equal_to(INVENTORY_ADJUSTMENT_NAME_CODE)),
-    )?;
-    let invad_name = name_result
-        .first()
+    let name_row = NameRepository::new(connection)
+        .find_one_by_code(INVENTORY_ADJUSTMENT_NAME_CODE)?
         .ok_or(UpdateStocktakeError::InternalError(
             "Missing inventory adjustment name".to_string(),
         ))?;
@@ -330,7 +327,7 @@ fn generate(
     let now = Utc::now().naive_utc();
     let shipment = InvoiceRow {
         id: shipment_id,
-        name_id: invad_name.name_row.id.to_owned(),
+        name_id: name_row.id,
         store_id: store_id.to_string(),
         invoice_number: next_number(connection, &NumberRowType::InventoryAdjustment, store_id)?,
         name_store_id: None,

--- a/service/src/sync_processor/mod.rs
+++ b/service/src/sync_processor/mod.rs
@@ -1,9 +1,8 @@
 use repository::EqualFilter;
 use repository::{
     schema::{InvoiceRow, NameRow, RequisitionRow, StoreRow},
-    InvoiceFilter, InvoiceQueryRepository, NameFilter, NameQueryRepository, NameRepository,
-    RepositoryError, RequisitionFilter, RequisitionRepository, StorageConnection,
-    StoreRowRepository,
+    InvoiceFilter, InvoiceQueryRepository, NameRepository, RepositoryError, RequisitionFilter,
+    RequisitionRepository, StorageConnection, StoreRowRepository,
 };
 
 use self::{
@@ -137,17 +136,7 @@ fn get_other_party_store(
         Record::InvoiceRow(invoice_row) => &invoice_row.name_id,
     };
 
-    let name = NameQueryRepository::new(connection)
-        .query_one(NameFilter::new().id(EqualFilter::equal_to(&name_id)))?
-        .ok_or(ProcessRecordError::CannotFindNameForSourceRecord(
-            record.clone(),
-        ))?;
-
-    let result = match name.store_id() {
-        Some(store_id) => StoreRowRepository::new(connection).find_one_by_id(store_id)?,
-        None => None,
-    };
-    Ok(result)
+    Ok(StoreRowRepository::new(connection).find_one_by_name_id(name_id)?)
 }
 
 fn get_source_name(

--- a/util/src/constants.rs
+++ b/util/src/constants.rs
@@ -4,3 +4,5 @@ pub const INVENTORY_ADJUSTMENT_NAME_CODE: &str = "invad";
 pub const NUMBER_OF_DAYS_IN_A_MONTH: f64 = 30.0;
 /// For use when service item is not specified in service invoice line
 pub const DEFAULT_SERVICE_ITEM_CODE: &str = "service";
+/// System names to not be included in name query
+pub const SYSTEM_NAME_CODES: &[&'static str] = &["invad", "build", "repack"];


### PR DESCRIPTION
closes #823 
closes #844 
closes #590

Ended up needing to add quite a few tests which and decided to change name to service trait to just test graphql mapping and the rest is tested in name repo. 

* Relocated tests for name repo query to name repo (out of common tests)
* Name repo now does a join on name_store_join which in turn is filtered by store_id, the other method (overall `where` with name_store_join.store_id = store_id || null, didn't quite work, since if there is another store joined to the name it will appear in query and be filtered out).
* Filtering out system names and not visible names by default but can show them with a filter.
* Since strore_id is required had to change translation and sync processor and stocktake update to just use Row level repos (with extra added methods)
* Fixed quite a few test and added new test data for name query test (fixes were required because is visible

Had to comment out OtherPartyIsThisStore test, since I didn't think it's possible for name_store_join to be there for same store and name, and thus name query will not return a name record when store_id = corresponding name_id, which results in OtherPartyNotFoundError (not 100% happy about, want to chat about this in our next meeting)
 