### PR TITLE
1009 add mock permission restriction for requisition mutation

### DIFF
--- a/repository/src/db_diesel/user_permission.rs
+++ b/repository/src/db_diesel/user_permission.rs
@@ -3,7 +3,8 @@ use crate::{
     diesel_macros::{apply_equal_filter, apply_sort_no_case},
     repository_error::RepositoryError,
     schema::user_permission::{
-        user_permission, user_permission::dsl as user_permission_dsl, Resource, UserPermissionRow,
+        user_permission, user_permission::dsl as user_permission_dsl, Permission, Resource,
+        UserPermissionRow,
     },
 };
 use crate::{EqualFilter, Pagination, Sort};
@@ -16,7 +17,9 @@ pub type UserPermission = UserPermissionRow;
 pub struct UserPermissionFilter {
     pub id: Option<EqualFilter<String>>,
     pub user_id: Option<EqualFilter<String>>,
+    pub store_id: Option<EqualFilter<String>>,
     pub resource: Option<EqualFilter<Resource>>,
+    pub permission: Option<EqualFilter<Permission>>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -98,11 +101,15 @@ fn create_filtered_query(filter: Option<UserPermissionFilter>) -> BoxedUserPermi
             id,
             user_id,
             resource,
+            store_id,
+            permission,
         } = f;
 
         apply_equal_filter!(query, id, user_permission_dsl::id);
         apply_equal_filter!(query, user_id, user_permission_dsl::user_id);
         apply_equal_filter!(query, resource, user_permission_dsl::resource);
+        apply_equal_filter!(query, store_id, user_permission_dsl::store_id);
+        apply_equal_filter!(query, permission, user_permission_dsl::permission);
     }
 
     query
@@ -125,6 +132,16 @@ impl UserPermissionFilter {
 
     pub fn resource(mut self, filter: EqualFilter<Resource>) -> Self {
         self.resource = Some(filter);
+        self
+    }
+
+    pub fn permission(mut self, filter: EqualFilter<Permission>) -> Self {
+        self.permission = Some(filter);
+        self
+    }
+
+    pub fn store_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.store_id = Some(filter);
         self
     }
 }

--- a/repository/src/db_diesel/user_permission.rs
+++ b/repository/src/db_diesel/user_permission.rs
@@ -145,3 +145,25 @@ impl UserPermissionFilter {
         self
     }
 }
+
+impl Resource {
+    pub fn equal_to(&self) -> EqualFilter<Resource> {
+        EqualFilter {
+            equal_to: Some(self.clone()),
+            not_equal_to: None,
+            equal_any: None,
+            not_equal_all: None,
+        }
+    }
+}
+
+impl Permission {
+    pub fn equal_to(&self) -> EqualFilter<Permission> {
+        EqualFilter {
+            equal_to: Some(self.clone()),
+            not_equal_to: None,
+            equal_any: None,
+            not_equal_all: None,
+        }
+    }
+}

--- a/repository/src/schema/user_permission.rs
+++ b/repository/src/schema/user_permission.rs
@@ -1,7 +1,5 @@
 use diesel_derive_enum::DbEnum;
 
-use crate::EqualFilter;
-
 table! {
   user_permission (id) {
       id -> Text,
@@ -37,26 +35,4 @@ pub struct UserPermissionRow {
     pub store_id: Option<String>,
     pub resource: Resource,
     pub permission: Permission,
-}
-
-impl Resource {
-    pub fn equal_to(&self) -> EqualFilter<Resource> {
-        EqualFilter {
-            equal_to: Some(self.clone()),
-            not_equal_to: None,
-            equal_any: None,
-            not_equal_all: None,
-        }
-    }
-}
-
-impl Permission {
-    pub fn equal_to(&self) -> EqualFilter<Permission> {
-        EqualFilter {
-            equal_to: Some(self.clone()),
-            not_equal_to: None,
-            equal_any: None,
-            not_equal_all: None,
-        }
-    }
 }

--- a/repository/src/schema/user_permission.rs
+++ b/repository/src/schema/user_permission.rs
@@ -1,5 +1,7 @@
 use diesel_derive_enum::DbEnum;
 
+use crate::EqualFilter;
+
 table! {
   user_permission (id) {
       id -> Text,
@@ -35,4 +37,26 @@ pub struct UserPermissionRow {
     pub store_id: Option<String>,
     pub resource: Resource,
     pub permission: Permission,
+}
+
+impl Resource {
+    pub fn equal_to(&self) -> EqualFilter<Resource> {
+        EqualFilter {
+            equal_to: Some(self.clone()),
+            not_equal_to: None,
+            equal_any: None,
+            not_equal_all: None,
+        }
+    }
+}
+
+impl Permission {
+    pub fn equal_to(&self) -> EqualFilter<Permission> {
+        EqualFilter {
+            equal_to: Some(self.clone()),
+            not_equal_to: None,
+            equal_any: None,
+            not_equal_all: None,
+        }
+    }
 }

--- a/service/src/apis/permissions.rs
+++ b/service/src/apis/permissions.rs
@@ -401,7 +401,7 @@ pub fn map_api_permissions(permissions: Vec<bool>) -> Vec<Permissions> {
         if !has_per {
             continue;
         }
-        if let Some(permission) = mapping.get(&(i as i16)) {
+        if let Some(permission) = mapping.get(&((i + 1) as i16)) {
             output.push(permission.clone())
         }
     }

--- a/service/src/permission_validation.rs
+++ b/service/src/permission_validation.rs
@@ -288,9 +288,11 @@ impl ValidationServiceTrait for ValidationService {
         };
 
         // TODO temp validation of  Resource::MutateRequisition
-        if let (Some(store_id), Resource::MutateRequisition) =
-            (&resource_request.store_id, &resource_request.resource)
-        {
+        if let (Some(store_id), Resource::MutateRequisition, false) = (
+            &resource_request.store_id,
+            &resource_request.resource,
+            auth_data.debug_no_access_control,
+        ) {
             let connection = self.connection_manager.connection()?;
 
             let matched_permission = UserPermissionRepository::new(&connection).query_by_filter(

--- a/service/src/permission_validation.rs
+++ b/service/src/permission_validation.rs
@@ -1,5 +1,10 @@
 use std::{collections::HashMap, sync::Arc};
 
+use repository::{
+    schema::user_permission, EqualFilter, RepositoryError, StorageConnectionManager,
+    UserPermissionFilter, UserPermissionRepository,
+};
+
 use crate::{
     auth_data::AuthData,
     permissions::{ApiRole, PermissionServiceTrait, StoreRole, UserPermissions},
@@ -234,13 +239,18 @@ pub trait ValidationServiceTrait: Send + Sync {
 pub struct ValidationService {
     pub permission_service: Arc<dyn PermissionServiceTrait>,
     pub permissions: HashMap<Resource, PermissionDSL>,
+    pub connection_manager: StorageConnectionManager,
 }
 
 impl ValidationService {
-    pub fn new(permission_service: Arc<dyn PermissionServiceTrait>) -> Self {
+    pub fn new(
+        permission_service: Arc<dyn PermissionServiceTrait>,
+        connection_manager: StorageConnectionManager,
+    ) -> Self {
         ValidationService {
             permission_service,
             permissions: all_permissions(),
+            connection_manager,
         }
     }
 }
@@ -277,11 +287,38 @@ impl ValidationServiceTrait for ValidationService {
             }
         };
 
+        // TODO temp validation of  Resource::MutateRequisition
+        if let (Some(store_id), Resource::MutateRequisition) =
+            (&resource_request.store_id, &resource_request.resource)
+        {
+            let connection = self.connection_manager.connection()?;
+
+            let matched_permission = UserPermissionRepository::new(&connection).query_by_filter(
+                UserPermissionFilter::new()
+                    .user_id(EqualFilter::equal_to(&validated_auth.user_id))
+                    .store_id(EqualFilter::equal_to(&store_id))
+                    .resource(user_permission::Resource::Requisition.equal_to())
+                    .permission(user_permission::Permission::Mutate.equal_to()),
+            )?;
+
+            if matched_permission.is_empty() {
+                return Err(ValidationError::Denied(
+                    ValidationDeniedKind::InsufficientPermission((String::new(), permissions)),
+                ));
+            }
+        }
+
         Ok(ValidatedUser {
             user_id: validated_auth.user_id,
             claims: validated_auth.claims,
             permissions,
         })
+    }
+}
+
+impl From<RepositoryError> for ValidationError {
+    fn from(error: RepositoryError) -> Self {
+        ValidationError::InternalError(format!("{:#?}", error))
     }
 }
 
@@ -294,7 +331,16 @@ mod permission_validation_test {
         auth_data::AuthData, permissions::PermissionService, service_provider::ServiceProvider,
         token_bucket::TokenBucket,
     };
-    use repository::{get_storage_connection_manager, test_db};
+    use repository::{
+        get_storage_connection_manager,
+        mock::{MockData, MockDataInserts},
+        schema::{
+            user_permission::{self, UserPermissionRow},
+            NameRow, StoreRow, UserAccountRow,
+        },
+        test_db::{self, setup_all_with_data},
+    };
+    use util::inline_init;
 
     #[actix_rt::test]
     async fn test_basic_permission_validation() {
@@ -315,15 +361,18 @@ mod permission_validation_test {
             test_db::get_test_db_settings("omsupply-database-basic_permission_validation");
         test_db::setup(&settings).await;
         let connection_manager = get_storage_connection_manager(&settings);
-        let service_provider = ServiceProvider::new(connection_manager);
+        let service_provider = ServiceProvider::new(connection_manager.clone());
         let context = service_provider.context().unwrap();
 
-        let mut service = ValidationService::new(Arc::new(PermissionService {
-            user_permissions: UserPermissions {
-                api: vec![ApiRole::User],
-                stores: HashMap::new(),
-            },
-        }));
+        let mut service = ValidationService::new(
+            Arc::new(PermissionService {
+                user_permissions: UserPermissions {
+                    api: vec![ApiRole::User],
+                    stores: HashMap::new(),
+                },
+            }),
+            connection_manager.clone(),
+        );
         service.permissions.clear();
         service
             .permissions
@@ -354,5 +403,113 @@ mod permission_validation_test {
                 &resource_access_request,
             )
             .unwrap();
+    }
+
+    #[actix_rt::test]
+    async fn test_basic_user_store_permissions() {
+        fn name() -> NameRow {
+            inline_init(|r: &mut NameRow| {
+                r.id = "name".to_string();
+            })
+        }
+
+        fn store() -> StoreRow {
+            StoreRow {
+                id: "store".to_string(),
+                name_id: name().id,
+                code: "n/a".to_string(),
+            }
+        }
+
+        fn user() -> UserAccountRow {
+            UserAccountRow {
+                id: "user".to_string(),
+                username: "user".to_string(),
+                hashed_password: "n/a".to_string(),
+                email: None,
+            }
+        }
+
+        fn user_without_permission() -> UserAccountRow {
+            UserAccountRow {
+                id: "user_without_permission".to_string(),
+                username: "user".to_string(),
+                hashed_password: "n/a".to_string(),
+                email: None,
+            }
+        }
+
+        fn permission() -> UserPermissionRow {
+            UserPermissionRow {
+                id: "permission".to_string(),
+                user_id: user().id,
+                store_id: Some(store().id),
+                resource: user_permission::Resource::Requisition,
+                permission: user_permission::Permission::Mutate,
+            }
+        }
+
+        let (_, _, connection_manager, _) = setup_all_with_data(
+            "test_basic_user_store_permissions",
+            MockDataInserts::all(),
+            inline_init(|r: &mut MockData| {
+                r.stores = vec![store()];
+                r.names = vec![name()];
+                r.user_accounts = vec![user(), user_without_permission()];
+                r.user_permissions = vec![permission()]
+            }),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider.context().unwrap();
+
+        let auth_data = AuthData {
+            auth_token_secret: "some secret".to_string(),
+            token_bucket: RwLock::new(TokenBucket::new()),
+            debug_no_ssl: true,
+            debug_no_access_control: false,
+        };
+
+        let token = TokenService::new(
+            &auth_data.token_bucket,
+            auth_data.auth_token_secret.as_bytes(),
+        )
+        .jwt_token(&user().id, 60, 120)
+        .unwrap()
+        .token;
+
+        assert!(service_provider
+            .validation_service
+            .validate(
+                &context,
+                &auth_data,
+                &Some(token),
+                &ResourceAccessRequest {
+                    resource: Resource::MutateRequisition,
+                    store_id: Some(store().id)
+                }
+            )
+            .is_ok());
+
+        let token = TokenService::new(
+            &auth_data.token_bucket,
+            auth_data.auth_token_secret.as_bytes(),
+        )
+        .jwt_token(&user_without_permission().id, 60, 120)
+        .unwrap()
+        .token;
+        assert!(service_provider
+            .validation_service
+            .validate(
+                &context,
+                &auth_data,
+                &Some(token),
+                &ResourceAccessRequest {
+                    resource: Resource::MutateRequisition,
+                    store_id: Some(store().id)
+                }
+            )
+            .is_err());
     }
 }

--- a/service/src/service_provider.rs
+++ b/service/src/service_provider.rs
@@ -59,9 +59,12 @@ impl ServiceProvider {
     pub fn new(connection_manager: StorageConnectionManager) -> Self {
         let permission_service = Arc::new(PermissionService::new());
         ServiceProvider {
-            connection_manager,
+            connection_manager: connection_manager.clone(),
             permission_service: permission_service.clone(),
-            validation_service: Box::new(ValidationService::new(permission_service)),
+            validation_service: Box::new(ValidationService::new(
+                permission_service,
+                connection_manager.clone(),
+            )),
             location_service: Box::new(LocationService {}),
             master_list_service: Box::new(MasterListService {}),
             invoice_line_service: Box::new(InvoiceLineService {}),


### PR DESCRIPTION
closes #1009 

Fixed permission mapping (it's a good idea to test central server UI configurations propagate correctly):
![Screen Shot 2022-04-06 at 11 38 13 AM](https://user-images.githubusercontent.com/26194949/161870739-1f4f99de-52ae-424d-a832-cb502b10893a.png)

Added a temp restriction for requisition mutate.

I did the following test:

* Log In, try mutate requisition with API (parameters don't matter, as long as strore_id is correct), you should get record not found error
* Update user permissions for the store_id you were using in central UI (see image above)
* Login again and try to mutate, should see permission error

I am not sure what front end would be showing as an error and if we need to present the error in a better format, would assume for V1 beta we would just show Unauthorised in UI

I think the error should be structure error, in the future when we sync users, user permissions could update without front end really knowing, and the plan was to return current user permission on authorisation error (so front end can update them).

Lastly, would assume permissions validations would be simplified quite a bit, i found it hard differentiation between PermissionServicTrait permissions and permissions in validation service. (I am sure there was a good reason to have them, but I don't think it would be needed to satisfy current requirements)
