### PR TITLE
Add reports mock endpoint to fetch a list of available reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,7 +1677,7 @@ dependencies = [
  "graphql_invoice",
  "graphql_invoice_line",
  "graphql_location",
- "graphql_printing",
+ "graphql_reports",
  "graphql_requisition",
  "graphql_requisition_line",
  "graphql_stocktake",
@@ -1833,7 +1833,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "graphql_printing"
+name = "graphql_reports"
 version = "0.1.0"
 dependencies = [
  "actix-rt",

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -21,7 +21,7 @@ graphql_core = { path = "core" }
 graphql_types = { path = "types" }
 graphql_general = { path = "general" }
 graphql_location = { path = "location" }
-graphql_printing = { path = "printing" }
+graphql_reports = { path = "reports" }
 graphql_invoice = { path = "invoice" }
 graphql_invoice_line = { path = "invoice_line" }
 graphql_requisition = { path = "requisition" }

--- a/graphql/lib.rs
+++ b/graphql/lib.rs
@@ -15,7 +15,7 @@ use graphql_general::{GeneralMutations, GeneralQueries};
 use graphql_invoice::{InvoiceMutations, InvoiceQueries};
 use graphql_invoice_line::InvoiceLineMutations;
 use graphql_location::{LocationMutations, LocationQueries};
-use graphql_printing::PrintingQueries;
+use graphql_reports::ReportQueries;
 use graphql_requisition::{RequisitionMutations, RequisitionQueries};
 use graphql_requisition_line::RequisitionLineMutations;
 use graphql_stocktake::{StocktakeMutations, StocktakeQueries};
@@ -32,7 +32,7 @@ pub struct FullQuery(
     pub StocktakeQueries,
     pub GeneralQueries,
     pub RequisitionQueries,
-    pub PrintingQueries,
+    pub ReportQueries,
 );
 
 #[derive(MergedObject, Default)]
@@ -59,7 +59,7 @@ pub fn build_schema() -> Builder {
             StocktakeQueries,
             GeneralQueries,
             RequisitionQueries,
-            PrintingQueries,
+            ReportQueries,
         ),
         FullMutation(
             InvoiceMutations,

--- a/graphql/reports/Cargo.toml
+++ b/graphql/reports/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "graphql_printing"
+name = "graphql_reports"
 version = "0.1.0"
 edition = "2018"
 

--- a/graphql/reports/src/lib.rs
+++ b/graphql/reports/src/lib.rs
@@ -1,0 +1,43 @@
+use async_graphql::*;
+use graphql_core::pagination::PaginationInput;
+use printing::{PrintReportNode, PrintReportResponse};
+use reports::{reports, ReportFilterInput, ReportSortInput, ReportsResponse};
+
+mod printing;
+mod reports;
+
+#[derive(Default, Clone)]
+pub struct ReportQueries;
+
+#[Object]
+impl ReportQueries {
+    /// Queries a list of available reports
+    pub async fn reports(
+        &self,
+        ctx: &Context<'_>,
+        store_id: String,
+        page: Option<PaginationInput>,
+        filter: Option<ReportFilterInput>,
+        sort: Option<Vec<ReportSortInput>>,
+    ) -> Result<ReportsResponse> {
+        reports(ctx, &store_id, page, filter, sort)
+    }
+
+    /// Creates a printed report.
+    ///
+    /// All details about the report, e.g. the output format, are specified in the report definition
+    /// which is referred to by the report_id.
+    /// The printed report can be retrieved from the `/files` endpoint using the returned file id.
+    pub async fn print_report(
+        &self,
+        _ctx: &Context<'_>,
+        _store_id: String,
+        #[graphql(desc = "The id of the report to be printed")] _report_id: String,
+        #[graphql(
+            desc = "The data id that should be used for the report, e.g. the invoice id when printing an invoice"
+        )]
+        _data_id: String,
+    ) -> Result<PrintReportResponse> {
+        Ok(PrintReportResponse::Response(PrintReportNode {}))
+    }
+}

--- a/graphql/reports/src/printing.rs
+++ b/graphql/reports/src/printing.rs
@@ -48,23 +48,3 @@ pub enum PrintReportResponse {
     Error(PrintReportError),
     Response(PrintReportNode),
 }
-
-#[derive(Default, Clone)]
-pub struct PrintingQueries;
-
-#[Object]
-impl PrintingQueries {
-    /// Query omSupply "locations" entries
-    pub async fn print_report(
-        &self,
-        _ctx: &Context<'_>,
-        _store_id: String,
-        #[graphql(desc = "The id of the report to be printed")] _report_id: String,
-        #[graphql(
-            desc = "The data id that should be used for the report, e.g. the invoice id when printing an invoice"
-        )]
-        _data_id: String,
-    ) -> Result<PrintReportResponse> {
-        Ok(PrintReportResponse::Response(PrintReportNode {}))
-    }
-}

--- a/graphql/reports/src/reports.rs
+++ b/graphql/reports/src/reports.rs
@@ -1,0 +1,113 @@
+#[derive(Enum, Copy, Clone, PartialEq, Eq)]
+#[graphql(rename_items = "camelCase")]
+pub enum ReportSortFieldInput {
+    Name,
+    Category,
+}
+
+use async_graphql::*;
+use graphql_core::{
+    generic_filters::{EqualFilterStringInput, SimpleStringFilterInput},
+    pagination::PaginationInput,
+};
+use serde::Serialize;
+
+#[derive(InputObject)]
+pub struct ReportSortInput {
+    /// Sort query result by `key`
+    key: ReportSortFieldInput,
+    /// Sort query result is sorted descending or ascending (if not provided the default is
+    /// ascending)
+    desc: Option<bool>,
+}
+
+#[derive(Debug, Enum, Copy, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ReportCategory {
+    OutboundShipment,
+    InboundShipment,
+    Requisition,
+    Stocktake,
+}
+
+#[derive(InputObject, Clone)]
+pub struct EqualFilterReportCategoryInput {
+    pub equal_to: Option<ReportCategory>,
+    pub equal_any: Option<Vec<ReportCategory>>,
+    pub not_equal_to: Option<ReportCategory>,
+}
+
+#[derive(InputObject, Clone)]
+pub struct ReportFilterInput {
+    pub id: Option<EqualFilterStringInput>,
+    pub name: Option<SimpleStringFilterInput>,
+    pub category: Option<EqualFilterReportCategoryInput>,
+}
+
+#[derive(Union)]
+pub enum ReportsResponse {
+    Response(ReportConnector),
+}
+
+#[derive(SimpleObject)]
+pub struct ReportConnector {
+    total_count: u32,
+    nodes: Vec<ReportNode>,
+}
+
+#[derive(PartialEq, Debug)]
+pub struct ReportNode {
+    id: String,
+    name: String,
+    category: ReportCategory,
+}
+
+#[Object]
+impl ReportNode {
+    pub async fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Human readable name of the report
+    pub async fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub async fn category(&self) -> &ReportCategory {
+        &self.category
+    }
+}
+
+pub fn reports(
+    _ctx: &Context<'_>,
+    _store_id: &str,
+    _page: Option<PaginationInput>,
+    _filter: Option<ReportFilterInput>,
+    _sort: Option<Vec<ReportSortInput>>,
+) -> Result<ReportsResponse> {
+    Ok(ReportsResponse::Response(ReportConnector {
+        total_count: 4,
+        nodes: vec![
+            ReportNode {
+                id: "OutboundShipmentReport_1".to_string(),
+                name: "Outbound shipment report".to_string(),
+                category: ReportCategory::OutboundShipment,
+            },
+            ReportNode {
+                id: "InboundShipmentReport_1".to_string(),
+                name: "Inbound shipment report".to_string(),
+                category: ReportCategory::InboundShipment,
+            },
+            ReportNode {
+                id: "RequisitionReport_1".to_string(),
+                name: "Requisition shipment report".to_string(),
+                category: ReportCategory::Requisition,
+            },
+            ReportNode {
+                id: "StocktakeReport_1".to_string(),
+                name: "Stocktake report".to_string(),
+                category: ReportCategory::Stocktake,
+            },
+        ],
+    }))
+}


### PR DESCRIPTION
- Rename the printing graphql crate to reports. The crate contains the
reports and printReport endpoints.

Is report "category" to correct term?

Closes #899 