### PR TITLE
878 remaining to supply on requisition

### DIFF
--- a/graphql/core/src/loader/invoice_line.rs
+++ b/graphql/core/src/loader/invoice_line.rs
@@ -1,4 +1,3 @@
-use super::{extract_unique_requisition_and_item_ids, RequisitionAndItemId};
 use actix_web::web::Data;
 use async_graphql::dataloader::*;
 use async_graphql::*;
@@ -6,6 +5,8 @@ use repository::EqualFilter;
 use repository::{InvoiceLine, InvoiceLineFilter};
 use service::service_provider::ServiceProvider;
 use std::collections::HashMap;
+
+use super::{IdPairWithPayload, RequisitionAndItemId};
 
 pub struct InvoiceLineByInvoiceIdLoader {
     pub service_provider: Data<ServiceProvider>,
@@ -58,7 +59,7 @@ impl Loader<RequisitionAndItemId> for InvoiceLineForRequisitionLine {
         let service_context = self.service_provider.context()?;
 
         let (requisition_ids, item_ids) =
-            extract_unique_requisition_and_item_ids(requisition_and_item_id);
+            IdPairWithPayload::extract_unique_ids(requisition_and_item_id);
 
         let filter = InvoiceLineFilter::new()
             .requisition_id(EqualFilter::equal_any(requisition_ids))
@@ -69,14 +70,14 @@ impl Loader<RequisitionAndItemId> for InvoiceLineForRequisitionLine {
             .invoice_line_service
             .get_invoice_lines(&service_context, Some(filter))?;
 
-        let mut map: HashMap<RequisitionAndItemId, Vec<InvoiceLine>> = HashMap::new();
+        let mut map = HashMap::new();
         for line in invoice_lines {
             if let Some(requisition_id) = &line.invoice_row.requisition_id {
                 let list = map
-                    .entry(RequisitionAndItemId {
-                        item_id: line.invoice_line_row.item_id.clone(),
-                        requisition_id: requisition_id.clone(),
-                    })
+                    .entry(RequisitionAndItemId::new(
+                        &requisition_id,
+                        &line.invoice_line_row.item_id,
+                    ))
                     .or_insert_with(|| Vec::<InvoiceLine>::new());
                 list.push(line);
             }

--- a/graphql/core/src/loader/invoice_line.rs
+++ b/graphql/core/src/loader/invoice_line.rs
@@ -6,7 +6,7 @@ use repository::{InvoiceLine, InvoiceLineFilter};
 use service::service_provider::ServiceProvider;
 use std::collections::HashMap;
 
-use super::{IdPairWithPayload, RequisitionAndItemId};
+use super::{IdPair, RequisitionAndItemId};
 
 pub struct InvoiceLineByInvoiceIdLoader {
     pub service_provider: Data<ServiceProvider>,
@@ -58,8 +58,7 @@ impl Loader<RequisitionAndItemId> for InvoiceLineForRequisitionLine {
     ) -> Result<HashMap<RequisitionAndItemId, Self::Value>, Self::Error> {
         let service_context = self.service_provider.context()?;
 
-        let (requisition_ids, item_ids) =
-            IdPairWithPayload::extract_unique_ids(requisition_and_item_id);
+        let (requisition_ids, item_ids) = IdPair::extract_unique_ids(requisition_and_item_id);
 
         let filter = InvoiceLineFilter::new()
             .requisition_id(EqualFilter::equal_any(requisition_ids))

--- a/graphql/core/src/loader/item_stats.rs
+++ b/graphql/core/src/loader/item_stats.rs
@@ -1,6 +1,7 @@
-use super::ItemStatsLoaderInput;
+use super::IdPairWithPayload;
 use actix_web::web::Data;
 use async_graphql::dataloader::*;
+use chrono::NaiveDateTime;
 use repository::EqualFilter;
 use repository::{ItemStats, ItemStatsFilter};
 use service::service_provider::ServiceProvider;
@@ -8,6 +9,18 @@ use std::collections::HashMap;
 
 pub struct ItemsStatsForItemLoader {
     pub service_provider: Data<ServiceProvider>,
+}
+
+pub type ItemStatsLoaderInputPayload = Option<NaiveDateTime>;
+pub type ItemStatsLoaderInput = IdPairWithPayload<ItemStatsLoaderInputPayload>;
+impl ItemStatsLoaderInput {
+    pub fn new(store_id: &str, item_id: &str, payload: ItemStatsLoaderInputPayload) -> Self {
+        ItemStatsLoaderInput {
+            primary_id: store_id.to_string(),
+            secondary_id: item_id.to_string(),
+            payload,
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -23,18 +36,15 @@ impl Loader<ItemStatsLoaderInput> for ItemsStatsForItemLoader {
 
         let (store_id, look_back_datetime) = if let Some(loader_input) = loader_inputs.first() {
             (
-                loader_input.store_id.clone(),
-                loader_input.look_back_datetime.clone(),
+                loader_input.primary_id.clone(),
+                loader_input.payload.clone(),
             )
         } else {
             return Ok(HashMap::new());
         };
 
         let filter = ItemStatsFilter::new().item_id(EqualFilter::equal_any(
-            loader_inputs
-                .iter()
-                .map(|loader_input| loader_input.item_id.clone())
-                .collect(),
+            IdPairWithPayload::get_all_secondary_ids(&loader_inputs),
         ));
 
         let item_stats = self.service_provider.item_stats_service.get_item_stats(
@@ -48,11 +58,7 @@ impl Loader<ItemStatsLoaderInput> for ItemsStatsForItemLoader {
             .into_iter()
             .map(|item_stat| {
                 (
-                    ItemStatsLoaderInput {
-                        item_id: item_stat.item_id.clone(),
-                        store_id: store_id.clone(),
-                        look_back_datetime,
-                    },
+                    ItemStatsLoaderInput::new(&store_id, &item_stat.item_id, look_back_datetime),
                     item_stat,
                 )
             })

--- a/graphql/core/src/loader/item_stats.rs
+++ b/graphql/core/src/loader/item_stats.rs
@@ -1,4 +1,4 @@
-use super::IdPairWithPayload;
+use super::IdPair;
 use actix_web::web::Data;
 use async_graphql::dataloader::*;
 use chrono::NaiveDateTime;
@@ -12,7 +12,7 @@ pub struct ItemsStatsForItemLoader {
 }
 
 pub type ItemStatsLoaderInputPayload = Option<NaiveDateTime>;
-pub type ItemStatsLoaderInput = IdPairWithPayload<ItemStatsLoaderInputPayload>;
+pub type ItemStatsLoaderInput = IdPair<ItemStatsLoaderInputPayload>;
 impl ItemStatsLoaderInput {
     pub fn new(store_id: &str, item_id: &str, payload: ItemStatsLoaderInputPayload) -> Self {
         ItemStatsLoaderInput {
@@ -44,7 +44,7 @@ impl Loader<ItemStatsLoaderInput> for ItemsStatsForItemLoader {
         };
 
         let filter = ItemStatsFilter::new().item_id(EqualFilter::equal_any(
-            IdPairWithPayload::get_all_secondary_ids(&loader_inputs),
+            IdPair::get_all_secondary_ids(&loader_inputs),
         ));
 
         let item_stats = self.service_provider.item_stats_service.get_item_stats(

--- a/graphql/core/src/loader/loader_registry.rs
+++ b/graphql/core/src/loader/loader_registry.rs
@@ -107,6 +107,16 @@ pub async fn get_loaders(
         service_provider: service_provider.clone(),
     });
 
+    let requisition_line_supply_status_loader =
+        DataLoader::new(RequisitionLineSupplyStatusLoader {
+            service_provider: service_provider.clone(),
+        });
+
+    let requisition_lines_remaining_to_supply_loader =
+        DataLoader::new(RequisitionLinesRemainingToSupplyLoader {
+            service_provider: service_provider.clone(),
+        });
+
     loaders.insert(item_loader);
     loaders.insert(name_by_id_loader);
     loaders.insert(store_loader);
@@ -126,6 +136,8 @@ pub async fn get_loaders(
     loaders.insert(requisition_line_by_linked_requisition_line_id_loader);
     loaders.insert(item_stats_for_item_loader);
     loaders.insert(stocktake_line_loader);
+    loaders.insert(requisition_line_supply_status_loader);
+    loaders.insert(requisition_lines_remaining_to_supply_loader);
 
     loaders
 }

--- a/graphql/core/src/loader/mod.rs
+++ b/graphql/core/src/loader/mod.rs
@@ -33,7 +33,7 @@ pub use store::StoreLoader;
 pub use user_account::UserAccountLoader;
 
 #[derive(Debug, Clone)]
-pub struct IdPairWithPayload<T>
+pub struct IdPair<T>
 where
     T: Clone,
 {
@@ -42,19 +42,19 @@ where
     pub payload: T,
 }
 
-impl<T: Clone> IdPairWithPayload<T> {
-    pub fn get_all_secondary_ids(id_pairs: &[IdPairWithPayload<T>]) -> Vec<String> {
+impl<T: Clone> IdPair<T> {
+    pub fn get_all_secondary_ids(id_pairs: &[IdPair<T>]) -> Vec<String> {
         id_pairs
             .iter()
             .map(|id_pair| id_pair.secondary_id.clone())
             .collect()
     }
 
-    fn extract_unique_ids(id_pairs: &[IdPairWithPayload<T>]) -> (Vec<String>, Vec<String>) {
+    fn extract_unique_ids(id_pairs: &[IdPair<T>]) -> (Vec<String>, Vec<String>) {
         let mut primary_ids: HashSet<String> = HashSet::new();
         let mut seconday_ids: HashSet<String> = HashSet::new();
 
-        for IdPairWithPayload {
+        for IdPair {
             primary_id,
             secondary_id,
             ..
@@ -71,15 +71,15 @@ impl<T: Clone> IdPairWithPayload<T> {
     }
 }
 
-impl<T: Clone> PartialEq for IdPairWithPayload<T> {
+impl<T: Clone> PartialEq for IdPair<T> {
     fn eq(&self, other: &Self) -> bool {
         self.primary_id == other.primary_id && self.secondary_id == other.secondary_id
     }
 }
 
-impl<T: Clone> Eq for IdPairWithPayload<T> {}
+impl<T: Clone> Eq for IdPair<T> {}
 
-impl<T: Clone> std::hash::Hash for IdPairWithPayload<T> {
+impl<T: Clone> std::hash::Hash for IdPair<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         format!("{}{}", self.primary_id, self.secondary_id).hash(state);
     }
@@ -87,7 +87,7 @@ impl<T: Clone> std::hash::Hash for IdPairWithPayload<T> {
 
 #[derive(Clone)]
 pub struct EmptyPayload;
-pub type RequisitionAndItemId = IdPairWithPayload<EmptyPayload>;
+pub type RequisitionAndItemId = IdPair<EmptyPayload>;
 impl RequisitionAndItemId {
     pub fn new(requisition_id: &str, item_id: &str) -> Self {
         RequisitionAndItemId {

--- a/graphql/core/src/loader/mod.rs
+++ b/graphql/core/src/loader/mod.rs
@@ -33,6 +33,12 @@ pub use store::StoreLoader;
 pub use user_account::UserAccountLoader;
 
 #[derive(Debug, Clone)]
+/// Sometimes loaders need to take an extra parameter, like store_id or requisition_id
+/// And in some cases even further parameter is required (lookback date for ItemStats)
+/// New types can be defined for each loader based on it's needs, but to make it easier
+/// to add new complex loader inputs generic IdPair is used (don't need to impl (Hash, Eq, PartialEq)
+/// also helper methods are provided to extract unique ids from &[IdPair] that is passed to load method
+/// See StockLineByItemAndStoreIdLoaderInput for payload example
 pub struct IdPair<T>
 where
     T: Clone,
@@ -86,6 +92,7 @@ impl<T: Clone> std::hash::Hash for IdPair<T> {
 }
 
 #[derive(Clone)]
+// Using struct instead of () to avoid conflicting new implementations
 pub struct EmptyPayload;
 pub type RequisitionAndItemId = IdPair<EmptyPayload>;
 impl RequisitionAndItemId {

--- a/graphql/core/src/loader/name.rs
+++ b/graphql/core/src/loader/name.rs
@@ -8,33 +8,46 @@ use repository::{Name, NameFilter};
 
 use crate::standard_graphql_error::StandardGraphqlError;
 
-use super::IdAndStoreId;
+use super::IdPair;
 
+#[derive(Clone)]
+pub struct EmptyPayload;
+pub type NameByIdLoaderInput = IdPair<EmptyPayload>;
+impl NameByIdLoaderInput {
+    pub fn new(store_id: &str, name_id: &str) -> Self {
+        NameByIdLoaderInput {
+            primary_id: store_id.to_string(),
+            secondary_id: name_id.to_string(),
+            payload: EmptyPayload {},
+        }
+    }
+}
 pub struct NameByIdLoader {
     pub service_provider: Data<ServiceProvider>,
 }
 
 #[async_trait::async_trait]
-impl Loader<IdAndStoreId> for NameByIdLoader {
+impl Loader<NameByIdLoaderInput> for NameByIdLoader {
     type Value = Name;
     type Error = async_graphql::Error;
 
     async fn load(
         &self,
-        ids_with_store_id: &[IdAndStoreId],
-    ) -> Result<HashMap<IdAndStoreId, Self::Value>, Self::Error> {
+        ids_with_store_id: &[NameByIdLoaderInput],
+    ) -> Result<HashMap<NameByIdLoaderInput, Self::Value>, Self::Error> {
         let service_context = self.service_provider.context()?;
 
-        let store_id = match IdAndStoreId::get_store_id(ids_with_store_id) {
-            Some(store_id) => store_id,
-            None => return Ok(HashMap::new()),
+        let store_id = if let Some(item_and_store_ids) = ids_with_store_id.first() {
+            &item_and_store_ids.primary_id
+        } else {
+            return Ok(HashMap::new());
         };
 
         let filter = NameFilter::new()
             // It's posible that historic name becomes invisible
             .show_invisible_in_current_store(true)
-            .id(EqualFilter::equal_any(IdAndStoreId::get_ids(
-                ids_with_store_id,
+            .id(EqualFilter::equal_any(IdPair::get_all_secondary_ids(
+                &ids_with_store_id,
             )));
 
         let names = self
@@ -46,15 +59,7 @@ impl Loader<IdAndStoreId> for NameByIdLoader {
         Ok(names
             .rows
             .into_iter()
-            .map(|name| {
-                (
-                    IdAndStoreId {
-                        id: name.name_row.id.clone(),
-                        store_id: store_id.to_string(),
-                    },
-                    name,
-                )
-            })
+            .map(|name| (NameByIdLoaderInput::new(store_id, &name.name_row.id), name))
             .collect())
     }
 }

--- a/graphql/core/src/loader/requisition_line.rs
+++ b/graphql/core/src/loader/requisition_line.rs
@@ -8,7 +8,7 @@ use service::service_provider::ServiceProvider;
 
 use crate::standard_graphql_error::StandardGraphqlError;
 
-use super::{IdPairWithPayload, RequisitionAndItemId};
+use super::{IdPair, RequisitionAndItemId};
 
 pub struct RequisitionLinesByRequisitionIdLoader {
     pub service_provider: Data<ServiceProvider>,
@@ -61,8 +61,7 @@ impl Loader<RequisitionAndItemId> for LinkedRequisitionLineLoader {
     ) -> Result<HashMap<RequisitionAndItemId, Self::Value>, Self::Error> {
         let service_context = self.service_provider.context()?;
 
-        let (requisition_ids, item_ids) =
-            IdPairWithPayload::extract_unique_ids(requisition_and_item_id);
+        let (requisition_ids, item_ids) = IdPair::extract_unique_ids(requisition_and_item_id);
 
         let filter = RequisitionLineFilter::new()
             .requisition_id(EqualFilter::equal_any(requisition_ids))

--- a/graphql/core/src/loader/requisition_line.rs
+++ b/graphql/core/src/loader/requisition_line.rs
@@ -8,7 +8,7 @@ use service::service_provider::ServiceProvider;
 
 use crate::standard_graphql_error::StandardGraphqlError;
 
-use super::{extract_unique_requisition_and_item_ids, RequisitionAndItemId};
+use super::{IdPairWithPayload, RequisitionAndItemId};
 
 pub struct RequisitionLinesByRequisitionIdLoader {
     pub service_provider: Data<ServiceProvider>,
@@ -62,7 +62,7 @@ impl Loader<RequisitionAndItemId> for LinkedRequisitionLineLoader {
         let service_context = self.service_provider.context()?;
 
         let (requisition_ids, item_ids) =
-            extract_unique_requisition_and_item_ids(requisition_and_item_id);
+            IdPairWithPayload::extract_unique_ids(requisition_and_item_id);
 
         let filter = RequisitionLineFilter::new()
             .requisition_id(EqualFilter::equal_any(requisition_ids))
@@ -79,10 +79,10 @@ impl Loader<RequisitionAndItemId> for LinkedRequisitionLineLoader {
             .into_iter()
             .map(|line| {
                 (
-                    RequisitionAndItemId {
-                        item_id: line.requisition_line_row.item_id.clone(),
-                        requisition_id: line.requisition_line_row.requisition_id.clone(),
-                    },
+                    RequisitionAndItemId::new(
+                        &line.requisition_line_row.requisition_id,
+                        &line.requisition_line_row.item_id,
+                    ),
                     line,
                 )
             })

--- a/graphql/core/src/loader/requisition_supply_status.rs
+++ b/graphql/core/src/loader/requisition_supply_status.rs
@@ -6,7 +6,7 @@ use repository::RequisitionLine;
 use service::requisition::requisition_supply_status::RequisitionLineSupplyStatus;
 use service::service_provider::ServiceProvider;
 
-use super::{IdPairWithPayload, RequisitionAndItemId};
+use super::{IdPair, RequisitionAndItemId};
 
 pub struct RequisitionLineSupplyStatusLoader {
     pub service_provider: Data<ServiceProvider>,
@@ -23,7 +23,7 @@ impl Loader<RequisitionAndItemId> for RequisitionLineSupplyStatusLoader {
     ) -> Result<HashMap<RequisitionAndItemId, Self::Value>, Self::Error> {
         let service_context = self.service_provider.context()?;
 
-        let (requisition_ids, _) = IdPairWithPayload::extract_unique_ids(requisition_and_item_id);
+        let (requisition_ids, _) = IdPair::extract_unique_ids(requisition_and_item_id);
 
         let requisition_supply_statuses = self
             .service_provider

--- a/graphql/core/src/loader/requisition_supply_status.rs
+++ b/graphql/core/src/loader/requisition_supply_status.rs
@@ -1,0 +1,83 @@
+use std::collections::HashMap;
+
+use actix_web::web::Data;
+use async_graphql::dataloader::*;
+use repository::RequisitionLine;
+use service::requisition::requisition_supply_status::RequisitionLineSupplyStatus;
+use service::service_provider::ServiceProvider;
+
+use super::{IdPairWithPayload, RequisitionAndItemId};
+
+pub struct RequisitionLineSupplyStatusLoader {
+    pub service_provider: Data<ServiceProvider>,
+}
+
+#[async_trait::async_trait]
+impl Loader<RequisitionAndItemId> for RequisitionLineSupplyStatusLoader {
+    type Value = RequisitionLineSupplyStatus;
+    type Error = async_graphql::Error;
+
+    async fn load(
+        &self,
+        requisition_and_item_id: &[RequisitionAndItemId],
+    ) -> Result<HashMap<RequisitionAndItemId, Self::Value>, Self::Error> {
+        let service_context = self.service_provider.context()?;
+
+        let (requisition_ids, _) = IdPairWithPayload::extract_unique_ids(requisition_and_item_id);
+
+        let requisition_supply_statuses = self
+            .service_provider
+            .requisition_service
+            .get_requisitions_supply_status(&service_context, requisition_ids)?;
+
+        Ok(requisition_supply_statuses
+            .into_iter()
+            .map(|status| {
+                let requisition_line_row = &status.requisition_line.requisition_line_row;
+                (
+                    RequisitionAndItemId::new(
+                        &requisition_line_row.requisition_id,
+                        &requisition_line_row.item_id,
+                    ),
+                    status,
+                )
+            })
+            .collect())
+    }
+}
+
+pub struct RequisitionLinesRemainingToSupplyLoader {
+    pub service_provider: Data<ServiceProvider>,
+}
+
+#[async_trait::async_trait]
+impl Loader<String> for RequisitionLinesRemainingToSupplyLoader {
+    type Value = RequisitionLine;
+    type Error = async_graphql::Error;
+
+    async fn load(
+        &self,
+        requisition_ids: &[String],
+    ) -> Result<HashMap<String, Self::Value>, Self::Error> {
+        let service_context = self.service_provider.context()?;
+
+        let requisition_supply_statuses = self
+            .service_provider
+            .requisition_service
+            .get_requisitions_supply_status(&service_context, requisition_ids.to_owned())?;
+
+        let remaining_to_supply =
+            RequisitionLineSupplyStatus::lines_remaining_to_supply(requisition_supply_statuses);
+
+        Ok(remaining_to_supply
+            .into_iter()
+            .map(|status| {
+                let requisition_line_row = &status.requisition_line.requisition_line_row;
+                (
+                    requisition_line_row.requisition_id.clone(),
+                    status.requisition_line,
+                )
+            })
+            .collect())
+    }
+}

--- a/graphql/core/src/loader/stock_line.rs
+++ b/graphql/core/src/loader/stock_line.rs
@@ -7,7 +7,7 @@ use async_graphql::dataloader::*;
 use async_graphql::*;
 use std::collections::HashMap;
 
-use super::IdAndStoreId;
+use super::IdPairWithPayload;
 
 pub struct StockLineByLocationIdLoader {
     pub connection_manager: StorageConnectionManager,
@@ -46,20 +46,33 @@ pub struct StockLineByItemAndStoreIdLoader {
     pub connection_manager: StorageConnectionManager,
 }
 
+#[derive(Clone)]
+pub struct EmptyPayload;
+pub type StockLineByItemAndStoreIdLoaderInput = IdPairWithPayload<EmptyPayload>;
+impl StockLineByItemAndStoreIdLoaderInput {
+    pub fn new(store_id: &str, item_id: &str) -> Self {
+        StockLineByItemAndStoreIdLoaderInput {
+            primary_id: store_id.to_string(),
+            secondary_id: item_id.to_string(),
+            payload: EmptyPayload {},
+        }
+    }
+}
+
 #[async_trait::async_trait]
-impl Loader<IdAndStoreId> for StockLineByItemAndStoreIdLoader {
+impl Loader<StockLineByItemAndStoreIdLoaderInput> for StockLineByItemAndStoreIdLoader {
     type Value = Vec<StockLine>;
     type Error = RepositoryError;
 
     async fn load(
         &self,
-        item_and_store_ids: &[IdAndStoreId],
-    ) -> Result<HashMap<IdAndStoreId, Self::Value>, Self::Error> {
+        item_and_store_ids: &[StockLineByItemAndStoreIdLoaderInput],
+    ) -> Result<HashMap<StockLineByItemAndStoreIdLoaderInput, Self::Value>, Self::Error> {
         let connection = self.connection_manager.connection()?;
         let repo = StockLineRepository::new(&connection);
 
         let store_id = if let Some(item_and_store_ids) = item_and_store_ids.first() {
-            &item_and_store_ids.store_id
+            &item_and_store_ids.primary_id
         } else {
             return Ok(HashMap::new());
         };
@@ -67,10 +80,7 @@ impl Loader<IdAndStoreId> for StockLineByItemAndStoreIdLoader {
         let result = repo.query_by_filter(
             StockLineFilter::new()
                 .item_id(EqualFilter::equal_any(
-                    item_and_store_ids
-                        .iter()
-                        .map(|item_and_store_id| item_and_store_id.id.clone())
-                        .collect(),
+                    IdPairWithPayload::get_all_secondary_ids(&item_and_store_ids),
                 ))
                 .store_id(EqualFilter::equal_to(store_id)),
         )?;
@@ -78,10 +88,10 @@ impl Loader<IdAndStoreId> for StockLineByItemAndStoreIdLoader {
         let mut result_map = HashMap::new();
         for stock_line in result {
             result_map
-                .entry(IdAndStoreId {
-                    id: stock_line.stock_line_row.item_id.clone(),
-                    store_id: store_id.clone(),
-                })
+                .entry(StockLineByItemAndStoreIdLoaderInput::new(
+                    &store_id,
+                    &stock_line.stock_line_row.item_id,
+                ))
                 .or_insert(Vec::new())
                 .push(stock_line);
         }

--- a/graphql/core/src/loader/stock_line.rs
+++ b/graphql/core/src/loader/stock_line.rs
@@ -7,7 +7,7 @@ use async_graphql::dataloader::*;
 use async_graphql::*;
 use std::collections::HashMap;
 
-use super::IdPairWithPayload;
+use super::IdPair;
 
 pub struct StockLineByLocationIdLoader {
     pub connection_manager: StorageConnectionManager,
@@ -48,7 +48,7 @@ pub struct StockLineByItemAndStoreIdLoader {
 
 #[derive(Clone)]
 pub struct EmptyPayload;
-pub type StockLineByItemAndStoreIdLoaderInput = IdPairWithPayload<EmptyPayload>;
+pub type StockLineByItemAndStoreIdLoaderInput = IdPair<EmptyPayload>;
 impl StockLineByItemAndStoreIdLoaderInput {
     pub fn new(store_id: &str, item_id: &str) -> Self {
         StockLineByItemAndStoreIdLoaderInput {
@@ -79,9 +79,9 @@ impl Loader<StockLineByItemAndStoreIdLoaderInput> for StockLineByItemAndStoreIdL
 
         let result = repo.query_by_filter(
             StockLineFilter::new()
-                .item_id(EqualFilter::equal_any(
-                    IdPairWithPayload::get_all_secondary_ids(&item_and_store_ids),
-                ))
+                .item_id(EqualFilter::equal_any(IdPair::get_all_secondary_ids(
+                    &item_and_store_ids,
+                )))
                 .store_id(EqualFilter::equal_to(store_id)),
         )?;
 

--- a/graphql/requisition/src/query_tests/requisition_loaders.rs
+++ b/graphql/requisition/src/query_tests/requisition_loaders.rs
@@ -136,6 +136,7 @@ mod test {
 
         // Test lines remaining to supply
         let variables = json!({
+            "storeId": "store_a",
           "filter": {
             "id": {
                 "equalAny": [mock_new_response_requisition_test().requisition.id]

--- a/graphql/types/src/types/invoice_query.rs
+++ b/graphql/types/src/types/invoice_query.rs
@@ -3,7 +3,7 @@ use async_graphql::*;
 use chrono::{DateTime, Utc};
 use dataloader::DataLoader;
 
-use graphql_core::loader::{IdAndStoreId, InvoiceByIdLoader, InvoiceLineByInvoiceIdLoader};
+use graphql_core::loader::{InvoiceByIdLoader, InvoiceLineByInvoiceIdLoader, NameByIdLoaderInput};
 use graphql_core::{
     loader::{InvoiceStatsLoader, NameByIdLoader, RequisitionsByIdLoader, StoreLoader},
     standard_graphql_error::StandardGraphqlError,
@@ -222,10 +222,7 @@ impl InvoiceNode {
         let loader = ctx.get_loader::<DataLoader<NameByIdLoader>>();
 
         let response_option = loader
-            .load_one(IdAndStoreId {
-                id: self.row().name_id.clone(),
-                store_id,
-            })
+            .load_one(NameByIdLoaderInput::new(&store_id, &self.row().name_id))
             .await?;
 
         response_option.map(NameNode::from_domain).ok_or(

--- a/graphql/types/src/types/item.rs
+++ b/graphql/types/src/types/item.rs
@@ -4,8 +4,8 @@ use async_graphql::*;
 use chrono::NaiveDateTime;
 use graphql_core::{
     loader::{
-        IdAndStoreId, ItemStatsLoaderInput, ItemsStatsForItemLoader,
-        StockLineByItemAndStoreIdLoader,
+        ItemStatsLoaderInput, ItemsStatsForItemLoader, StockLineByItemAndStoreIdLoader,
+        StockLineByItemAndStoreIdLoaderInput,
     },
     simple_generic_errors::InternalError,
     standard_graphql_error::StandardGraphqlError,
@@ -55,11 +55,11 @@ impl ItemNode {
     ) -> Result<ItemStatsNode> {
         let loader = ctx.get_loader::<DataLoader<ItemsStatsForItemLoader>>();
         let result = loader
-            .load_one(ItemStatsLoaderInput {
-                store_id: store_id.clone(),
+            .load_one(ItemStatsLoaderInput::new(
+                &store_id,
+                &self.row().id,
                 look_back_datetime,
-                item_id: self.row().id.to_string(),
-            })
+            ))
             .await?
             .ok_or(
                 StandardGraphqlError::InternalError(format!(
@@ -80,10 +80,10 @@ impl ItemNode {
     ) -> Result<StockLineConnector> {
         let loader = ctx.get_loader::<DataLoader<StockLineByItemAndStoreIdLoader>>();
         let result_option = loader
-            .load_one(IdAndStoreId {
-                id: self.row().id.to_string(),
-                store_id,
-            })
+            .load_one(StockLineByItemAndStoreIdLoaderInput::new(
+                &store_id,
+                &self.row().id,
+            ))
             .await?;
 
         Ok(StockLineConnector::from_vec(

--- a/graphql/types/src/types/requisition.rs
+++ b/graphql/types/src/types/requisition.rs
@@ -3,8 +3,8 @@ use async_graphql::*;
 use chrono::{DateTime, Utc};
 use graphql_core::{
     loader::{
-        IdAndStoreId, InvoiceByRequisitionIdLoader, NameByIdLoader,
-        RequisitionLinesByRequisitionIdLoader, RequisitionsByIdLoader,
+        InvoiceByRequisitionIdLoader, NameByIdLoader, RequisitionLinesByRequisitionIdLoader,
+        RequisitionsByIdLoader, NameByIdLoaderInput,
     },
     standard_graphql_error::StandardGraphqlError,
     ContextExt,
@@ -102,10 +102,7 @@ impl RequisitionNode {
         let loader = ctx.get_loader::<DataLoader<NameByIdLoader>>();
 
         let response_option = loader
-            .load_one(IdAndStoreId {
-                id: self.row().name_id.clone(),
-                store_id,
-            })
+            .load_one(NameByIdLoaderInput::new(&store_id, &self.row().name_id))
             .await?;
 
         response_option.map(NameNode::from_domain).ok_or(

--- a/graphql/types/src/types/requisition.rs
+++ b/graphql/types/src/types/requisition.rs
@@ -172,6 +172,21 @@ impl RequisitionNode {
         Ok(InvoiceConnector::from_vec(result))
     }
 
+    /// All lines that have not been supplied
+    /// based on same logic as RequisitionLineNode.remainingQuantityToSupply
+    /// only applicable to Response requisition, Request requisition will empty connector
+    pub async fn lines_remaining_to_supply(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<RequisitionLineConnector> {
+        let loader = ctx.get_loader::<DataLoader<RequisitionLinesByRequisitionIdLoader>>();
+        let result_option = loader.load_one(self.row().id.clone()).await?;
+
+        let result = result_option.unwrap_or(vec![]);
+
+        Ok(RequisitionLineConnector::from_vec(result))
+    }
+
     // % allocated ?
     // % shipped ?
     // lead time ?

--- a/graphql/types/src/types/store.rs
+++ b/graphql/types/src/types/store.rs
@@ -1,6 +1,6 @@
 use async_graphql::{dataloader::DataLoader, Context, ErrorExtensions, Object, Result};
 use graphql_core::{
-    loader::{IdAndStoreId, NameByIdLoader},
+    loader::{NameByIdLoader, NameByIdLoaderInput},
     standard_graphql_error::StandardGraphqlError,
     ContextExt,
 };
@@ -27,10 +27,7 @@ impl StoreNode {
         let loader = ctx.get_loader::<DataLoader<NameByIdLoader>>();
 
         let response_option = loader
-            .load_one(IdAndStoreId {
-                id: self.store.name_id.clone(),
-                store_id,
-            })
+            .load_one(NameByIdLoaderInput::new(&store_id, &self.store.name_id))
             .await?;
 
         response_option.map(NameNode::from_domain).ok_or(

--- a/service/src/requisition/mod.rs
+++ b/service/src/requisition/mod.rs
@@ -8,6 +8,7 @@ use self::{
         InsertRequestRequisition, InsertRequestRequisitionError, UpdateRequestRequisition,
         UpdateRequestRequisitionError, UseSuggestedQuantity, UseSuggestedQuantityError,
     },
+    requisition_supply_status::{get_requisitions_supply_statuses, RequisitionLineSupplyStatus},
     response_requisition::{
         create_requisition_shipment, supply_requested_quantity, update_response_requisition,
         CreateRequisitionShipment, CreateRequisitionShipmentError, SupplyRequestedQuantity,
@@ -26,6 +27,7 @@ use repository::{
 pub mod common;
 pub mod query;
 pub mod request_requisition;
+pub mod requisition_supply_status;
 pub mod response_requisition;
 
 pub trait RequisitionServiceTrait: Sync + Send {
@@ -57,6 +59,14 @@ pub trait RequisitionServiceTrait: Sync + Send {
         r#type: RequisitionRowType,
     ) -> Result<Option<Requisition>, RepositoryError> {
         get_requisition_by_number(ctx, store_id, requisition_number, r#type)
+    }
+
+    fn get_requisitions_supply_status(
+        &self,
+        ctx: &ServiceContext,
+        requisition_ids: Vec<String>,
+    ) -> Result<Vec<RequisitionLineSupplyStatus>, RepositoryError> {
+        get_requisitions_supply_statuses(&ctx.connection, requisition_ids)
     }
 
     fn insert_request_requisition(

--- a/service/src/requisition/requisition_supply_status.rs
+++ b/service/src/requisition/requisition_supply_status.rs
@@ -80,12 +80,9 @@ impl RequisitionLineSupplyStatus {
     }
 
     pub fn quantity_in_invoices(&self) -> i32 {
-        self.invoice_lines
-            .iter()
-            .try_fold(0, |sum, line| {
-                Some(sum + line.invoice_line_row.pack_size * line.invoice_line_row.number_of_packs)
-            })
-            .unwrap_or(0)
+        self.invoice_lines.iter().fold(0, |sum, line| {
+            sum + line.invoice_line_row.pack_size * line.invoice_line_row.number_of_packs
+        })
     }
 
     pub fn item_id(&self) -> &str {

--- a/service/src/requisition/requisition_supply_status.rs
+++ b/service/src/requisition/requisition_supply_status.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+
+use repository::{
+    EqualFilter, InvoiceLine, InvoiceLineFilter, InvoiceLineRepository, RepositoryError,
+    RequisitionLine, RequisitionLineFilter, RequisitionLineRepository, StorageConnection,
+};
+
+pub fn get_requisitions_supply_statuses(
+    connection: &StorageConnection,
+    requisition_ids: Vec<String>,
+) -> Result<Vec<RequisitionLineSupplyStatus>, RepositoryError> {
+    let existing_invoice_lines = InvoiceLineRepository::new(connection).query_by_filter(
+        InvoiceLineFilter::new().requisition_id(EqualFilter::equal_any(requisition_ids.clone())),
+    )?;
+
+    let requisition_lines = RequisitionLineRepository::new(connection).query_by_filter(
+        RequisitionLineFilter::new().requisition_id(EqualFilter::equal_any(requisition_ids)),
+    )?;
+
+    let mut statuses: HashMap<RequistionAndItemId, RequisitionLineSupplyStatus> = requisition_lines
+        .into_iter()
+        .map(|requisition_line| {
+            (
+                RequistionAndItemId {
+                    requisition_id: requisition_line.requisition_line_row.requisition_id.clone(),
+                    item_id: requisition_line.requisition_line_row.item_id.clone(),
+                },
+                RequisitionLineSupplyStatus {
+                    requisition_line,
+                    invoice_lines: Vec::new(),
+                },
+            )
+        })
+        .collect();
+
+    for line in existing_invoice_lines {
+        let requisition_id = if let Some(requisition_id) = &line.invoice_row.requisition_id {
+            requisition_id
+        } else {
+            continue;
+        };
+
+        let status = if let Some(status) = statuses.get_mut(&RequistionAndItemId {
+            requisition_id: requisition_id.clone(),
+            item_id: line.invoice_line_row.item_id.clone(),
+        }) {
+            status
+        } else {
+            continue;
+        };
+
+        status.invoice_lines.push(line)
+    }
+
+    Ok(statuses.into_values().collect())
+}
+
+#[derive(PartialEq, Eq, Hash)]
+pub struct RequistionAndItemId {
+    pub requisition_id: String,
+    pub item_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RequisitionLineSupplyStatus {
+    pub requisition_line: RequisitionLine,
+    pub invoice_lines: Vec<InvoiceLine>,
+}
+
+impl RequisitionLineSupplyStatus {
+    pub fn remaining_quantity(&self) -> i32 {
+        let result = self.requisition_line.requisition_line_row.supply_quantity
+            - self.quantity_in_invoices();
+
+        if result > 0 {
+            result
+        } else {
+            0
+        }
+    }
+
+    pub fn quantity_in_invoices(&self) -> i32 {
+        self.invoice_lines
+            .iter()
+            .try_fold(0, |sum, line| {
+                Some(sum + line.invoice_line_row.pack_size * line.invoice_line_row.number_of_packs)
+            })
+            .unwrap_or(0)
+    }
+
+    pub fn item_id(&self) -> &str {
+        &self.requisition_line.requisition_line_row.item_id
+    }
+
+    pub fn lines_remaining_to_supply(
+        statuses: Vec<RequisitionLineSupplyStatus>,
+    ) -> Vec<RequisitionLineSupplyStatus> {
+        statuses
+            .into_iter()
+            .filter(|status| status.remaining_quantity() > 0)
+            .collect()
+    }
+}

--- a/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
+++ b/service/src/requisition/response_requisition/create_requisition_shipment/generate.rs
@@ -1,5 +1,8 @@
-use super::{ItemFulFillment, OutError};
-use crate::{invoice::check_other_party_id, number::next_number};
+use super::OutError;
+use crate::{
+    invoice::check_other_party_id, number::next_number,
+    requisition::requisition_supply_status::RequisitionLineSupplyStatus,
+};
 use chrono::Utc;
 use repository::{
     schema::{
@@ -14,7 +17,7 @@ pub fn generate(
     connection: &StorageConnection,
     store_id: &str,
     requisition_row: RequisitionRow,
-    fullfilments: Vec<ItemFulFillment>,
+    fullfilments: Vec<RequisitionLineSupplyStatus>,
 ) -> Result<(InvoiceRow, Vec<InvoiceLineRow>), OutError> {
     let other_party = check_other_party_id(connection, &requisition_row.name_id)?
         .ok_or(OutError::ProblemGettingOtherParty)?;
@@ -50,21 +53,21 @@ pub fn generate(
 pub fn generate_invoice_lines(
     connection: &StorageConnection,
     invoice_id: &str,
-    fullfilments: Vec<ItemFulFillment>,
+    requisition_line_supply_statuses: Vec<RequisitionLineSupplyStatus>,
 ) -> Result<Vec<InvoiceLineRow>, OutError> {
     let mut invoice_line_rows = vec![];
 
-    for ItemFulFillment { item_id, quantity } in fullfilments.into_iter() {
+    for requisition_line_supply_status in requisition_line_supply_statuses.into_iter() {
         let item_row = ItemRepository::new(connection)
-            .find_one_by_id(&item_id)?
+            .find_one_by_id(requisition_line_supply_status.item_id())?
             .ok_or(OutError::ProblemFindingItem)?;
 
         invoice_line_rows.push(InvoiceLineRow {
             id: uuid(),
             invoice_id: invoice_id.to_owned(),
             pack_size: 1,
-            number_of_packs: quantity,
-            item_id,
+            number_of_packs: requisition_line_supply_status.remaining_quantity(),
+            item_id: item_row.id,
             item_code: item_row.code,
             item_name: item_row.name,
             r#type: InvoiceLineRowType::UnallocatedStock,

--- a/service/src/requisition/response_requisition/create_requisition_shipment/mod.rs
+++ b/service/src/requisition/response_requisition/create_requisition_shipment/mod.rs
@@ -17,11 +17,6 @@ pub struct CreateRequisitionShipment {
     pub response_requisition_id: String,
 }
 
-pub struct ItemFulFillment {
-    pub item_id: String,
-    pub quantity: i32,
-}
-
 #[derive(Debug, PartialEq)]
 pub enum CreateRequisitionShipmentError {
     RequisitionDoesNotExist,


### PR DESCRIPTION
closes #878 

Needed to relocate get_remaing_fulfilments so that it can be shared for loaders, ended up just making a new service.

Decided to just use on generic type for input struct to loaders that require more than one value `IdPairWithPayload`. A bit out of scope, and at the end wasn't really needed, could have reused `RequisitionAndItemId`, but set a better pattern I think for those use cases in the future.



