### PR TITLE
886 printing endpoint stub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-files"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51e8a9146c12fce92a6e4c24b8c4d9b05268130bfd8d61bc587e822c32ce689"
+dependencies = [
+ "actix-service",
+ "actix-web",
+ "bitflags",
+ "bytes 0.5.6",
+ "derive_more",
+ "futures-core",
+ "futures-util",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "v_htmlescape",
+]
+
+[[package]]
 name = "actix-http"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,7 +379,7 @@ checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom 0.2.3",
  "once_cell",
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -896,6 +916,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "buf-min"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa17aa1cf56bdd6bb30518767d00e58019d326f3f05d8c3e0730b549d332ea83"
+dependencies = [
+ "bytes 0.5.6",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,7 +1051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
 dependencies = [
  "lazy_static",
- "nom",
+ "nom 5.1.2",
  "rust-ini",
  "serde 1.0.130",
  "serde-hjson",
@@ -1051,7 +1080,7 @@ checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
 dependencies = [
  "percent-encoding",
  "time 0.2.27",
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -1592,7 +1621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -1648,6 +1677,7 @@ dependencies = [
  "graphql_invoice",
  "graphql_invoice_line",
  "graphql_location",
+ "graphql_printing",
  "graphql_requisition",
  "graphql_requisition_line",
  "graphql_stocktake",
@@ -1781,6 +1811,29 @@ dependencies = [
 
 [[package]]
 name = "graphql_location"
+version = "0.1.0"
+dependencies = [
+ "actix-rt",
+ "actix-web",
+ "anymap",
+ "assert-json-diff",
+ "async-graphql",
+ "async-graphql-actix-web",
+ "async-trait",
+ "chrono",
+ "graphql_core",
+ "graphql_types",
+ "repository",
+ "reqwest",
+ "serde 1.0.130",
+ "serde_json",
+ "service",
+ "thiserror",
+ "util",
+]
+
+[[package]]
+name = "graphql_printing"
 version = "0.1.0"
 dependencies = [
  "actix-rt",
@@ -2585,7 +2638,7 @@ dependencies = [
  "mime",
  "spin 0.9.2",
  "twoway",
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -2625,13 +2678,23 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nom"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+dependencies = [
+ "memchr",
+ "version_check 0.1.5",
+]
+
+[[package]]
+name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "lexical-core",
  "memchr",
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -3441,6 +3504,7 @@ name = "server"
 version = "0.1.0"
 dependencies = [
  "actix-cors",
+ "actix-files",
  "actix-rt",
  "actix-web",
  "anyhow",
@@ -3623,7 +3687,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -3795,7 +3859,7 @@ dependencies = [
  "standback",
  "stdweb",
  "time-macros",
- "version_check",
+ "version_check 0.9.3",
  "winapi 0.3.9",
 ]
 
@@ -4078,7 +4142,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -4145,13 +4209,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "v_escape"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e0ab5fab1db278a9413d2ea794cb66f471f898c5b020c3c394f6447625d9d4"
+dependencies = [
+ "buf-min",
+ "v_escape_derive",
+]
+
+[[package]]
+name = "v_escape_derive"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29769400af8b264944b851c961a4a6930e76604f59b1fcd51246bab6a296c8c"
+dependencies = [
+ "nom 4.2.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "v_htmlescape"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f9a8af610ad6f7fc9989c9d2590d9764bc61f294884e9ee93baa58795174572"
+dependencies = [
+ "cfg-if 1.0.0",
+ "v_escape",
+]
+
+[[package]]
 name = "value-bag"
 version = "1.0.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
 dependencies = [
  "ctor",
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -4159,6 +4255,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -21,6 +21,7 @@ graphql_core = { path = "core" }
 graphql_types = { path = "types" }
 graphql_general = { path = "general" }
 graphql_location = { path = "location" }
+graphql_printing = { path = "printing" }
 graphql_invoice = { path = "invoice" }
 graphql_invoice_line = { path = "invoice_line" }
 graphql_requisition = { path = "requisition" }
@@ -48,3 +49,4 @@ assert-json-diff = "2.0.1"
 [features]
 default = ["repository/sqlite"]
 postgres = ["repository/postgres"]
+

--- a/graphql/lib.rs
+++ b/graphql/lib.rs
@@ -15,6 +15,7 @@ use graphql_general::{GeneralMutations, GeneralQueries};
 use graphql_invoice::{InvoiceMutations, InvoiceQueries};
 use graphql_invoice_line::InvoiceLineMutations;
 use graphql_location::{LocationMutations, LocationQueries};
+use graphql_printing::PrintingQueries;
 use graphql_requisition::{RequisitionMutations, RequisitionQueries};
 use graphql_requisition_line::RequisitionLineMutations;
 use graphql_stocktake::{StocktakeMutations, StocktakeQueries};
@@ -31,6 +32,7 @@ pub struct FullQuery(
     pub StocktakeQueries,
     pub GeneralQueries,
     pub RequisitionQueries,
+    pub PrintingQueries,
 );
 
 #[derive(MergedObject, Default)]
@@ -57,6 +59,7 @@ pub fn build_schema() -> Builder {
             StocktakeQueries,
             GeneralQueries,
             RequisitionQueries,
+            PrintingQueries,
         ),
         FullMutation(
             InvoiceMutations,

--- a/graphql/printing/Cargo.toml
+++ b/graphql/printing/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "graphql_printing"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+
+repository = { path = "../../repository" }
+service = { path = "../../service" }
+util = { path = "../../util" }
+graphql_core = { path = "../core" }
+graphql_types = { path = "../types" }
+
+actix-web = "3.3.2" # Versions >=v4 depend on Tokio v1.
+anymap = "0.12"
+async-graphql = { version = "=2.11.3", features = ["dataloader", "chrono"] }
+async-graphql-actix-web = "=2.11.3"
+async-trait = "0.1.16"
+chrono = { version = "0.4", features = ["serde"] }
+reqwest = { version = "0.10", features = ["json"] } # Versions >=0.11 depend on Tokio v1.
+serde = "1.0.126"
+serde_json = "1.0.66"
+thiserror = "1.0.30"
+
+[dev-dependencies]
+actix-rt = "1.1.1" # for Tokio 0.2
+assert-json-diff = "2.0.1"
+
+
+[features]
+default = ["repository/sqlite"]
+postgres = ["repository/postgres"]

--- a/graphql/printing/src/lib.rs
+++ b/graphql/printing/src/lib.rs
@@ -1,0 +1,69 @@
+use async_graphql::*;
+use graphql_core::simple_generic_errors::RecordNotFound;
+
+pub struct InvalidReport;
+#[Object]
+impl InvalidReport {
+    pub async fn description(&self) -> &'static str {
+        "Report exist but is invalid"
+    }
+}
+
+pub struct FailedToFetchReportData;
+#[Object]
+impl FailedToFetchReportData {
+    pub async fn description(&self) -> &'static str {
+        "Failed to query data required for the report"
+    }
+}
+
+#[derive(Interface)]
+#[graphql(field(name = "description", type = "String"))]
+pub enum PrintReportErrorInterface {
+    /// No report found with the specified report id
+    ReportNotFound(RecordNotFound),
+    InvalidReport(InvalidReport),
+    FailedToFetchReportData(FailedToFetchReportData),
+}
+
+#[derive(SimpleObject)]
+pub struct PrintReportError {
+    pub error: PrintReportErrorInterface,
+}
+
+#[derive(PartialEq, Debug)]
+pub struct PrintReportNode {}
+
+#[Object]
+impl PrintReportNode {
+    /// Return the file id of the printed report.
+    /// The file can be fetched using the /files?id={id} endpoint
+    pub async fn file_id(&self) -> &str {
+        "demofile0123456789"
+    }
+}
+
+#[derive(Union)]
+pub enum PrintReportResponse {
+    Error(PrintReportError),
+    Response(PrintReportNode),
+}
+
+#[derive(Default, Clone)]
+pub struct PrintingQueries;
+
+#[Object]
+impl PrintingQueries {
+    /// Query omSupply "locations" entries
+    pub async fn print_report(
+        &self,
+        _ctx: &Context<'_>,
+        _store_id: String,
+        #[graphql(
+            desc = "The data id that should be used for the report, e.g. the invoice id when printing an invoice"
+        )]
+        _data_id: String,
+    ) -> Result<PrintReportResponse> {
+        Ok(PrintReportResponse::Response(PrintReportNode {}))
+    }
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -23,6 +23,7 @@ util = { path = "../util" }
 
 actix-cors = "0.5.4"
 actix-web = { version= "3.3.2", features = ["openssl"] } # Versions >=v4 depend on Tokio v1.
+actix-files = "0.5.0"
 openssl = { version = "0.10", features = ["v110"] }
 anyhow = "1.0.44"
 config = "0.11.0"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,3 +1,5 @@
+use crate::static_files::config_static_files;
+
 use self::{
     middleware::{compress as compress_middleware, logger as logger_middleware},
     settings::Settings,
@@ -20,6 +22,7 @@ pub mod configuration;
 pub mod environment;
 pub mod middleware;
 pub mod settings;
+pub mod static_files;
 pub mod sync;
 pub mod test_utils;
 
@@ -70,6 +73,7 @@ pub async fn start_server(
                 service_provider_data.clone(),
                 auth_data.clone(),
             ))
+            .configure(config_static_files)
     });
     match load_certs() {
         Ok(ssl_builder) => {

--- a/server/src/static_files.rs
+++ b/server/src/static_files.rs
@@ -1,0 +1,115 @@
+use std::io::ErrorKind;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::time::{Duration, SystemTime};
+
+use actix_files as fs;
+use actix_web::error::InternalError;
+use actix_web::http::header::{ContentDisposition, DispositionParam, DispositionType};
+use actix_web::web::{get, scope};
+use actix_web::{web, Error, HttpRequest, HttpResponse};
+use reqwest::StatusCode;
+use serde::Deserialize;
+
+// this function could be located in different module
+pub fn config_static_files(cfg: &mut web::ServiceConfig) {
+    cfg.service(scope("/").route("/files", get().to(files)));
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FileRequestQuery {
+    id: String,
+}
+
+async fn files(
+    req: HttpRequest,
+    query: web::Query<FileRequestQuery>,
+) -> Result<HttpResponse, Error> {
+    // write dummy file:
+    let file_dir = "./static_files";
+    std::fs::create_dir_all(file_dir).unwrap();
+    let out_path = PathBuf::from_str(file_dir)
+        .unwrap()
+        .join(format!("{}_test.txt", query.id));
+    std::fs::write(out_path, format!("Hello world! (id = {})", query.id))?;
+
+    let file_path = find_file(&query.id, file_dir)?.ok_or(std::io::Error::new(
+        ErrorKind::NotFound,
+        "Static file not found",
+    ))?;
+    let original_file_name = parse_original_file_name(&query.id, &file_path).ok_or(
+        InternalError::new("Invalid file name", StatusCode::INTERNAL_SERVER_ERROR),
+    )?;
+    // clean up the static file directory
+    let max_lifetime_sec = 60 * 60; // 1 hours
+    delete_old_files(file_dir, max_lifetime_sec)?;
+
+    fs::NamedFile::open(file_path)?
+        .set_content_disposition(ContentDisposition {
+            disposition: DispositionType::Attachment,
+            parameters: vec![DispositionParam::Filename(original_file_name)],
+        })
+        .into_response(&req)
+}
+
+/// Returns the file name part of the path like:
+/// `./static_file_path/{ui}_{file_name};
+fn parse_original_file_name(id: &str, file_path: &PathBuf) -> Option<String> {
+    let file_name = file_path.file_name()?.to_string_lossy();
+    let name = &file_name[id.len() + 1..];
+    if name.len() == 0 {
+        // something is wrong...
+        return None;
+    }
+    Some(name.to_string())
+}
+
+/// TODO move into a service
+/// Finds file starting with the provided id
+fn find_file(id: &str, file_dir: &str) -> Result<Option<PathBuf>, Error> {
+    let starts_with = format!("{}_", id);
+    let paths = std::fs::read_dir(file_dir)?;
+    for path in paths {
+        let entry = path?;
+        let entry_path = entry.path();
+        let metadata = entry.metadata()?;
+        if !metadata.is_file() {
+            continue;
+        }
+
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with(&starts_with) {
+            return Ok(Some(entry_path));
+        }
+    }
+
+    Ok(None)
+}
+
+fn delete_old_files(file_dir: &str, max_life_time_sec: u64) -> Result<(), Error> {
+    let paths = std::fs::read_dir(file_dir)?;
+    for path in paths {
+        let entry = path?;
+        let entry_path = entry.path();
+        let metadata = entry.metadata()?;
+        if !metadata.is_file() {
+            continue;
+        }
+        // creation time is not available on some file systems...
+        let file_time = metadata.modified()?;
+        if SystemTime::now()
+            .duration_since(file_time)
+            .unwrap_or(Duration::from_secs(0))
+            > Duration::from_secs(max_life_time_sec)
+        {
+            log::info!("Delete old static file: {:?}", entry_path);
+            std::fs::remove_file(entry_path).unwrap_or_else(|err| {
+                log::error!("Failed to delete old static file: {}", err);
+                ()
+            });
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Adds:
- printReport graphql endpoint that only takes a report id and the id of the entity to be printed, e.g. the invoice id, and returns a file id
- /files?id={id} endpoint to fetch the printed report

The files endpoint already contains some proof of concept logic which needs to be update and put into a service:
- It always creates a dummy txt file for a given id in the static_files directory
- Returns this dummy txt file with a proper file name (not the file id). The "proper" filename is currently encode like `{file_id}_filename.pdf`
- Cleans up old static files that are too old

#886