### PR TITLE
951 1 Allign existing batch mutations

### DIFF
--- a/graphql/batch_mutations/src/batch_inbound_shipment.rs
+++ b/graphql/batch_mutations/src/batch_inbound_shipment.rs
@@ -3,33 +3,16 @@ use graphql_core::standard_graphql_error::validate_auth;
 use graphql_core::ContextExt;
 use graphql_invoice::mutations::inbound_shipment;
 use graphql_invoice_line::mutations::inbound_shipment_line;
-use repository::Invoice;
-use repository::InvoiceLine;
-use service::invoice::inbound_shipment::DeleteInboundShipment;
-use service::invoice::inbound_shipment::DeleteInboundShipmentError;
-use service::invoice_line::inbound_shipment_line::InsertInboundShipmentLine;
-use service::invoice_line::inbound_shipment_line::InsertInboundShipmentLineError;
-use service::invoice_line::inbound_shipment_line::UpdateInboundShipmentLine;
-use service::invoice_line::inbound_shipment_line::UpdateInboundShipmentLineError;
-use service::invoice_line::inbound_shipment_service_line::DeleteInboundShipmentServiceLineError;
-use service::invoice_line::inbound_shipment_service_line::InsertInboundShipmentServiceLine;
-use service::invoice_line::inbound_shipment_service_line::InsertInboundShipmentServiceLineError;
-use service::invoice_line::inbound_shipment_service_line::UpdateInboundShipmentServiceLine;
-use service::invoice_line::inbound_shipment_service_line::UpdateInboundShipmentServiceLineError;
+use service::invoice::inbound_shipment::*;
+use service::invoice::inbound_shipment::{BatchInboundShipment, BatchInboundShipmentResult};
 use service::permission_validation::Resource;
 use service::permission_validation::ResourceAccessRequest;
-use service::InputWithResult;
-use service::{
-    invoice::inbound_shipment::{
-        BatchInboundShipment, BatchInboundShipmentResult, InsertInboundShipment,
-        InsertInboundShipmentError, UpdateInboundShipment, UpdateInboundShipmentError,
-    },
-    invoice_line::inbound_shipment_line::{
-        DeleteInboundShipmentLine, DeleteInboundShipmentLineError,
-    },
-};
 
+use crate::to_standard_error;
 use crate::VecOrNone;
+
+type ServiceInput = BatchInboundShipment;
+type ServiceResult = BatchInboundShipmentResult;
 
 #[derive(SimpleObject)]
 #[graphql(concrete(
@@ -73,27 +56,39 @@ pub struct MutationWithId<T: OutputType> {
     pub response: T,
 }
 
+type InsertShipmentsResponse = Option<Vec<MutationWithId<inbound_shipment::InsertResponse>>>;
+type InsertShipmentLinesResponse =
+    Option<Vec<MutationWithId<inbound_shipment_line::line::InsertResponse>>>;
+type UpdateShipmentLinesResponse =
+    Option<Vec<MutationWithId<inbound_shipment_line::line::UpdateResponse>>>;
+type DeleteShipmentLinesResponse =
+    Option<Vec<MutationWithId<inbound_shipment_line::line::DeleteResponse>>>;
+type InsertShipmentServiceLinesResponse =
+    Option<Vec<MutationWithId<inbound_shipment_line::service_line::InsertResponse>>>;
+type UpdateShipmentServiceLinesResponse =
+    Option<Vec<MutationWithId<inbound_shipment_line::service_line::UpdateResponse>>>;
+type DeleteShipmentServiceLinesResponse =
+    Option<Vec<MutationWithId<inbound_shipment_line::service_line::DeleteResponse>>>;
+type UpdateShipmentsResponse = Option<Vec<MutationWithId<inbound_shipment::UpdateResponse>>>;
+type DeleteShipmentsResponse = Option<Vec<MutationWithId<inbound_shipment::DeleteResponse>>>;
+
 #[derive(SimpleObject)]
-pub struct BatchInboundShipmentResponse {
-    insert_inbound_shipments: Option<Vec<MutationWithId<inbound_shipment::InsertResponse>>>,
-    insert_inbound_shipment_lines:
-        Option<Vec<MutationWithId<inbound_shipment_line::line::InsertResponse>>>,
-    update_inbound_shipment_lines:
-        Option<Vec<MutationWithId<inbound_shipment_line::line::UpdateResponse>>>,
-    delete_inbound_shipment_lines:
-        Option<Vec<MutationWithId<inbound_shipment_line::line::DeleteResponse>>>,
-    insert_inbound_shipment_service_lines:
-        Option<Vec<MutationWithId<inbound_shipment_line::service_line::InsertResponse>>>,
-    update_inbound_shipment_service_lines:
-        Option<Vec<MutationWithId<inbound_shipment_line::service_line::UpdateResponse>>>,
-    delete_inbound_shipment_service_lines:
-        Option<Vec<MutationWithId<inbound_shipment_line::service_line::DeleteResponse>>>,
-    update_inbound_shipments: Option<Vec<MutationWithId<inbound_shipment::UpdateResponse>>>,
-    delete_inbound_shipments: Option<Vec<MutationWithId<inbound_shipment::DeleteResponse>>>,
+#[graphql(name = "BatchInboundShipmentResponse")]
+pub struct BatchResponse {
+    insert_inbound_shipments: InsertShipmentsResponse,
+    insert_inbound_shipment_lines: InsertShipmentLinesResponse,
+    update_inbound_shipment_lines: UpdateShipmentLinesResponse,
+    delete_inbound_shipment_lines: DeleteShipmentLinesResponse,
+    insert_inbound_shipment_service_lines: InsertShipmentServiceLinesResponse,
+    update_inbound_shipment_service_lines: UpdateShipmentServiceLinesResponse,
+    delete_inbound_shipment_service_lines: DeleteShipmentServiceLinesResponse,
+    update_inbound_shipments: UpdateShipmentsResponse,
+    delete_inbound_shipments: DeleteShipmentsResponse,
 }
 
 #[derive(InputObject)]
-pub struct BatchInboundShipmentInput {
+#[graphql(name = "BatchInboundShipmentInput")]
+pub struct BatchInput {
     pub insert_inbound_shipments: Option<Vec<inbound_shipment::InsertInput>>,
     pub insert_inbound_shipment_lines: Option<Vec<inbound_shipment_line::line::InsertInput>>,
     pub update_inbound_shipment_lines: Option<Vec<inbound_shipment_line::line::UpdateInput>>,
@@ -109,11 +104,7 @@ pub struct BatchInboundShipmentInput {
     pub continue_on_error: Option<bool>,
 }
 
-pub fn batch_inbound_shipment(
-    ctx: &Context<'_>,
-    store_id: &str,
-    input: BatchInboundShipmentInput,
-) -> Result<BatchInboundShipmentResponse> {
+pub fn batch(ctx: &Context<'_>, store_id: &str, input: BatchInput) -> Result<BatchResponse> {
     let user = validate_auth(
         ctx,
         &ResourceAccessRequest {
@@ -132,12 +123,12 @@ pub fn batch_inbound_shipment(
         input.to_domain(),
     )?;
 
-    Ok(BatchInboundShipmentResponse::from_domain(response)?)
+    Ok(BatchResponse::from_domain(response)?)
 }
 
-impl BatchInboundShipmentInput {
-    fn to_domain(self) -> BatchInboundShipment {
-        let BatchInboundShipmentInput {
+impl BatchInput {
+    fn to_domain(self) -> ServiceInput {
+        let BatchInput {
             insert_inbound_shipments,
             insert_inbound_shipment_lines,
             update_inbound_shipment_lines,
@@ -150,7 +141,7 @@ impl BatchInboundShipmentInput {
             continue_on_error,
         } = self;
 
-        BatchInboundShipment {
+        ServiceInput {
             insert_shipment: insert_inbound_shipments
                 .map(|inputs| inputs.into_iter().map(|input| input.to_domain()).collect()),
             insert_line: insert_inbound_shipment_lines
@@ -174,9 +165,9 @@ impl BatchInboundShipmentInput {
     }
 }
 
-impl BatchInboundShipmentResponse {
+impl BatchResponse {
     fn from_domain(
-        BatchInboundShipmentResult {
+        ServiceResult {
             insert_shipment,
             insert_line,
             update_line,
@@ -186,260 +177,190 @@ impl BatchInboundShipmentResponse {
             delete_service_line,
             update_shipment,
             delete_shipment,
-        }: BatchInboundShipmentResult,
-    ) -> Result<BatchInboundShipmentResponse> {
-        // Insert Shipment
-
-        let insert_inbound_shipments_result: Result<
-            Vec<MutationWithId<inbound_shipment::InsertResponse>>,
-        > = insert_shipment
-            .into_iter()
-            .map(map_insert_shipment)
-            .collect();
-
-        // Normal Line
-
-        let insert_inbound_shipment_lines_result: Result<
-            Vec<MutationWithId<inbound_shipment_line::line::InsertResponse>>,
-        > = insert_line.into_iter().map(map_insert_line).collect();
-
-        let update_inbound_shipment_lines_result: Result<
-            Vec<MutationWithId<inbound_shipment_line::line::UpdateResponse>>,
-        > = update_line.into_iter().map(map_update_line).collect();
-
-        let delete_inbound_shipment_lines_result: Result<
-            Vec<MutationWithId<inbound_shipment_line::line::DeleteResponse>>,
-        > = delete_line.into_iter().map(map_delete_line).collect();
-
-        // Service Line
-
-        let insert_inbound_shipment_service_lines_result: Result<
-            Vec<MutationWithId<inbound_shipment_line::service_line::InsertResponse>>,
-        > = insert_service_line
-            .into_iter()
-            .map(map_insert_service_line)
-            .collect();
-
-        let update_inbound_shipment_service_lines_result: Result<
-            Vec<MutationWithId<inbound_shipment_line::service_line::UpdateResponse>>,
-        > = update_service_line
-            .into_iter()
-            .map(map_update_service_line)
-            .collect();
-
-        let delete_inbound_shipment_service_lines_result: Result<
-            Vec<MutationWithId<inbound_shipment_line::service_line::DeleteResponse>>,
-        > = delete_service_line
-            .into_iter()
-            .map(map_delete_service_line)
-            .collect();
-
-        // Update delete shipment
-
-        let update_inbound_shipments_result: Result<
-            Vec<MutationWithId<inbound_shipment::UpdateResponse>>,
-        > = update_shipment
-            .into_iter()
-            .map(map_update_shipment)
-            .collect();
-
-        let delete_inbound_shipments_result: Result<
-            Vec<MutationWithId<inbound_shipment::DeleteResponse>>,
-        > = delete_shipment
-            .into_iter()
-            .map(map_delete_shipment)
-            .collect();
-
-        let result = BatchInboundShipmentResponse {
-            insert_inbound_shipments: insert_inbound_shipments_result?.vec_or_none(),
-            insert_inbound_shipment_lines: insert_inbound_shipment_lines_result?.vec_or_none(),
-            update_inbound_shipment_lines: update_inbound_shipment_lines_result?.vec_or_none(),
-            delete_inbound_shipment_lines: delete_inbound_shipment_lines_result?.vec_or_none(),
-
-            insert_inbound_shipment_service_lines: insert_inbound_shipment_service_lines_result?
-                .vec_or_none(),
-            update_inbound_shipment_service_lines: update_inbound_shipment_service_lines_result?
-                .vec_or_none(),
-            delete_inbound_shipment_service_lines: delete_inbound_shipment_service_lines_result?
-                .vec_or_none(),
-
-            update_inbound_shipments: update_inbound_shipments_result?.vec_or_none(),
-            delete_inbound_shipments: delete_inbound_shipments_result?.vec_or_none(),
+        }: ServiceResult,
+    ) -> Result<BatchResponse> {
+        let result = BatchResponse {
+            insert_inbound_shipments: map_insert_shipments(insert_shipment)?,
+            insert_inbound_shipment_lines: map_insert_lines(insert_line)?,
+            update_inbound_shipment_lines: map_update_lines(update_line)?,
+            delete_inbound_shipment_lines: map_delete_lines(delete_line)?,
+            insert_inbound_shipment_service_lines: map_insert_service_lines(insert_service_line)?,
+            update_inbound_shipment_service_lines: map_update_service_lines(update_service_line)?,
+            delete_inbound_shipment_service_lines: map_delete_service_lines(delete_service_line)?,
+            update_inbound_shipments: map_update_shipments(update_shipment)?,
+            delete_inbound_shipments: map_delete_shipments(delete_shipment)?,
         };
 
         Ok(result)
     }
 }
 
-fn map_insert_shipment(
-    from: InputWithResult<InsertInboundShipment, Result<Invoice, InsertInboundShipmentError>>,
-) -> Result<MutationWithId<inbound_shipment::InsertResponse>> {
-    let response = match inbound_shipment::insert::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_insert_shipments(responses: InsertShipmentsResult) -> Result<InsertShipmentsResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response = match inbound_shipment::insert::map_response(response.result) {
+            Ok(response) => response,
+            Err(standard_error) => return Err(to_standard_error(response.input, standard_error)),
+        };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_update_shipment(
-    from: InputWithResult<UpdateInboundShipment, Result<Invoice, UpdateInboundShipmentError>>,
-) -> Result<MutationWithId<inbound_shipment::UpdateResponse>> {
-    let response = match inbound_shipment::update::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_update_shipments(responses: UpdateShipmentsResult) -> Result<UpdateShipmentsResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response = match inbound_shipment::update::map_response(response.result) {
+            Ok(response) => response,
+            Err(standard_error) => return Err(to_standard_error(response.input, standard_error)),
+        };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_delete_shipment(
-    from: InputWithResult<DeleteInboundShipment, Result<String, DeleteInboundShipmentError>>,
-) -> Result<MutationWithId<inbound_shipment::DeleteResponse>> {
-    let response = match inbound_shipment::delete::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_delete_shipments(responses: DeleteShipmentsResult) -> Result<DeleteShipmentsResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response = match inbound_shipment::delete::map_response(response.result) {
+            Ok(response) => response,
+            Err(standard_error) => return Err(to_standard_error(response.input, standard_error)),
+        };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_insert_line(
-    from: InputWithResult<
-        InsertInboundShipmentLine,
-        Result<InvoiceLine, InsertInboundShipmentLineError>,
-    >,
-) -> Result<MutationWithId<inbound_shipment_line::line::InsertResponse>> {
-    let response = match inbound_shipment_line::line::insert::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_insert_lines(responses: InsertShipmentLinesResult) -> Result<InsertShipmentLinesResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response =
+            match inbound_shipment_line::line::insert::map_response(response.result) {
+                Ok(response) => response,
+                Err(standard_error) => {
+                    return Err(to_standard_error(response.input, standard_error))
+                }
+            };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_update_line(
-    from: InputWithResult<
-        UpdateInboundShipmentLine,
-        Result<InvoiceLine, UpdateInboundShipmentLineError>,
-    >,
-) -> Result<MutationWithId<inbound_shipment_line::line::UpdateResponse>> {
-    let response = match inbound_shipment_line::line::update::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_update_lines(responses: UpdateShipmentLinesResult) -> Result<UpdateShipmentLinesResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response =
+            match inbound_shipment_line::line::update::map_response(response.result) {
+                Ok(response) => response,
+                Err(standard_error) => {
+                    return Err(to_standard_error(response.input, standard_error))
+                }
+            };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_delete_line(
-    from: InputWithResult<
-        DeleteInboundShipmentLine,
-        Result<String, DeleteInboundShipmentLineError>,
-    >,
-) -> Result<MutationWithId<inbound_shipment_line::line::DeleteResponse>> {
-    let response = match inbound_shipment_line::line::delete::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_delete_lines(responses: DeleteShipmentLinesResult) -> Result<DeleteShipmentLinesResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response =
+            match inbound_shipment_line::line::delete::map_response(response.result) {
+                Ok(response) => response,
+                Err(standard_error) => {
+                    return Err(to_standard_error(response.input, standard_error))
+                }
+            };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_insert_service_line(
-    from: InputWithResult<
-        InsertInboundShipmentServiceLine,
-        Result<InvoiceLine, InsertInboundShipmentServiceLineError>,
-    >,
-) -> Result<MutationWithId<inbound_shipment_line::service_line::InsertResponse>> {
-    let response = match inbound_shipment_line::service_line::insert::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_insert_service_lines(
+    responses: InsertShipmentServiceLinesResult,
+) -> Result<InsertShipmentServiceLinesResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response =
+            match inbound_shipment_line::service_line::insert::map_response(response.result) {
+                Ok(response) => response,
+                Err(standard_error) => {
+                    return Err(to_standard_error(response.input, standard_error))
+                }
+            };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_update_service_line(
-    from: InputWithResult<
-        UpdateInboundShipmentServiceLine,
-        Result<InvoiceLine, UpdateInboundShipmentServiceLineError>,
-    >,
-) -> Result<MutationWithId<inbound_shipment_line::service_line::UpdateResponse>> {
-    let response = match inbound_shipment_line::service_line::update::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_update_service_lines(
+    responses: UpdateShipmentServiceLinesResult,
+) -> Result<UpdateShipmentServiceLinesResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response =
+            match inbound_shipment_line::service_line::update::map_response(response.result) {
+                Ok(response) => response,
+                Err(standard_error) => {
+                    return Err(to_standard_error(response.input, standard_error))
+                }
+            };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_delete_service_line(
-    from: InputWithResult<
-        DeleteInboundShipmentLine,
-        Result<String, DeleteInboundShipmentServiceLineError>,
-    >,
-) -> Result<MutationWithId<inbound_shipment_line::service_line::DeleteResponse>> {
-    let response = match inbound_shipment_line::service_line::delete::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_delete_service_lines(
+    responses: DeleteShipmentServiceLinesResult,
+) -> Result<DeleteShipmentServiceLinesResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response =
+            match inbound_shipment_line::service_line::delete::map_response(response.result) {
+                Ok(response) => response,
+                Err(standard_error) => {
+                    return Err(to_standard_error(response.input, standard_error))
+                }
+            };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
 #[cfg(test)]

--- a/graphql/batch_mutations/src/batch_outbound_shipment.rs
+++ b/graphql/batch_mutations/src/batch_outbound_shipment.rs
@@ -3,38 +3,12 @@ use graphql_core::standard_graphql_error::validate_auth;
 use graphql_core::ContextExt;
 use graphql_invoice::mutations::outbound_shipment;
 use graphql_invoice_line::mutations::outbound_shipment_line;
-use repository::Invoice;
-use repository::InvoiceLine;
-use service::invoice::outbound_shipment::DeleteOutboundShipmentError;
-use service::invoice_line::outbound_shipment_line::InsertOutboundShipmentLine;
-use service::invoice_line::outbound_shipment_line::InsertOutboundShipmentLineError;
-use service::invoice_line::outbound_shipment_line::UpdateOutboundShipmentLine;
-use service::invoice_line::outbound_shipment_line::UpdateOutboundShipmentLineError;
-use service::invoice_line::outbound_shipment_service_line::DeleteOutboundShipmentServiceLineError;
-use service::invoice_line::outbound_shipment_service_line::InsertOutboundShipmentServiceLine;
-use service::invoice_line::outbound_shipment_service_line::InsertOutboundShipmentServiceLineError;
-use service::invoice_line::outbound_shipment_service_line::UpdateOutboundShipmentServiceLine;
-use service::invoice_line::outbound_shipment_service_line::UpdateOutboundShipmentServiceLineError;
-use service::invoice_line::outbound_shipment_unallocated_line::DeleteOutboundShipmentUnallocatedLine;
-use service::invoice_line::outbound_shipment_unallocated_line::DeleteOutboundShipmentUnallocatedLineError;
-use service::invoice_line::outbound_shipment_unallocated_line::InsertOutboundShipmentUnallocatedLine;
-use service::invoice_line::outbound_shipment_unallocated_line::InsertOutboundShipmentUnallocatedLineError;
-use service::invoice_line::outbound_shipment_unallocated_line::UpdateOutboundShipmentUnallocatedLine;
-use service::invoice_line::outbound_shipment_unallocated_line::UpdateOutboundShipmentUnallocatedLineError;
+use service::invoice::outbound_shipment::*;
+use service::invoice::outbound_shipment::{BatchOutboundShipment, BatchOutboundShipmentResult};
 use service::permission_validation::Resource;
 use service::permission_validation::ResourceAccessRequest;
-use service::InputWithResult;
-use service::{
-    invoice::outbound_shipment::{
-        BatchOutboundShipment, BatchOutboundShipmentResult, InsertOutboundShipment,
-        InsertOutboundShipmentError, UpdateOutboundShipment, UpdateOutboundShipmentError,
-    },
-    invoice_line::outbound_shipment_line::{
-        DeleteOutboundShipmentLine, DeleteOutboundShipmentLineError,
-    },
-};
 
-use crate::VecOrNone;
+use crate::{to_standard_error, VecOrNone};
 
 #[derive(SimpleObject)]
 #[graphql(concrete(
@@ -90,33 +64,51 @@ pub struct MutationWithId<T: OutputType> {
     pub response: T,
 }
 
+type ServiceInput = BatchOutboundShipment;
+type ServiceResult = BatchOutboundShipmentResult;
+
+type InsertShipmentsResponse = Option<Vec<MutationWithId<outbound_shipment::InsertResponse>>>;
+type InsertShipmentLinesResponse =
+    Option<Vec<MutationWithId<outbound_shipment_line::line::InsertResponse>>>;
+type UpdateShipmentLinesResponse =
+    Option<Vec<MutationWithId<outbound_shipment_line::line::UpdateResponse>>>;
+type DeleteShipmentLinesResponse =
+    Option<Vec<MutationWithId<outbound_shipment_line::line::DeleteResponse>>>;
+type InsertShipmentServiceLinesResponse =
+    Option<Vec<MutationWithId<outbound_shipment_line::service_line::InsertResponse>>>;
+type UpdateShipmentServiceLinesResponse =
+    Option<Vec<MutationWithId<outbound_shipment_line::service_line::UpdateResponse>>>;
+type DeleteShipmentServiceLinesResponse =
+    Option<Vec<MutationWithId<outbound_shipment_line::service_line::DeleteResponse>>>;
+type InsertShipmentUnallocatedLinesResponse =
+    Option<Vec<MutationWithId<outbound_shipment_line::unallocated_line::InsertResponse>>>;
+type UpdateShipmentUnallocatedLinesResponse =
+    Option<Vec<MutationWithId<outbound_shipment_line::unallocated_line::UpdateResponse>>>;
+type DeleteShipmentUnallocatedLinesResponse =
+    Option<Vec<MutationWithId<outbound_shipment_line::unallocated_line::DeleteResponse>>>;
+type UpdateShipmentsResponse = Option<Vec<MutationWithId<outbound_shipment::UpdateResponse>>>;
+type DeleteShipmentsResponse = Option<Vec<MutationWithId<outbound_shipment::DeleteResponse>>>;
+
 #[derive(SimpleObject)]
-pub struct BatchOutboundShipmentResponse {
-    insert_outbound_shipments: Option<Vec<MutationWithId<outbound_shipment::InsertResponse>>>,
-    insert_outbound_shipment_lines:
-        Option<Vec<MutationWithId<outbound_shipment_line::line::InsertResponse>>>,
-    update_outbound_shipment_lines:
-        Option<Vec<MutationWithId<outbound_shipment_line::line::UpdateResponse>>>,
-    delete_outbound_shipment_lines:
-        Option<Vec<MutationWithId<outbound_shipment_line::line::DeleteResponse>>>,
-    insert_outbound_shipment_service_lines:
-        Option<Vec<MutationWithId<outbound_shipment_line::service_line::InsertResponse>>>,
-    update_outbound_shipment_service_lines:
-        Option<Vec<MutationWithId<outbound_shipment_line::service_line::UpdateResponse>>>,
-    delete_outbound_shipment_service_lines:
-        Option<Vec<MutationWithId<outbound_shipment_line::service_line::DeleteResponse>>>,
-    insert_outbound_shipment_unallocated_lines:
-        Option<Vec<MutationWithId<outbound_shipment_line::unallocated_line::InsertResponse>>>,
-    update_outbound_shipment_unallocated_lines:
-        Option<Vec<MutationWithId<outbound_shipment_line::unallocated_line::UpdateResponse>>>,
-    delete_outbound_shipment_unallocated_lines:
-        Option<Vec<MutationWithId<outbound_shipment_line::unallocated_line::DeleteResponse>>>,
-    update_outbound_shipments: Option<Vec<MutationWithId<outbound_shipment::UpdateResponse>>>,
-    delete_outbound_shipments: Option<Vec<MutationWithId<outbound_shipment::DeleteResponse>>>,
+#[graphql(name = "BatchOutboundShipmentResponse")]
+pub struct BatchResponse {
+    insert_outbound_shipments: InsertShipmentsResponse,
+    insert_outbound_shipment_lines: InsertShipmentLinesResponse,
+    update_outbound_shipment_lines: UpdateShipmentLinesResponse,
+    delete_outbound_shipment_lines: DeleteShipmentLinesResponse,
+    insert_outbound_shipment_service_lines: InsertShipmentServiceLinesResponse,
+    update_outbound_shipment_service_lines: UpdateShipmentServiceLinesResponse,
+    delete_outbound_shipment_service_lines: DeleteShipmentServiceLinesResponse,
+    insert_outbound_shipment_unallocated_lines: InsertShipmentUnallocatedLinesResponse,
+    update_outbound_shipment_unallocated_lines: UpdateShipmentUnallocatedLinesResponse,
+    delete_outbound_shipment_unallocated_lines: DeleteShipmentUnallocatedLinesResponse,
+    update_outbound_shipments: UpdateShipmentsResponse,
+    delete_outbound_shipments: DeleteShipmentsResponse,
 }
 
 #[derive(InputObject)]
-pub struct BatchOutboundShipmentInput {
+#[graphql(name = "BatchOutboundShipmentInput")]
+pub struct BatchInput {
     pub insert_outbound_shipments: Option<Vec<outbound_shipment::InsertInput>>,
     pub insert_outbound_shipment_lines: Option<Vec<outbound_shipment_line::line::InsertInput>>,
     pub update_outbound_shipment_lines: Option<Vec<outbound_shipment_line::line::UpdateInput>>,
@@ -138,11 +130,7 @@ pub struct BatchOutboundShipmentInput {
     pub continue_on_error: Option<bool>,
 }
 
-pub fn batch_outbound_shipment(
-    ctx: &Context<'_>,
-    store_id: &str,
-    input: BatchOutboundShipmentInput,
-) -> Result<BatchOutboundShipmentResponse> {
+pub fn batch(ctx: &Context<'_>, store_id: &str, input: BatchInput) -> Result<BatchResponse> {
     let user = validate_auth(
         ctx,
         &ResourceAccessRequest {
@@ -161,12 +149,12 @@ pub fn batch_outbound_shipment(
         input.to_domain(),
     )?;
 
-    Ok(BatchOutboundShipmentResponse::from_domain(response)?)
+    Ok(BatchResponse::from_domain(response)?)
 }
 
-impl BatchOutboundShipmentInput {
-    fn to_domain(self) -> BatchOutboundShipment {
-        let BatchOutboundShipmentInput {
+impl BatchInput {
+    fn to_domain(self) -> ServiceInput {
+        let BatchInput {
             insert_outbound_shipments,
             insert_outbound_shipment_lines,
             update_outbound_shipment_lines,
@@ -182,7 +170,7 @@ impl BatchOutboundShipmentInput {
             delete_outbound_shipment_unallocated_lines,
         } = self;
 
-        BatchOutboundShipment {
+        ServiceInput {
             insert_shipment: insert_outbound_shipments
                 .map(|inputs| inputs.into_iter().map(|input| input.to_domain()).collect()),
             insert_line: insert_outbound_shipment_lines
@@ -212,9 +200,9 @@ impl BatchOutboundShipmentInput {
     }
 }
 
-impl BatchOutboundShipmentResponse {
+impl BatchResponse {
     fn from_domain(
-        BatchOutboundShipmentResult {
+        ServiceResult {
             insert_shipment,
             insert_line,
             update_line,
@@ -227,353 +215,262 @@ impl BatchOutboundShipmentResponse {
             insert_unallocated_line,
             update_unallocated_line,
             delete_unallocated_line,
-        }: BatchOutboundShipmentResult,
-    ) -> Result<BatchOutboundShipmentResponse> {
-        // Insert Shipment
-
-        let insert_outbound_shipments_result: Result<
-            Vec<MutationWithId<outbound_shipment::InsertResponse>>,
-        > = insert_shipment
-            .into_iter()
-            .map(map_insert_shipment)
-            .collect();
-
-        // Normal Line
-
-        let insert_outbound_shipment_lines_result: Result<
-            Vec<MutationWithId<outbound_shipment_line::line::InsertResponse>>,
-        > = insert_line.into_iter().map(map_insert_line).collect();
-
-        let update_outbound_shipment_lines_result: Result<
-            Vec<MutationWithId<outbound_shipment_line::line::UpdateResponse>>,
-        > = update_line.into_iter().map(map_update_line).collect();
-
-        let delete_outbound_shipment_lines_result: Result<
-            Vec<MutationWithId<outbound_shipment_line::line::DeleteResponse>>,
-        > = delete_line.into_iter().map(map_delete_line).collect();
-
-        // Service Line
-
-        let insert_outbound_shipment_service_lines_result: Result<
-            Vec<MutationWithId<outbound_shipment_line::service_line::InsertResponse>>,
-        > = insert_service_line
-            .into_iter()
-            .map(map_insert_service_line)
-            .collect();
-
-        let update_outbound_shipment_service_lines_result: Result<
-            Vec<MutationWithId<outbound_shipment_line::service_line::UpdateResponse>>,
-        > = update_service_line
-            .into_iter()
-            .map(map_update_service_line)
-            .collect();
-
-        let delete_outbound_shipment_service_lines_result: Result<
-            Vec<MutationWithId<outbound_shipment_line::service_line::DeleteResponse>>,
-        > = delete_service_line
-            .into_iter()
-            .map(map_delete_service_line)
-            .collect();
-
-        // Unallocated Line
-
-        let insert_outbound_shipment_unallocated_lines_result: Result<
-            Vec<MutationWithId<outbound_shipment_line::unallocated_line::InsertResponse>>,
-        > = insert_unallocated_line
-            .into_iter()
-            .map(map_insert_unallocated_line)
-            .collect();
-
-        let update_outbound_shipment_unallocated_lines_result: Result<
-            Vec<MutationWithId<outbound_shipment_line::unallocated_line::UpdateResponse>>,
-        > = update_unallocated_line
-            .into_iter()
-            .map(map_update_unallocated_line)
-            .collect();
-
-        let delete_outbound_shipment_unallocated_lines_result: Result<
-            Vec<MutationWithId<outbound_shipment_line::unallocated_line::DeleteResponse>>,
-        > = delete_unallocated_line
-            .into_iter()
-            .map(map_delete_unallocated_line)
-            .collect();
-
-        // Update delete shipment
-
-        let update_outbound_shipments_result: Result<
-            Vec<MutationWithId<outbound_shipment::UpdateResponse>>,
-        > = update_shipment
-            .into_iter()
-            .map(map_update_shipment)
-            .collect();
-
-        let delete_outbound_shipments_result: Result<
-            Vec<MutationWithId<outbound_shipment::DeleteResponse>>,
-        > = delete_shipment
-            .into_iter()
-            .map(map_delete_shipment)
-            .collect();
-
-        let result = BatchOutboundShipmentResponse {
-            insert_outbound_shipments: insert_outbound_shipments_result?.vec_or_none(),
-            insert_outbound_shipment_lines: insert_outbound_shipment_lines_result?.vec_or_none(),
-            update_outbound_shipment_lines: update_outbound_shipment_lines_result?.vec_or_none(),
-            delete_outbound_shipment_lines: delete_outbound_shipment_lines_result?.vec_or_none(),
-
-            insert_outbound_shipment_service_lines: insert_outbound_shipment_service_lines_result?
-                .vec_or_none(),
-            update_outbound_shipment_service_lines: update_outbound_shipment_service_lines_result?
-                .vec_or_none(),
-            delete_outbound_shipment_service_lines: delete_outbound_shipment_service_lines_result?
-                .vec_or_none(),
-
-            insert_outbound_shipment_unallocated_lines:
-                insert_outbound_shipment_unallocated_lines_result?.vec_or_none(),
-            update_outbound_shipment_unallocated_lines:
-                update_outbound_shipment_unallocated_lines_result?.vec_or_none(),
-            delete_outbound_shipment_unallocated_lines:
-                delete_outbound_shipment_unallocated_lines_result?.vec_or_none(),
-
-            update_outbound_shipments: update_outbound_shipments_result?.vec_or_none(),
-            delete_outbound_shipments: delete_outbound_shipments_result?.vec_or_none(),
+        }: ServiceResult,
+    ) -> Result<BatchResponse> {
+        let result = BatchResponse {
+            insert_outbound_shipments: map_insert_shipments(insert_shipment)?,
+            insert_outbound_shipment_lines: map_insert_lines(insert_line)?,
+            update_outbound_shipment_lines: map_update_lines(update_line)?,
+            delete_outbound_shipment_lines: map_delete_lines(delete_line)?,
+            insert_outbound_shipment_service_lines: map_insert_service_lines(insert_service_line)?,
+            update_outbound_shipment_service_lines: map_update_service_lines(update_service_line)?,
+            delete_outbound_shipment_service_lines: map_delete_service_lines(delete_service_line)?,
+            insert_outbound_shipment_unallocated_lines: map_insert_unallocated_lines(
+                insert_unallocated_line,
+            )?,
+            update_outbound_shipment_unallocated_lines: map_update_unallocated_lines(
+                update_unallocated_line,
+            )?,
+            delete_outbound_shipment_unallocated_lines: map_delete_unallocated_lines(
+                delete_unallocated_line,
+            )?,
+            update_outbound_shipments: map_update_shipments(update_shipment)?,
+            delete_outbound_shipments: map_delete_shipments(delete_shipment)?,
         };
 
         Ok(result)
     }
 }
 
-fn map_insert_shipment(
-    from: InputWithResult<InsertOutboundShipment, Result<Invoice, InsertOutboundShipmentError>>,
-) -> Result<MutationWithId<outbound_shipment::InsertResponse>> {
-    let response = match outbound_shipment::insert::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_insert_shipments(responses: InsertShipmentsResult) -> Result<InsertShipmentsResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response = match outbound_shipment::insert::map_response(response.result) {
+            Ok(response) => response,
+            Err(standard_error) => return Err(to_standard_error(response.input, standard_error)),
+        };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_update_shipment(
-    from: InputWithResult<UpdateOutboundShipment, Result<Invoice, UpdateOutboundShipmentError>>,
-) -> Result<MutationWithId<outbound_shipment::UpdateResponse>> {
-    let response = match outbound_shipment::update::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_update_shipments(responses: UpdateShipmentsResult) -> Result<UpdateShipmentsResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response = match outbound_shipment::update::map_response(response.result) {
+            Ok(response) => response,
+            Err(standard_error) => return Err(to_standard_error(response.input, standard_error)),
+        };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_delete_shipment(
-    from: InputWithResult<String, Result<String, DeleteOutboundShipmentError>>,
-) -> Result<MutationWithId<outbound_shipment::DeleteResponse>> {
-    let response = match outbound_shipment::delete::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_delete_shipments(responses: DeleteShipmentsResult) -> Result<DeleteShipmentsResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response = match outbound_shipment::delete::map_response(response.result) {
+            Ok(response) => response,
+            Err(standard_error) => return Err(to_standard_error(response.input, standard_error)),
+        };
+        result.push(MutationWithId {
+            id: response.input.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input,
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_insert_line(
-    from: InputWithResult<
-        InsertOutboundShipmentLine,
-        Result<InvoiceLine, InsertOutboundShipmentLineError>,
-    >,
-) -> Result<MutationWithId<outbound_shipment_line::line::InsertResponse>> {
-    let response = match outbound_shipment_line::line::insert::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_insert_lines(responses: InsertShipmentLinesResult) -> Result<InsertShipmentLinesResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response =
+            match outbound_shipment_line::line::insert::map_response(response.result) {
+                Ok(response) => response,
+                Err(standard_error) => {
+                    return Err(to_standard_error(response.input, standard_error))
+                }
+            };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_update_line(
-    from: InputWithResult<
-        UpdateOutboundShipmentLine,
-        Result<InvoiceLine, UpdateOutboundShipmentLineError>,
-    >,
-) -> Result<MutationWithId<outbound_shipment_line::line::UpdateResponse>> {
-    let response = match outbound_shipment_line::line::update::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_update_lines(responses: UpdateShipmentLinesResult) -> Result<UpdateShipmentLinesResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response =
+            match outbound_shipment_line::line::update::map_response(response.result) {
+                Ok(response) => response,
+                Err(standard_error) => {
+                    return Err(to_standard_error(response.input, standard_error))
+                }
+            };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_delete_line(
-    from: InputWithResult<
-        DeleteOutboundShipmentLine,
-        Result<String, DeleteOutboundShipmentLineError>,
-    >,
-) -> Result<MutationWithId<outbound_shipment_line::line::DeleteResponse>> {
-    let response = match outbound_shipment_line::line::delete::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_delete_lines(responses: DeleteShipmentLinesResult) -> Result<DeleteShipmentLinesResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response =
+            match outbound_shipment_line::line::delete::map_response(response.result) {
+                Ok(response) => response,
+                Err(standard_error) => {
+                    return Err(to_standard_error(response.input, standard_error))
+                }
+            };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_insert_service_line(
-    from: InputWithResult<
-        InsertOutboundShipmentServiceLine,
-        Result<InvoiceLine, InsertOutboundShipmentServiceLineError>,
-    >,
-) -> Result<MutationWithId<outbound_shipment_line::service_line::InsertResponse>> {
-    let response = match outbound_shipment_line::service_line::insert::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_insert_service_lines(
+    responses: InsertShipmentServiceLinesResult,
+) -> Result<InsertShipmentServiceLinesResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response =
+            match outbound_shipment_line::service_line::insert::map_response(response.result) {
+                Ok(response) => response,
+                Err(standard_error) => {
+                    return Err(to_standard_error(response.input, standard_error))
+                }
+            };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_update_service_line(
-    from: InputWithResult<
-        UpdateOutboundShipmentServiceLine,
-        Result<InvoiceLine, UpdateOutboundShipmentServiceLineError>,
-    >,
-) -> Result<MutationWithId<outbound_shipment_line::service_line::UpdateResponse>> {
-    let response = match outbound_shipment_line::service_line::update::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_update_service_lines(
+    responses: UpdateShipmentServiceLinesResult,
+) -> Result<UpdateShipmentServiceLinesResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response =
+            match outbound_shipment_line::service_line::update::map_response(response.result) {
+                Ok(response) => response,
+                Err(standard_error) => {
+                    return Err(to_standard_error(response.input, standard_error))
+                }
+            };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_delete_service_line(
-    from: InputWithResult<
-        DeleteOutboundShipmentLine,
-        Result<String, DeleteOutboundShipmentServiceLineError>,
-    >,
-) -> Result<MutationWithId<outbound_shipment_line::service_line::DeleteResponse>> {
-    let response = match outbound_shipment_line::service_line::delete::map_response(from.result) {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_delete_service_lines(
+    responses: DeleteShipmentServiceLinesResult,
+) -> Result<DeleteShipmentServiceLinesResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response =
+            match outbound_shipment_line::service_line::delete::map_response(response.result) {
+                Ok(response) => response,
+                Err(standard_error) => {
+                    return Err(to_standard_error(response.input, standard_error))
+                }
+            };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_insert_unallocated_line(
-    from: InputWithResult<
-        InsertOutboundShipmentUnallocatedLine,
-        Result<InvoiceLine, InsertOutboundShipmentUnallocatedLineError>,
-    >,
-) -> Result<MutationWithId<outbound_shipment_line::unallocated_line::InsertResponse>> {
-    let response = match outbound_shipment_line::unallocated_line::insert::map_response(from.result)
-    {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_insert_unallocated_lines(
+    responses: InsertShipmentUnallocatedLinesResult,
+) -> Result<InsertShipmentUnallocatedLinesResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response =
+            match outbound_shipment_line::unallocated_line::insert::map_response(response.result) {
+                Ok(response) => response,
+                Err(standard_error) => {
+                    return Err(to_standard_error(response.input, standard_error))
+                }
+            };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_update_unallocated_line(
-    from: InputWithResult<
-        UpdateOutboundShipmentUnallocatedLine,
-        Result<InvoiceLine, UpdateOutboundShipmentUnallocatedLineError>,
-    >,
-) -> Result<MutationWithId<outbound_shipment_line::unallocated_line::UpdateResponse>> {
-    let response = match outbound_shipment_line::unallocated_line::update::map_response(from.result)
-    {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_update_unallocated_lines(
+    responses: UpdateShipmentUnallocatedLinesResult,
+) -> Result<UpdateShipmentUnallocatedLinesResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response =
+            match outbound_shipment_line::unallocated_line::update::map_response(response.result) {
+                Ok(response) => response,
+                Err(standard_error) => {
+                    return Err(to_standard_error(response.input, standard_error))
+                }
+            };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
-fn map_delete_unallocated_line(
-    from: InputWithResult<
-        DeleteOutboundShipmentUnallocatedLine,
-        Result<String, DeleteOutboundShipmentUnallocatedLineError>,
-    >,
-) -> Result<MutationWithId<outbound_shipment_line::unallocated_line::DeleteResponse>> {
-    let response = match outbound_shipment_line::unallocated_line::delete::map_response(from.result)
-    {
-        Ok(response) => response,
-        Err(standard_error) => {
-            let input_string = format!("{:#?}", from.input);
-            return Err(standard_error.extend_with(|_, e| e.set("input", input_string)));
-        }
-    };
+fn map_delete_unallocated_lines(
+    responses: DeleteShipmentUnallocatedLinesResult,
+) -> Result<DeleteShipmentUnallocatedLinesResponse> {
+    let mut result = Vec::new();
+    for response in responses {
+        let mapped_response =
+            match outbound_shipment_line::unallocated_line::delete::map_response(response.result) {
+                Ok(response) => response,
+                Err(standard_error) => {
+                    return Err(to_standard_error(response.input, standard_error))
+                }
+            };
+        result.push(MutationWithId {
+            id: response.input.id.clone(),
+            response: mapped_response,
+        });
+    }
 
-    Ok(MutationWithId {
-        id: from.input.id.clone(),
-        response,
-    })
+    Ok(result.vec_or_none())
 }
 
 #[cfg(test)]

--- a/graphql/batch_mutations/src/batch_request_requisition.rs
+++ b/graphql/batch_mutations/src/batch_request_requisition.rs
@@ -7,7 +7,7 @@ use service::{
     requisition::request_requisition::*,
 };
 
-use crate::VecOrNone;
+use crate::{to_standard_error, VecOrNone};
 
 type ServiceResult = BatchRequestRequisitionResult;
 type ServiceInput = BatchRequestRequisition;
@@ -146,14 +146,6 @@ impl BatchResponse {
 
         Ok(result)
     }
-}
-
-fn to_standard_error<I>(input: I, error: Error) -> Error
-where
-    I: std::fmt::Debug,
-{
-    let input_string = format!("{:#?}", input);
-    error.extend_with(|_, e| e.set("input", input_string))
 }
 
 fn map_insert_requisitions(

--- a/graphql/batch_mutations/src/batch_stocktake.rs
+++ b/graphql/batch_mutations/src/batch_stocktake.rs
@@ -7,7 +7,7 @@ use service::{
     stocktake::*,
 };
 
-use crate::VecOrNone;
+use crate::{VecOrNone, to_standard_error};
 
 type ServiceResult = BatchStocktakeResult;
 type ServiceInput = BatchStocktake;
@@ -146,14 +146,6 @@ impl BatchResponse {
 
         Ok(result)
     }
-}
-
-fn to_standard_error<I>(input: I, error: Error) -> Error
-where
-    I: std::fmt::Debug,
-{
-    let input_string = format!("{:#?}", input);
-    error.extend_with(|_, e| e.set("input", input_string))
 }
 
 fn map_insert_stocktakes(responses: InsertStocktakesResult) -> Result<InsertStocktakesResponse> {

--- a/graphql/batch_mutations/src/lib.rs
+++ b/graphql/batch_mutations/src/lib.rs
@@ -3,12 +3,6 @@ mod batch_outbound_shipment;
 mod batch_request_requisition;
 mod batch_stocktake;
 use async_graphql::*;
-use batch_inbound_shipment::{
-    batch_inbound_shipment, BatchInboundShipmentInput, BatchInboundShipmentResponse,
-};
-use batch_outbound_shipment::{
-    batch_outbound_shipment, BatchOutboundShipmentInput, BatchOutboundShipmentResponse,
-};
 
 #[derive(Default, Clone)]
 pub struct BatchMutations;
@@ -19,18 +13,18 @@ impl BatchMutations {
         &self,
         ctx: &Context<'_>,
         store_id: String,
-        input: BatchInboundShipmentInput,
-    ) -> Result<BatchInboundShipmentResponse> {
-        batch_inbound_shipment(ctx, &store_id, input)
+        input: batch_inbound_shipment::BatchInput,
+    ) -> Result<batch_inbound_shipment::BatchResponse> {
+        batch_inbound_shipment::batch(ctx, &store_id, input)
     }
 
     async fn batch_outbound_shipment(
         &self,
         ctx: &Context<'_>,
         store_id: String,
-        input: BatchOutboundShipmentInput,
-    ) -> Result<BatchOutboundShipmentResponse> {
-        batch_outbound_shipment(ctx, &store_id, input)
+        input: batch_outbound_shipment::BatchInput,
+    ) -> Result<batch_outbound_shipment::BatchResponse> {
+        batch_outbound_shipment::batch(ctx, &store_id, input)
     }
 
     async fn batch_request_requisition(
@@ -64,4 +58,12 @@ impl<T> VecOrNone<T> for Vec<T> {
             Some(self)
         }
     }
+}
+
+fn to_standard_error<I>(input: I, error: Error) -> Error
+where
+    I: std::fmt::Debug,
+{
+    let input_string = format!("{:#?}", input);
+    error.extend_with(|_, e| e.set("input", input_string))
 }

--- a/service/src/invoice/inbound_shipment/batch.rs
+++ b/service/src/invoice/inbound_shipment/batch.rs
@@ -40,47 +40,50 @@ pub struct BatchInboundShipment {
     pub continue_on_error: Option<bool>,
 }
 
+pub type InsertShipmentsResult =
+    Vec<InputWithResult<InsertInboundShipment, Result<Invoice, InsertInboundShipmentError>>>;
+pub type InsertShipmentLinesResult = Vec<
+    InputWithResult<InsertInboundShipmentLine, Result<InvoiceLine, InsertInboundShipmentLineError>>,
+>;
+pub type UpdateShipmentLinesResult = Vec<
+    InputWithResult<UpdateInboundShipmentLine, Result<InvoiceLine, UpdateInboundShipmentLineError>>,
+>;
+pub type DeleteShipmentLinesResult =
+    Vec<InputWithResult<DeleteInboundShipmentLine, Result<String, DeleteInboundShipmentLineError>>>;
+pub type InsertShipmentServiceLinesResult = Vec<
+    InputWithResult<
+        InsertInboundShipmentServiceLine,
+        Result<InvoiceLine, InsertInboundShipmentServiceLineError>,
+    >,
+>;
+pub type UpdateShipmentServiceLinesResult = Vec<
+    InputWithResult<
+        UpdateInboundShipmentServiceLine,
+        Result<InvoiceLine, UpdateInboundShipmentServiceLineError>,
+    >,
+>;
+pub type DeleteShipmentServiceLinesResult = Vec<
+    InputWithResult<
+        DeleteInboundShipmentLine,
+        Result<String, DeleteInboundShipmentServiceLineError>,
+    >,
+>;
+pub type UpdateShipmentsResult =
+    Vec<InputWithResult<UpdateInboundShipment, Result<Invoice, UpdateInboundShipmentError>>>;
+pub type DeleteShipmentsResult =
+    Vec<InputWithResult<DeleteInboundShipment, Result<String, DeleteInboundShipmentError>>>;
+
 #[derive(Debug, Default)]
 pub struct BatchInboundShipmentResult {
-    pub insert_shipment:
-        Vec<InputWithResult<InsertInboundShipment, Result<Invoice, InsertInboundShipmentError>>>,
-    pub insert_line: Vec<
-        InputWithResult<
-            InsertInboundShipmentLine,
-            Result<InvoiceLine, InsertInboundShipmentLineError>,
-        >,
-    >,
-    pub update_line: Vec<
-        InputWithResult<
-            UpdateInboundShipmentLine,
-            Result<InvoiceLine, UpdateInboundShipmentLineError>,
-        >,
-    >,
-    pub delete_line: Vec<
-        InputWithResult<DeleteInboundShipmentLine, Result<String, DeleteInboundShipmentLineError>>,
-    >,
-    pub insert_service_line: Vec<
-        InputWithResult<
-            InsertInboundShipmentServiceLine,
-            Result<InvoiceLine, InsertInboundShipmentServiceLineError>,
-        >,
-    >,
-    pub update_service_line: Vec<
-        InputWithResult<
-            UpdateInboundShipmentServiceLine,
-            Result<InvoiceLine, UpdateInboundShipmentServiceLineError>,
-        >,
-    >,
-    pub delete_service_line: Vec<
-        InputWithResult<
-            DeleteInboundShipmentLine,
-            Result<String, DeleteInboundShipmentServiceLineError>,
-        >,
-    >,
-    pub update_shipment:
-        Vec<InputWithResult<UpdateInboundShipment, Result<Invoice, UpdateInboundShipmentError>>>,
-    pub delete_shipment:
-        Vec<InputWithResult<DeleteInboundShipment, Result<String, DeleteInboundShipmentError>>>,
+    pub insert_shipment: InsertShipmentsResult,
+    pub insert_line: InsertShipmentLinesResult,
+    pub update_line: UpdateShipmentLinesResult,
+    pub delete_line: DeleteShipmentLinesResult,
+    pub insert_service_line: InsertShipmentServiceLinesResult,
+    pub update_service_line: UpdateShipmentServiceLinesResult,
+    pub delete_service_line: DeleteShipmentServiceLinesResult,
+    pub update_shipment: UpdateShipmentsResult,
+    pub delete_shipment: DeleteShipmentsResult,
 }
 
 pub fn batch_inbound_shipment(

--- a/service/src/invoice/outbound_shipment/batch.rs
+++ b/service/src/invoice/outbound_shipment/batch.rs
@@ -50,67 +50,78 @@ pub struct BatchOutboundShipment {
     pub continue_on_error: Option<bool>,
 }
 
+pub type InsertShipmentsResult =
+    Vec<InputWithResult<InsertOutboundShipment, Result<Invoice, InsertOutboundShipmentError>>>;
+pub type InsertShipmentLinesResult = Vec<
+    InputWithResult<
+        InsertOutboundShipmentLine,
+        Result<InvoiceLine, InsertOutboundShipmentLineError>,
+    >,
+>;
+pub type UpdateShipmentLinesResult = Vec<
+    InputWithResult<
+        UpdateOutboundShipmentLine,
+        Result<InvoiceLine, UpdateOutboundShipmentLineError>,
+    >,
+>;
+pub type DeleteShipmentLinesResult = Vec<
+    InputWithResult<DeleteOutboundShipmentLine, Result<String, DeleteOutboundShipmentLineError>>,
+>;
+pub type InsertShipmentServiceLinesResult = Vec<
+    InputWithResult<
+        InsertOutboundShipmentServiceLine,
+        Result<InvoiceLine, InsertOutboundShipmentServiceLineError>,
+    >,
+>;
+pub type UpdateShipmentServiceLinesResult = Vec<
+    InputWithResult<
+        UpdateOutboundShipmentServiceLine,
+        Result<InvoiceLine, UpdateOutboundShipmentServiceLineError>,
+    >,
+>;
+pub type DeleteShipmentServiceLinesResult = Vec<
+    InputWithResult<
+        DeleteOutboundShipmentLine,
+        Result<String, DeleteOutboundShipmentServiceLineError>,
+    >,
+>;
+pub type InsertShipmentUnallocatedLinesResult = Vec<
+    InputWithResult<
+        InsertOutboundShipmentUnallocatedLine,
+        Result<InvoiceLine, InsertOutboundShipmentUnallocatedLineError>,
+    >,
+>;
+pub type UpdateShipmentUnallocatedLinesResult = Vec<
+    InputWithResult<
+        UpdateOutboundShipmentUnallocatedLine,
+        Result<InvoiceLine, UpdateOutboundShipmentUnallocatedLineError>,
+    >,
+>;
+pub type DeleteShipmentUnallocatedLinesResult = Vec<
+    InputWithResult<
+        DeleteOutboundShipmentUnallocatedLine,
+        Result<String, DeleteOutboundShipmentUnallocatedLineError>,
+    >,
+>;
+pub type UpdateShipmentsResult =
+    Vec<InputWithResult<UpdateOutboundShipment, Result<Invoice, UpdateOutboundShipmentError>>>;
+pub type DeleteShipmentsResult =
+    Vec<InputWithResult<String, Result<String, DeleteOutboundShipmentError>>>;
+
 #[derive(Debug, Default)]
 pub struct BatchOutboundShipmentResult {
-    pub insert_shipment:
-        Vec<InputWithResult<InsertOutboundShipment, Result<Invoice, InsertOutboundShipmentError>>>,
-    pub insert_line: Vec<
-        InputWithResult<
-            InsertOutboundShipmentLine,
-            Result<InvoiceLine, InsertOutboundShipmentLineError>,
-        >,
-    >,
-    pub update_line: Vec<
-        InputWithResult<
-            UpdateOutboundShipmentLine,
-            Result<InvoiceLine, UpdateOutboundShipmentLineError>,
-        >,
-    >,
-    pub delete_line: Vec<
-        InputWithResult<
-            DeleteOutboundShipmentLine,
-            Result<String, DeleteOutboundShipmentLineError>,
-        >,
-    >,
-    pub insert_service_line: Vec<
-        InputWithResult<
-            InsertOutboundShipmentServiceLine,
-            Result<InvoiceLine, InsertOutboundShipmentServiceLineError>,
-        >,
-    >,
-    pub update_service_line: Vec<
-        InputWithResult<
-            UpdateOutboundShipmentServiceLine,
-            Result<InvoiceLine, UpdateOutboundShipmentServiceLineError>,
-        >,
-    >,
-    pub delete_service_line: Vec<
-        InputWithResult<
-            DeleteOutboundShipmentLine,
-            Result<String, DeleteOutboundShipmentServiceLineError>,
-        >,
-    >,
-    pub insert_unallocated_line: Vec<
-        InputWithResult<
-            InsertOutboundShipmentUnallocatedLine,
-            Result<InvoiceLine, InsertOutboundShipmentUnallocatedLineError>,
-        >,
-    >,
-    pub update_unallocated_line: Vec<
-        InputWithResult<
-            UpdateOutboundShipmentUnallocatedLine,
-            Result<InvoiceLine, UpdateOutboundShipmentUnallocatedLineError>,
-        >,
-    >,
-    pub delete_unallocated_line: Vec<
-        InputWithResult<
-            DeleteOutboundShipmentUnallocatedLine,
-            Result<String, DeleteOutboundShipmentUnallocatedLineError>,
-        >,
-    >,
-    pub update_shipment:
-        Vec<InputWithResult<UpdateOutboundShipment, Result<Invoice, UpdateOutboundShipmentError>>>,
-    pub delete_shipment: Vec<InputWithResult<String, Result<String, DeleteOutboundShipmentError>>>,
+    pub insert_shipment: InsertShipmentsResult,
+    pub insert_line: InsertShipmentLinesResult,
+    pub update_line: UpdateShipmentLinesResult,
+    pub delete_line: DeleteShipmentLinesResult,
+    pub insert_service_line: InsertShipmentServiceLinesResult,
+    pub update_service_line: UpdateShipmentServiceLinesResult,
+    pub delete_service_line: DeleteShipmentServiceLinesResult,
+    pub insert_unallocated_line: InsertShipmentUnallocatedLinesResult,
+    pub update_unallocated_line: UpdateShipmentUnallocatedLinesResult,
+    pub delete_unallocated_line: DeleteShipmentUnallocatedLinesResult,
+    pub update_shipment: UpdateShipmentsResult,
+    pub delete_shipment: DeleteShipmentsResult,
 }
 
 pub fn batch_outbound_shipment(


### PR DESCRIPTION
Fixes buletpoint 1 in #951 

Wanted to do this before adding new mutation to batch outbound shipment, to simplify future tasks of adding to batch mutations (and to simplify batch mutations)