### PR TITLE
715 add sort and extra filters to store query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # test databases
 *.sqlite
+*.sqlite-journal
 
 # directories used by the server at runtime
 plugins

--- a/graphql/core/src/loader/loader_registry.rs
+++ b/graphql/core/src/loader/loader_registry.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::loader::{ItemLoader, StoreLoader, UserAccountLoader};
+use crate::loader::{ItemLoader, StoreByIdLoader, UserAccountLoader};
 use actix_web::web::Data;
 use anymap::{any::Any, Map};
 use async_graphql::dataloader::DataLoader;
@@ -32,8 +32,8 @@ pub async fn get_loaders(
         connection_manager: connection_manager.clone(),
     });
 
-    let store_loader = DataLoader::new(StoreLoader {
-        connection_manager: connection_manager.clone(),
+    let store_by_id_loader = DataLoader::new(StoreByIdLoader {
+        service_provider: service_provider.clone(),
     });
 
     let invoice_by_id_loader = DataLoader::new(InvoiceByIdLoader {
@@ -109,7 +109,7 @@ pub async fn get_loaders(
 
     loaders.insert(item_loader);
     loaders.insert(name_by_id_loader);
-    loaders.insert(store_loader);
+    loaders.insert(store_by_id_loader);
     loaders.insert(invoice_by_id_loader);
     loaders.insert(invoice_by_requisition_id_loader);
     loaders.insert(invoice_line_by_invoice_id_loader);

--- a/graphql/core/src/loader/mod.rs
+++ b/graphql/core/src/loader/mod.rs
@@ -28,7 +28,7 @@ pub use requisition::*;
 pub use requisition_line::*;
 pub use stock_line::*;
 pub use stocktake_lines::*;
-pub use store::StoreLoader;
+pub use store::*;
 pub use user_account::UserAccountLoader;
 
 #[derive(Hash, Debug, Clone, PartialEq, Eq)]

--- a/graphql/general/src/lib.rs
+++ b/graphql/general/src/lib.rs
@@ -60,8 +60,10 @@ impl GeneralQueries {
         ctx: &Context<'_>,
         #[graphql(desc = "Pagination option (first and offset)")] page: Option<PaginationInput>,
         #[graphql(desc = "Filter option")] filter: Option<StoreFilterInput>,
+        #[graphql(desc = "Sort options (only first sort input is evaluated for this endpoint)")]
+        sort: Option<Vec<StoreSortInput>>,
     ) -> Result<StoresResponse> {
-        stores(ctx, page, filter)
+        stores(ctx, page, filter, sort)
     }
 
     /// Query omSupply "master_lists" entries

--- a/graphql/general/src/queries/store.rs
+++ b/graphql/general/src/queries/store.rs
@@ -1,22 +1,36 @@
 use async_graphql::*;
+use graphql_core::generic_filters::EqualFilterStringInput;
 use graphql_core::{
     generic_filters::SimpleStringFilterInput, pagination::PaginationInput,
     standard_graphql_error::list_error_to_gql_err, ContextExt,
 };
 use graphql_types::types::StoreNode;
-use repository::StoreFilter;
+use repository::{EqualFilter, StoreFilter, StoreSort, StoreSortField};
 use repository::{PaginationOption, SimpleStringFilter};
+
 #[derive(InputObject, Clone)]
 pub struct StoreFilterInput {
-    pub id: Option<SimpleStringFilterInput>,
+    pub id: Option<EqualFilterStringInput>,
+    pub code: Option<SimpleStringFilterInput>,
+    pub name: Option<SimpleStringFilterInput>,
+    pub name_code: Option<SimpleStringFilterInput>,
 }
 
-impl From<StoreFilterInput> for StoreFilter {
-    fn from(f: StoreFilterInput) -> Self {
-        StoreFilter {
-            id: f.id.map(SimpleStringFilter::from),
-        }
-    }
+#[derive(Enum, Copy, Clone, PartialEq, Eq)]
+#[graphql(rename_items = "camelCase")]
+pub enum StoreSortFieldInput {
+    Code,
+    Name,
+    NameCode,
+}
+
+#[derive(InputObject)]
+pub struct StoreSortInput {
+    /// Sort query result by `key`
+    key: StoreSortFieldInput,
+    /// Sort query result is sorted descending or ascending (if not provided the default is
+    /// ascending)
+    desc: Option<bool>,
 }
 
 #[derive(SimpleObject)]
@@ -34,10 +48,11 @@ pub fn stores(
     ctx: &Context<'_>,
     page: Option<PaginationInput>,
     filter: Option<StoreFilterInput>,
+    sort: Option<Vec<StoreSortInput>>,
 ) -> Result<StoresResponse> {
     let service_provider = ctx.service_provider();
     let service_context = service_provider.context()?;
-    let service = &service_provider.store_service;
+    let service = &service_provider.general_service;
 
     // TODO add auth validation and restrict returned stores according to the user's permissions
 
@@ -45,14 +60,54 @@ pub fn stores(
         .get_stores(
             &service_context,
             page.map(PaginationOption::from),
-            filter.map(StoreFilter::from),
-            None,
+            filter.map(|filter| filter.to_domain()),
+            // Currently only one sort option is supported, use the first from the list.
+            sort.map(|mut sort_list| sort_list.pop())
+                .flatten()
+                .map(|sort| sort.to_domain()),
         )
         .map_err(list_error_to_gql_err)?;
     Ok(StoresResponse::Response({
         StoreConnector {
             total_count: result.count,
-            nodes: result.rows.into_iter().map(StoreNode::from).collect(),
+            nodes: result
+                .rows
+                .into_iter()
+                .map(StoreNode::from_domain)
+                .collect(),
         }
     }))
+}
+
+impl StoreFilterInput {
+    fn to_domain(self) -> StoreFilter {
+        let StoreFilterInput {
+            id,
+            code,
+            name,
+            name_code,
+        } = self;
+
+        StoreFilter {
+            id: id.map(EqualFilter::from),
+            code: code.map(SimpleStringFilter::from),
+            name: name.map(SimpleStringFilter::from),
+            name_code: name_code.map(SimpleStringFilter::from),
+        }
+    }
+}
+
+impl StoreSortInput {
+    pub fn to_domain(self) -> StoreSort {
+        let key = match self.key {
+            StoreSortFieldInput::Code => StoreSortField::Code,
+            StoreSortFieldInput::Name => StoreSortField::Name,
+            StoreSortFieldInput::NameCode => StoreSortField::NameCode,
+        };
+
+        StoreSort {
+            key,
+            desc: self.desc,
+        }
+    }
 }

--- a/graphql/types/src/types/invoice_query.rs
+++ b/graphql/types/src/types/invoice_query.rs
@@ -5,7 +5,7 @@ use dataloader::DataLoader;
 
 use graphql_core::loader::{IdAndStoreId, InvoiceByIdLoader, InvoiceLineByInvoiceIdLoader};
 use graphql_core::{
-    loader::{InvoiceStatsLoader, NameByIdLoader, RequisitionsByIdLoader, StoreLoader},
+    loader::{InvoiceStatsLoader, NameByIdLoader, RequisitionsByIdLoader, StoreByIdLoader},
     standard_graphql_error::StandardGraphqlError,
     ContextExt,
 };
@@ -89,11 +89,11 @@ impl InvoiceNode {
             None => return Ok(None),
         };
 
-        let loader = ctx.get_loader::<DataLoader<StoreLoader>>();
+        let loader = ctx.get_loader::<DataLoader<StoreByIdLoader>>();
         Ok(loader
             .load_one(other_party_store_id.clone())
             .await?
-            .map(StoreNode::from))
+            .map(StoreNode::from_domain))
     }
 
     pub async fn r#type(&self) -> InvoiceNodeType {

--- a/graphql/types/src/types/name.rs
+++ b/graphql/types/src/types/name.rs
@@ -2,7 +2,7 @@ use async_graphql::*;
 use dataloader::DataLoader;
 use repository::{schema::NameRow, Name};
 
-use graphql_core::{loader::StoreLoader, simple_generic_errors::NodeError, ContextExt};
+use graphql_core::{loader::StoreByIdLoader, simple_generic_errors::NodeError, ContextExt};
 
 use super::StoreNode;
 
@@ -34,11 +34,11 @@ impl NameNode {
             None => return Ok(None),
         };
 
-        let loader = ctx.get_loader::<DataLoader<StoreLoader>>();
+        let loader = ctx.get_loader::<DataLoader<StoreByIdLoader>>();
         Ok(loader
             .load_one(store_id.to_string())
             .await?
-            .map(StoreNode::from))
+            .map(StoreNode::from_domain))
     }
 }
 

--- a/service/src/service_provider.rs
+++ b/service/src/service_provider.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use repository::{
     Name, NameFilter, NameSort, PaginationOption, RepositoryError, StorageConnection,
-    StorageConnectionManager,
+    StorageConnectionManager, Store, StoreFilter, StoreSort,
 };
 
 use crate::{
@@ -22,7 +22,7 @@ use crate::{
     requisition_line::{RequisitionLineService, RequisitionLineServiceTrait},
     stocktake::{StocktakeService, StocktakeServiceTrait},
     stocktake_line::{StocktakeLineService, StocktakeLineServiceTrait},
-    store::{StoreService, StoreServiceTrait},
+    store::get_stores,
     ListError, ListResult,
 };
 
@@ -36,7 +36,6 @@ pub struct ServiceProvider {
     pub master_list_service: Box<dyn MasterListServiceTrait>,
     pub stocktake_service: Box<dyn StocktakeServiceTrait>,
     pub stocktake_line_service: Box<dyn StocktakeLineServiceTrait>,
-    pub store_service: Box<dyn StoreServiceTrait>,
     pub invoice_line_service: Box<dyn InvoiceLineServiceTrait>,
     pub requisition_service: Box<dyn RequisitionServiceTrait>,
     pub requisition_line_service: Box<dyn RequisitionLineServiceTrait>,
@@ -61,7 +60,6 @@ impl ServiceProvider {
             validation_service: Box::new(ValidationService::new(permission_service)),
             location_service: Box::new(LocationService {}),
             master_list_service: Box::new(MasterListService {}),
-            store_service: Box::new(StoreService {}),
             invoice_line_service: Box::new(InvoiceLineService {}),
             invoice_count_service: Box::new(InvoiceCountService {}),
             invoice_service: Box::new(InvoiceService {}),
@@ -98,6 +96,16 @@ pub trait GeneralServiceTrait: Sync + Send {
         sort: Option<NameSort>,
     ) -> Result<ListResult<Name>, ListError> {
         get_names(ctx, store_id, pagination, filter, sort)
+    }
+
+    fn get_stores(
+        &self,
+        ctx: &ServiceContext,
+        pagination: Option<PaginationOption>,
+        filter: Option<StoreFilter>,
+        sort: Option<StoreSort>,
+    ) -> Result<ListResult<Store>, ListError> {
+        get_stores(ctx, pagination, filter, sort)
     }
 }
 

--- a/service/src/store.rs
+++ b/service/src/store.rs
@@ -1,27 +1,21 @@
-use repository::PaginationOption;
-use repository::{schema::StoreRow, StoreFilter, StoreRepository, StoreSort};
+use repository::{PaginationOption, Store};
+use repository::{StoreFilter, StoreRepository, StoreSort};
 
 use crate::{
     get_default_pagination, i64_to_u32, service_provider::ServiceContext, ListError, ListResult,
 };
 
-pub trait StoreServiceTrait: Sync + Send {
-    fn get_stores(
-        &self,
-        ctx: &ServiceContext,
-        pagination: Option<PaginationOption>,
-        filter: Option<StoreFilter>,
-        sort: Option<StoreSort>,
-    ) -> Result<ListResult<StoreRow>, ListError> {
-        let pagination = get_default_pagination(pagination, u32::MAX, 1)?;
-        let repository = StoreRepository::new(&ctx.connection);
+pub fn get_stores(
+    ctx: &ServiceContext,
+    pagination: Option<PaginationOption>,
+    filter: Option<StoreFilter>,
+    sort: Option<StoreSort>,
+) -> Result<ListResult<Store>, ListError> {
+    let pagination = get_default_pagination(pagination, u32::MAX, 1)?;
+    let repository = StoreRepository::new(&ctx.connection);
 
-        Ok(ListResult {
-            rows: repository.query(pagination, filter.clone(), sort)?,
-            count: i64_to_u32(repository.count(filter)?),
-        })
-    }
+    Ok(ListResult {
+        rows: repository.query(pagination, filter.clone(), sort)?,
+        count: i64_to_u32(repository.count(filter)?),
+    })
 }
-
-pub struct StoreService;
-impl StoreServiceTrait for StoreService {}


### PR DESCRIPTION
closes #715 

as per commit description 
* Add store service to general service
* Use store service in loader
* Join name to store in store repository
* Expose sort in store query with Code, Name and NameCode
* Add extra fitlers in store query for code, name_code, and name