### PR TITLE
Add basic mock fields for item and name

### DIFF
--- a/graphql/types/src/types/item.rs
+++ b/graphql/types/src/types/item.rs
@@ -97,6 +97,60 @@ impl ItemNode {
             result_option.unwrap_or(vec![]),
         ))
     }
+
+    // Mock
+
+    pub async fn msupply_universal_code(&self) -> &str {
+        "368154bf"
+    }
+
+    pub async fn msupply_universal_name(&self) -> &str {
+        "Amoxicilin"
+    }
+
+    pub async fn doses(&self) -> u32 {
+        0
+    }
+
+    pub async fn is_vaccine(&self) -> bool {
+        false
+    }
+
+    pub async fn default_pack_size(&self) -> u32 {
+        1
+    }
+
+    pub async fn outer_pack_size(&self) -> u32 {
+        10
+    }
+
+    pub async fn volume_per_outer_pack(&self) -> u32 {
+        5
+    }
+
+    pub async fn volume_per_pack(&self) -> f64 {
+        0.5
+    }
+
+    pub async fn margin(&self) -> f64 {
+        0.1
+    }
+
+    pub async fn weight(&self) -> f64 {
+        0.2
+    }
+
+    pub async fn strength(&self) -> &str {
+        "0.01mg"
+    }
+
+    pub async fn atc_category(&self) -> &str {
+        "J01CA04"
+    }
+
+    pub async fn ddd(&self) -> f64 {
+        1.5
+    }
 }
 
 #[derive(Union)]

--- a/graphql/types/src/types/name.rs
+++ b/graphql/types/src/types/name.rs
@@ -1,4 +1,5 @@
 use async_graphql::*;
+use chrono::{NaiveDate, Utc};
 use dataloader::DataLoader;
 use repository::{schema::NameRow, Name};
 
@@ -47,6 +48,52 @@ impl NameNode {
             .load_one(store_id.to_string())
             .await?
             .map(StoreNode::from_domain))
+    }
+
+    // Mock
+
+    pub async fn phone(&self) -> &str {
+        "+64 932184910"
+    }
+
+    pub async fn charge_code(&self) -> &str {
+        &self.row().code
+    }
+
+    pub async fn comment(&self) -> &str {
+        "For billing contact Sam"
+    }
+
+    pub async fn country(&self) -> &str {
+        "UK"
+    }
+
+    pub async fn address(&self) -> &str {
+        "10 Downing Street"
+    }
+
+    pub async fn email(&self) -> &str {
+        "mock@moc.ki.ng"
+    }
+
+    pub async fn website(&self) -> &str {
+        "https://moc.ki.ng"
+    }
+
+    pub async fn is_manufacturer(&self) -> bool {
+        true
+    }
+
+    pub async fn is_donor(&self) -> bool {
+        false
+    }
+
+    pub async fn created_date(&self) -> Option<NaiveDate> {
+        Some(NaiveDate::from_ymd(2010, 02, 28))
+    }
+
+    pub async fn is_on_hold(&self) -> bool {
+        false
     }
 }
 


### PR DESCRIPTION
links to #595 and #513

I didn't give too much though to field types and their storage (just looked at basic mSupply fields), so it's possible they will change when we actually implement (i.e. some maybe optional, address will probably be address node, etc..)