### PR TITLE
987 store sync site

### DIFF
--- a/graphql/general/src/queries/store.rs
+++ b/graphql/general/src/queries/store.rs
@@ -14,7 +14,7 @@ pub struct StoreFilterInput {
     pub code: Option<SimpleStringFilterInput>,
     pub name: Option<SimpleStringFilterInput>,
     pub name_code: Option<SimpleStringFilterInput>,
-    pub remote_site_id: Option<EqualFilterInput<i32>>,
+    pub site_id: Option<EqualFilterInput<i32>>,
 }
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
@@ -87,7 +87,7 @@ impl StoreFilterInput {
             code,
             name,
             name_code,
-            remote_site_id,
+            site_id,
         } = self;
 
         StoreFilter {
@@ -95,7 +95,7 @@ impl StoreFilterInput {
             code: code.map(SimpleStringFilter::from),
             name: name.map(SimpleStringFilter::from),
             name_code: name_code.map(SimpleStringFilter::from),
-            remote_site_id: remote_site_id.map(EqualFilter::from),
+            site_id: site_id.map(EqualFilter::from),
         }
     }
 }

--- a/graphql/general/src/queries/store.rs
+++ b/graphql/general/src/queries/store.rs
@@ -1,5 +1,5 @@
 use async_graphql::*;
-use graphql_core::generic_filters::EqualFilterStringInput;
+use graphql_core::generic_filters::{EqualFilterInput, EqualFilterStringInput};
 use graphql_core::{
     generic_filters::SimpleStringFilterInput, pagination::PaginationInput,
     standard_graphql_error::list_error_to_gql_err, ContextExt,
@@ -14,6 +14,7 @@ pub struct StoreFilterInput {
     pub code: Option<SimpleStringFilterInput>,
     pub name: Option<SimpleStringFilterInput>,
     pub name_code: Option<SimpleStringFilterInput>,
+    pub remote_site_id: Option<EqualFilterInput<i32>>,
 }
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
@@ -86,6 +87,7 @@ impl StoreFilterInput {
             code,
             name,
             name_code,
+            remote_site_id,
         } = self;
 
         StoreFilter {
@@ -93,6 +95,7 @@ impl StoreFilterInput {
             code: code.map(SimpleStringFilter::from),
             name: name.map(SimpleStringFilter::from),
             name_code: name_code.map(SimpleStringFilter::from),
+            remote_site_id: remote_site_id.map(EqualFilter::from),
         }
     }
 }

--- a/graphql/types/src/types/store.rs
+++ b/graphql/types/src/types/store.rs
@@ -40,8 +40,8 @@ impl StoreNode {
         )
     }
 
-    pub async fn remote_site_id(&self) -> i32 {
-        self.row().remote_site_id
+    pub async fn site_id(&self) -> i32 {
+        self.row().site_id
     }
 }
 

--- a/graphql/types/src/types/store.rs
+++ b/graphql/types/src/types/store.rs
@@ -39,6 +39,10 @@ impl StoreNode {
             .extend(),
         )
     }
+
+    pub async fn remote_site_id(&self) -> i32 {
+        self.row().remote_site_id
+    }
 }
 
 impl StoreNode {

--- a/repository/migrations/postgres/2021-08-25T10-00_create_store_table/up.sql
+++ b/repository/migrations/postgres/2021-08-25T10-00_create_store_table/up.sql
@@ -4,6 +4,6 @@ CREATE TABLE store (
     id TEXT NOT NULL PRIMARY KEY,
     name_id TEXT NOT NULL,
     code TEXT NOT NULL,
-    remote_site_id INTEGER NOT NULL,
+    site_id INTEGER NOT NULL,
     FOREIGN KEY(name_id) REFERENCES name(id)
 )

--- a/repository/migrations/postgres/2021-08-25T10-00_create_store_table/up.sql
+++ b/repository/migrations/postgres/2021-08-25T10-00_create_store_table/up.sql
@@ -4,5 +4,6 @@ CREATE TABLE store (
     id TEXT NOT NULL PRIMARY KEY,
     name_id TEXT NOT NULL,
     code TEXT NOT NULL,
+    remote_site_id INTEGER NOT NULL,
     FOREIGN KEY(name_id) REFERENCES name(id)
 )

--- a/repository/migrations/sqlite/2021-08-20T10-00_create_store_table/up.sql
+++ b/repository/migrations/sqlite/2021-08-20T10-00_create_store_table/up.sql
@@ -4,6 +4,6 @@ CREATE TABLE store (
     id TEXT NOT NULL PRIMARY KEY,
     name_id TEXT NOT NULL,
     code TEXT NOT NULL,
-    remote_site_id INTEGER NOT NULL,
+    site_id INTEGER NOT NULL,
     FOREIGN KEY(name_id) REFERENCES name(id)
 )

--- a/repository/migrations/sqlite/2021-08-20T10-00_create_store_table/up.sql
+++ b/repository/migrations/sqlite/2021-08-20T10-00_create_store_table/up.sql
@@ -4,5 +4,6 @@ CREATE TABLE store (
     id TEXT NOT NULL PRIMARY KEY,
     name_id TEXT NOT NULL,
     code TEXT NOT NULL,
+    remote_site_id INTEGER NOT NULL,
     FOREIGN KEY(name_id) REFERENCES name(id)
 )

--- a/repository/src/db_diesel/filter_sort_pagination.rs
+++ b/repository/src/db_diesel/filter_sort_pagination.rs
@@ -41,6 +41,17 @@ impl EqualFilter<i64> {
     }
 }
 
+impl EqualFilter<i32> {
+    pub fn equal_to_i32(value: i32) -> Self {
+        EqualFilter {
+            equal_to: Some(value),
+            not_equal_to: None,
+            equal_any: None,
+            not_equal_all: None,
+        }
+    }
+}
+
 impl EqualFilter<String> {
     pub fn equal_to(value: &str) -> Self {
         EqualFilter {

--- a/repository/src/db_diesel/invoice_query.rs
+++ b/repository/src/db_diesel/invoice_query.rs
@@ -5,10 +5,8 @@ use crate::{
         apply_sort_no_case,
     },
     schema::{
-        diesel_schema::{
-            invoice, invoice::dsl as invoice_dsl, name, name::dsl as name_dsl, store,
-            store::dsl as store_dsl,
-        },
+        diesel_schema::{invoice, invoice::dsl as invoice_dsl, name, name::dsl as name_dsl},
+        store::{store, store::dsl as store_dsl},
         InvoiceRow, InvoiceRowStatus, InvoiceRowType, NameRow, StoreRow,
     },
     RepositoryError,

--- a/repository/src/db_diesel/master_list.rs
+++ b/repository/src/db_diesel/master_list.rs
@@ -5,8 +5,8 @@ use crate::{
         diesel_schema::{
             master_list, master_list::dsl as master_list_dsl,
             master_list_name_join::dsl as master_list_name_join_dsl, name::dsl as name_dsl,
-            store::dsl as store_dsl,
         },
+        store::store::dsl as store_dsl,
         MasterListRow,
     },
 };

--- a/repository/src/db_diesel/name_query.rs
+++ b/repository/src/db_diesel/name_query.rs
@@ -5,8 +5,9 @@ use crate::{
     schema::{
         diesel_schema::{
             name, name::dsl as name_dsl, name_store_join,
-            name_store_join::dsl as name_store_join_dsl, store, store::dsl as store_dsl,
+            name_store_join::dsl as name_store_join_dsl,
         },
+        store::{store, store::dsl as store_dsl},
         NameRow, NameStoreJoinRow, StoreRow,
     },
 };

--- a/repository/src/db_diesel/stock_movement.rs
+++ b/repository/src/db_diesel/stock_movement.rs
@@ -103,11 +103,11 @@ mod test {
         }
 
         fn store() -> StoreRow {
-            StoreRow {
-                id: "store".to_string(),
-                name_id: name().id,
-                code: "n/a".to_string(),
-            }
+            inline_init(|s: &mut StoreRow| {
+                s.id = "store".to_string();
+                s.name_id = name().id;
+                s.code = "n/a".to_string();
+            })
         }
 
         fn stock_movement_point() -> MockData {

--- a/repository/src/db_diesel/store.rs
+++ b/repository/src/db_diesel/store.rs
@@ -27,7 +27,7 @@ pub struct StoreFilter {
     pub code: Option<SimpleStringFilter>,
     pub name: Option<SimpleStringFilter>,
     pub name_code: Option<SimpleStringFilter>,
-    pub remote_site_id: Option<EqualFilter<i32>>,
+    pub site_id: Option<EqualFilter<i32>>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -61,8 +61,8 @@ impl StoreFilter {
         self
     }
 
-    pub fn remote_site_id(mut self, filter: EqualFilter<i32>) -> Self {
-        self.remote_site_id = Some(filter);
+    pub fn site_id(mut self, filter: EqualFilter<i32>) -> Self {
+        self.site_id = Some(filter);
         self
     }
 }
@@ -132,14 +132,14 @@ fn create_filtered_query(filter: Option<StoreFilter>) -> BoxedStoreQuery {
             code,
             name,
             name_code,
-            remote_site_id,
+            site_id,
         } = f;
 
         apply_equal_filter!(query, id, store_dsl::id);
         apply_simple_string_filter!(query, code, store_dsl::code);
         apply_simple_string_filter!(query, name, name_dsl::name_);
         apply_simple_string_filter!(query, name_code, name_dsl::code);
-        apply_equal_filter!(query, remote_site_id, store_dsl::remote_site_id);
+        apply_equal_filter!(query, site_id, store_dsl::site_id);
     }
 
     query

--- a/repository/src/db_diesel/store.rs
+++ b/repository/src/db_diesel/store.rs
@@ -5,7 +5,8 @@ use crate::{EqualFilter, Pagination, SimpleStringFilter, Sort};
 use crate::{
     diesel_macros::apply_simple_string_filter,
     schema::{
-        diesel_schema::{name, name::dsl as name_dsl, store, store::dsl as store_dsl},
+        diesel_schema::{name, name::dsl as name_dsl},
+        store::{store, store::dsl as store_dsl},
         StoreRow,
     },
     DBType, RepositoryError, StorageConnection,
@@ -26,6 +27,7 @@ pub struct StoreFilter {
     pub code: Option<SimpleStringFilter>,
     pub name: Option<SimpleStringFilter>,
     pub name_code: Option<SimpleStringFilter>,
+    pub remote_site_id: Option<EqualFilter<i32>>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -111,12 +113,14 @@ fn create_filtered_query(filter: Option<StoreFilter>) -> BoxedStoreQuery {
             code,
             name,
             name_code,
+            remote_site_id,
         } = f;
 
         apply_equal_filter!(query, id, store_dsl::id);
         apply_simple_string_filter!(query, code, store_dsl::code);
         apply_simple_string_filter!(query, name, name_dsl::name_);
         apply_simple_string_filter!(query, name_code, name_dsl::code);
+        apply_equal_filter!(query, remote_site_id, store_dsl::remote_site_id);
     }
 
     query

--- a/repository/src/db_diesel/store.rs
+++ b/repository/src/db_diesel/store.rs
@@ -50,6 +50,21 @@ impl StoreFilter {
         self.id = Some(filter);
         self
     }
+
+    pub fn code(mut self, filter: SimpleStringFilter) -> Self {
+        self.code = Some(filter);
+        self
+    }
+
+    pub fn name(mut self, filter: SimpleStringFilter) -> Self {
+        self.name = Some(filter);
+        self
+    }
+
+    pub fn remote_site_id(mut self, filter: EqualFilter<i32>) -> Self {
+        self.remote_site_id = Some(filter);
+        self
+    }
 }
 
 pub struct StoreRepository<'a> {
@@ -64,6 +79,10 @@ impl<'a> StoreRepository<'a> {
     pub fn count(&self, filter: Option<StoreFilter>) -> Result<i64, RepositoryError> {
         let query = create_filtered_query(filter);
         Ok(query.count().get_result(&self.connection.connection)?)
+    }
+
+    pub fn query_one(&self, filter: StoreFilter) -> Result<Option<Store>, RepositoryError> {
+        Ok(self.query_by_filter(filter)?.pop())
     }
 
     pub fn query_by_filter(&self, filter: StoreFilter) -> Result<Vec<Store>, RepositoryError> {

--- a/repository/src/db_diesel/store_row.rs
+++ b/repository/src/db_diesel/store_row.rs
@@ -1,5 +1,6 @@
 use super::StorageConnection;
 
+use crate::schema::store::store::dsl as store_dsl;
 use crate::{repository_error::RepositoryError, schema::StoreRow};
 
 use diesel::prelude::*;
@@ -15,10 +16,9 @@ impl<'a> StoreRowRepository<'a> {
 
     #[cfg(feature = "postgres")]
     pub fn upsert_one(&self, row: &StoreRow) -> Result<(), RepositoryError> {
-        use crate::schema::diesel_schema::store::dsl::*;
-        diesel::insert_into(store)
+        diesel::insert_into(store_dsl::store)
             .values(row)
-            .on_conflict(id)
+            .on_conflict(store_dsl::id)
             .do_update()
             .set(row)
             .execute(&self.connection.connection)?;
@@ -27,32 +27,28 @@ impl<'a> StoreRowRepository<'a> {
 
     #[cfg(not(feature = "postgres"))]
     pub fn upsert_one(&self, row: &StoreRow) -> Result<(), RepositoryError> {
-        use crate::schema::diesel_schema::store::dsl::*;
-        diesel::replace_into(store)
+        diesel::replace_into(store_dsl::store)
             .values(row)
             .execute(&self.connection.connection)?;
         Ok(())
     }
 
     pub async fn insert_one(&self, store_row: &StoreRow) -> Result<(), RepositoryError> {
-        use crate::schema::diesel_schema::store::dsl::*;
-        diesel::insert_into(store)
+        diesel::insert_into(store_dsl::store)
             .values(store_row)
             .execute(&self.connection.connection)?;
         Ok(())
     }
 
     pub fn find_one_by_id(&self, store_id: &str) -> Result<Option<StoreRow>, RepositoryError> {
-        use crate::schema::diesel_schema::store::dsl::*;
-        let result = store
-            .filter(id.eq(store_id))
+        let result = store_dsl::store
+            .filter(store_dsl::id.eq(store_id))
             .first(&self.connection.connection)
             .optional()?;
         Ok(result)
     }
 
     pub fn find_one_by_name_id(&self, name_id: &str) -> Result<Option<StoreRow>, RepositoryError> {
-        use crate::schema::diesel_schema::store::dsl as store_dsl;
         let result = store_dsl::store
             .filter(store_dsl::name_id.eq(name_id))
             .first(&self.connection.connection)
@@ -61,16 +57,14 @@ impl<'a> StoreRowRepository<'a> {
     }
 
     pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<StoreRow>, RepositoryError> {
-        use crate::schema::diesel_schema::store::dsl::*;
-        let result = store
-            .filter(id.eq_any(ids))
+        let result = store_dsl::store
+            .filter(store_dsl::id.eq_any(ids))
             .load(&self.connection.connection)?;
         Ok(result)
     }
 
     pub fn all(&self) -> Result<Vec<StoreRow>, RepositoryError> {
-        use crate::schema::diesel_schema::store::dsl::*;
-        let result = store.load(&self.connection.connection)?;
+        let result = store_dsl::store.load(&self.connection.connection)?;
         Ok(result)
     }
 }

--- a/repository/src/db_diesel/user.rs
+++ b/repository/src/db_diesel/user.rs
@@ -5,8 +5,8 @@ use crate::{
     diesel_macros::{apply_equal_filter, apply_simple_string_filter, apply_sort_no_case},
     repository_error::RepositoryError,
     schema::{
-        diesel_schema::{store, store::dsl as store_dsl},
         diesel_schema::{user_account, user_account::dsl as user_dsl},
+        store::{store, store::dsl as store_dsl},
         user_permission::UserPermissionRow,
         user_store_join::{
             user_store_join, user_store_join::dsl as user_store_join_dsl, UserStoreJoinRow,

--- a/repository/src/mock/store.rs
+++ b/repository/src/mock/store.rs
@@ -1,27 +1,29 @@
+use util::inline_init;
+
 use crate::schema::StoreRow;
 
 pub fn mock_store_a() -> StoreRow {
-    StoreRow {
-        id: String::from("store_a"),
-        name_id: String::from("name_store_a"),
-        code: String::from("code"),
-    }
+    inline_init(|s: &mut StoreRow| {
+        s.id = "store_a".to_string();
+        s.name_id = "name_store_a".to_string();
+        s.code = "code".to_string();
+    })
 }
 
 pub fn mock_store_b() -> StoreRow {
-    StoreRow {
-        id: String::from("store_b"),
-        name_id: String::from("name_store_b"),
-        code: String::from("code"),
-    }
+    inline_init(|s: &mut StoreRow| {
+        s.id = "store_b".to_string();
+        s.name_id = "name_store_b".to_string();
+        s.code = "code".to_string();
+    })
 }
 
 pub fn mock_store_c() -> StoreRow {
-    StoreRow {
-        id: String::from("store_c"),
-        name_id: String::from("name_store_c"),
-        code: String::from("code"),
-    }
+    inline_init(|s: &mut StoreRow| {
+        s.id = "store_c".to_string();
+        s.name_id = "name_store_c".to_string();
+        s.code = "code".to_string();
+    })
 }
 
 pub fn mock_stores() -> Vec<StoreRow> {

--- a/repository/src/mock/test_master_list_repository.rs
+++ b/repository/src/mock/test_master_list_repository.rs
@@ -1,3 +1,5 @@
+use util::inline_init;
+
 use crate::schema::{MasterListNameJoinRow, MasterListRow, NameRow, StoreRow};
 
 use super::{common::FullMockMasterList, MockData};
@@ -54,11 +56,11 @@ pub fn mock_test_master_list_name3() -> NameRow {
 }
 
 pub fn mock_test_master_list_store1() -> StoreRow {
-    StoreRow {
-        id: String::from("mock_test_master_list_store1"),
-        name_id: mock_test_master_list_name3().id,
-        code: String::from("mock_test_master_list_store1"),
-    }
+    inline_init(|s: &mut StoreRow| {
+        s.id = "mock_test_master_list_store1".to_string();
+        s.name_id = mock_test_master_list_name3().id;
+        s.code = "mock_test_master_list_store1".to_string();
+    })
 }
 
 // For name 1 and 2

--- a/repository/src/mock/test_name_query.rs
+++ b/repository/src/mock/test_name_query.rs
@@ -22,19 +22,19 @@ pub fn mock_test_name_query() -> MockData {
 }
 
 pub fn mock_test_name_query_store_1() -> StoreRow {
-    StoreRow {
-        id: "mock_test_name_query_store_1".to_string(),
-        name_id: mock_name_1().id,
-        code: "mock_test_name_query_store_1_code".to_string(),
-    }
+    inline_init(|s: &mut StoreRow| {
+        s.id = "mock_test_name_query_store_1".to_string();
+        s.name_id = mock_name_1().id;
+        s.code = "mock_test_name_query_store_1_code".to_string();
+    })
 }
 
 pub fn mock_test_name_query_store_2() -> StoreRow {
-    StoreRow {
-        id: "mock_test_name_query_store_2".to_string(),
-        name_id: mock_name_2().id,
-        code: "mock_test_name_query_store_2_code".to_string(),
-    }
+    inline_init(|s: &mut StoreRow| {
+        s.id = "mock_test_name_query_store_2".to_string();
+        s.name_id = mock_name_2().id;
+        s.code = "mock_test_name_query_store_2_code".to_string();
+    })
 }
 
 pub fn mock_name_1() -> NameRow {

--- a/repository/src/mock/test_name_store_id.rs
+++ b/repository/src/mock/test_name_store_id.rs
@@ -1,3 +1,5 @@
+use util::inline_init;
+
 use crate::schema::{NameRow, NameStoreJoinRow, StoreRow};
 
 use super::MockData;
@@ -30,11 +32,11 @@ pub fn mock_name_linked_to_store() -> NameRow {
 }
 
 pub fn mock_store_linked_to_name() -> StoreRow {
-    StoreRow {
-        id: "name_store_id".to_owned(),
-        name_id: "name_linked_to_store_id".to_owned(),
-        code: "name_store_code".to_owned(),
-    }
+    inline_init(|s: &mut StoreRow| {
+        s.id = "name_store_id".to_string();
+        s.name_id = "name_linked_to_store_id".to_string();
+        s.code = "name_store_code".to_string();
+    })
 }
 
 pub fn mock_name_linked_to_store_join() -> NameStoreJoinRow {

--- a/repository/src/mock/test_remote_pull.rs
+++ b/repository/src/mock/test_remote_pull.rs
@@ -1,3 +1,5 @@
+use util::inline_init;
+
 use crate::schema::{NameRow, StoreRow};
 
 use super::MockData;
@@ -14,11 +16,11 @@ pub fn mock_name_store_remote_pull() -> NameRow {
 
 // unique store is needed for number tests since number ids are not unique
 pub fn mock_store_remote_pull() -> StoreRow {
-    StoreRow {
-        id: String::from("store_remote_pull"),
-        name_id: String::from("name_store_remote_pull"),
-        code: String::from("codepull"),
-    }
+    inline_init(|s: &mut StoreRow| {
+        s.id = "store_remote_pull".to_string();
+        s.name_id = "name_store_remote_pull".to_string();
+        s.code = "codepull".to_string();
+    })
 }
 
 pub fn mock_test_remote_pull() -> MockData {

--- a/repository/src/schema/diesel_schema.rs
+++ b/repository/src/schema/diesel_schema.rs
@@ -1,3 +1,5 @@
+use super::store::store;
+
 table! {
     central_sync_buffer (id) {
         id -> Integer,
@@ -109,14 +111,6 @@ table! {
         average_monthly_consumption -> Integer,
         snapshot_datetime -> Nullable<Timestamp>,
         comment -> Nullable<Text>,
-    }
-}
-
-table! {
-    store (id) {
-        id -> Text,
-        name_id -> Text,
-        code -> Text,
     }
 }
 

--- a/repository/src/schema/mod.rs
+++ b/repository/src/schema/mod.rs
@@ -21,7 +21,7 @@ mod requisition_line;
 mod stock_line;
 mod stocktake;
 mod stocktake_line;
-mod store;
+pub mod store;
 mod sync_out;
 mod unit;
 mod user_account;

--- a/repository/src/schema/store.rs
+++ b/repository/src/schema/store.rs
@@ -3,7 +3,7 @@ table! {
         id -> Text,
         name_id -> Text,
         code -> Text,
-        remote_site_id -> Integer,
+        site_id -> Integer,
     }
 }
 
@@ -13,5 +13,5 @@ pub struct StoreRow {
     pub id: String,
     pub name_id: String,
     pub code: String,
-    pub remote_site_id: i32,
+    pub site_id: i32,
 }

--- a/repository/src/schema/store.rs
+++ b/repository/src/schema/store.rs
@@ -1,4 +1,11 @@
-use super::diesel_schema::store;
+table! {
+    store (id) {
+        id -> Text,
+        name_id -> Text,
+        code -> Text,
+        remote_site_id -> Integer,
+    }
+}
 
 #[derive(Clone, Queryable, Insertable, Debug, PartialEq, Eq, AsChangeset, Default)]
 #[table_name = "store"]
@@ -6,4 +13,5 @@ pub struct StoreRow {
     pub id: String,
     pub name_id: String,
     pub code: String,
+    pub remote_site_id: i32,
 }

--- a/repository/src/schema/user_store_join.rs
+++ b/repository/src/schema/user_store_join.rs
@@ -1,4 +1,4 @@
-use super::diesel_schema::{store, user_account};
+use super::{diesel_schema::user_account, store::store};
 
 table! {
   user_store_join (id) {

--- a/repository/src/tests.rs
+++ b/repository/src/tests.rs
@@ -17,11 +17,11 @@ mod repository_test {
         }
 
         pub fn store_1() -> StoreRow {
-            StoreRow {
-                id: "store1".to_string(),
-                name_id: "name1".to_string(),
-                code: "code1".to_string(),
-            }
+            inline_init(|s: &mut StoreRow| {
+                s.id = "store1".to_string();
+                s.name_id = "name1".to_string();
+                s.code = "code1".to_string();
+            })
         }
 
         pub fn item_1() -> ItemRow {

--- a/server/src/sync/integration_tests/remote_sync_integration_test.rs
+++ b/server/src/sync/integration_tests/remote_sync_integration_test.rs
@@ -67,8 +67,7 @@ mod remote_sync_integration_tests {
             .unwrap();
         let store_id = StoreRepository::new(&connection)
             .query_one(
-                StoreFilter::new()
-                    .remote_site_id(EqualFilter::equal_to_i32(sync_settings.site_id as i32)),
+                StoreFilter::new().site_id(EqualFilter::equal_to_i32(sync_settings.site_id as i32)),
             )
             .unwrap()
             .unwrap()

--- a/server/src/sync/translation_central/store.rs
+++ b/server/src/sync/translation_central/store.rs
@@ -14,7 +14,7 @@ pub struct LegacyStoreRow {
     name_id: String,
     code: String,
     #[serde(rename = "sync_id_remote_site")]
-    remote_site_id: i32,
+    site_id: i32,
 }
 
 pub struct StoreTranslation {}
@@ -50,7 +50,7 @@ impl CentralPushTranslation for StoreTranslation {
             id: data.id,
             name_id: data.name_id,
             code: data.code,
-            remote_site_id: data.remote_site_id,
+            site_id: data.site_id,
         })))
     }
 }

--- a/server/src/sync/translation_central/store.rs
+++ b/server/src/sync/translation_central/store.rs
@@ -8,9 +8,13 @@ use super::{CentralPushTranslation, IntegrationUpsertRecord};
 #[allow(non_snake_case)]
 #[derive(Deserialize)]
 pub struct LegacyStoreRow {
-    ID: String,
-    name_ID: String,
+    #[serde(rename = "ID")]
+    id: String,
+    #[serde(rename = "name_ID")]
+    name_id: String,
     code: String,
+    #[serde(rename = "sync_id_remote_site")]
+    remote_site_id: i32,
 }
 
 pub struct StoreTranslation {}
@@ -38,14 +42,15 @@ impl CentralPushTranslation for StoreTranslation {
         }
 
         // ignore stores without name
-        if data.name_ID == "" {
+        if data.name_id == "" {
             return Ok(None);
         }
 
         Ok(Some(IntegrationUpsertRecord::Store(StoreRow {
-            id: data.ID,
-            name_id: data.name_ID,
+            id: data.id,
+            name_id: data.name_id,
             code: data.code,
+            remote_site_id: data.remote_site_id,
         })))
     }
 }

--- a/server/src/sync/translation_central/test_data/store.rs
+++ b/server/src/sync/translation_central/test_data/store.rs
@@ -1,5 +1,6 @@
 use crate::sync::translation_central::test_data::{TestSyncDataRecord, TestSyncRecord};
 use repository::schema::{CentralSyncBufferRow, StoreRow};
+use util::inline_init;
 
 const STORE_1: (&'static str, &'static str) = (
     "4E27CEB263354EB7B1B33CEA8F7884D8",
@@ -186,11 +187,12 @@ const RECORD_TYPE: &'static str = "store";
 pub fn get_test_store_records() -> Vec<TestSyncRecord> {
     vec![
         TestSyncRecord {
-            translated_record: TestSyncDataRecord::Store(Some(StoreRow {
-                id: STORE_1.0.to_owned(),
-                name_id: "1FB32324AF8049248D929CFB35F255BA".to_owned(),
-                code: "GEN".to_owned(),
-            })),
+            translated_record: TestSyncDataRecord::Store(Some(inline_init(|s: &mut StoreRow| {
+                s.id = STORE_1.0.to_owned();
+                s.name_id = "1FB32324AF8049248D929CFB35F255BA".to_string();
+                s.code = "GEN".to_string();
+                s.remote_site_id = 1;
+            }))),
             identifier: "General",
             central_sync_buffer_row: CentralSyncBufferRow {
                 id: 10,

--- a/server/src/sync/translation_central/test_data/store.rs
+++ b/server/src/sync/translation_central/test_data/store.rs
@@ -191,7 +191,7 @@ pub fn get_test_store_records() -> Vec<TestSyncRecord> {
                 s.id = STORE_1.0.to_owned();
                 s.name_id = "1FB32324AF8049248D929CFB35F255BA".to_string();
                 s.code = "GEN".to_string();
-                s.remote_site_id = 1;
+                s.site_id = 1;
             }))),
             identifier: "General",
             central_sync_buffer_row: CentralSyncBufferRow {

--- a/service/src/requisition_line/chart/mod.rs
+++ b/service/src/requisition_line/chart/mod.rs
@@ -238,11 +238,11 @@ mod test {
         }
 
         fn store() -> StoreRow {
-            StoreRow {
-                id: "store".to_string(),
-                name_id: name().id,
-                code: "n/a".to_string(),
-            }
+            inline_init(|s: &mut StoreRow| {
+                s.id = "store".to_string();
+                s.name_id = name().id;
+                s.code = "n/a".to_string();
+            })
         }
 
         fn requisition() -> RequisitionRow {
@@ -422,11 +422,11 @@ mod test {
         }
 
         fn store() -> StoreRow {
-            StoreRow {
-                id: "store".to_string(),
-                name_id: name().id,
-                code: "n/a".to_string(),
-            }
+            inline_init(|s: &mut StoreRow| {
+                s.id = "store".to_string();
+                s.name_id = name().id;
+                s.code = "n/a".to_string();
+            })
         }
 
         fn requisition() -> RequisitionRow {


### PR DESCRIPTION
Remote sync integration test: Get store_id automatically from the site_id provided in the settings.

This includes the following change:
- Add `remote_site_id` (further rename to `site_id`?) to the store row
- Add remote_site_id filter in StoreRepositiory. 
- Central sync: integrate the remote_site_id
- Use inline_init in store mocks (think this was also done in another PR(?) but should merge easily)
- Expose remote_site_id it in graphql

#987 