### PR TITLE
Use fix login response time in case of a login error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3829,6 +3829,7 @@ dependencies = [
  "serde 1.0.130",
  "serde_json",
  "tera",
+ "tokio",
  "util",
 ]
 

--- a/graphql/general/src/queries/login.rs
+++ b/graphql/general/src/queries/login.rs
@@ -8,6 +8,9 @@ use service::{
     token::TokenPair,
 };
 
+// Fixed login response time in case of an error (see service)
+const MIN_ERR_RESPONSE_TIME_SEC: u64 = 6;
+
 pub struct AuthToken {
     pub pair: TokenPair,
 }
@@ -57,6 +60,7 @@ pub async fn login(ctx: &Context<'_>, username: &str, password: &str) -> Result<
             password: password.to_string(),
             central_server_url: sync_settings.url.clone(),
         },
+        MIN_ERR_RESPONSE_TIME_SEC,
     )
     .await
     {

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -20,6 +20,7 @@ reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0.126"
 serde_json = "1.0.66"
 tera = "1"
+tokio = "1.17.0"
 headless_chrome = "0.9"
 failure = "0.1.8"
 


### PR DESCRIPTION
If there is a login error I wait till (the randomly chosen time of) 6s for the total response has been passed.

#1006 

Needed to add tokio as a dependency for an async sleep...