### PR TITLE
Introduce a develop settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,15 @@ cargo test --features postgres
 ## Building docs
 
 Docs are built via github action, but can build local version with docker: [how to build docs locally](docker/zola_docs/README.md)
+
+## Development Mode
+
+In production certificates are needed to start the server.
+Furthermore, the central server must be running.
+For convenience these requirements are disabled in development mode.
+To enable development mode the `develop` flag must be set to `true` in the settings (`true` on default when using local.yaml):
+
+```yaml
+server:
+  develop: true
+```

--- a/android/src/android.rs
+++ b/android/src/android.rs
@@ -87,6 +87,7 @@ pub mod android {
                     server: ServerSettings {
                         host: "127.0.0.1".to_string(),
                         port,
+                        develop: false,
                         debug_no_access_control: false,
                     },
                     database: DatabaseSettings {

--- a/configuration/local.yaml
+++ b/configuration/local.yaml
@@ -1,4 +1,5 @@
 server:
   host: 127.0.0.1
+  develop: true
 sync:
   url: "http://localhost:2048"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -93,10 +93,9 @@ pub async fn start_server(
                     ErrorKind::Other,
                     "Certificate required in production",
                 ));
-            } else {
-                warn!("No certificates found: Run in HTTP development mode");
             }
 
+            warn!("No certificates found: Run in HTTP development mode");
             let listener = TcpListener::bind(settings.server.address())
                 .expect("Failed to bind server to address");
             http_server = http_server.listen(listener)?;

--- a/server/src/settings.rs
+++ b/server/src/settings.rs
@@ -19,6 +19,10 @@ pub struct Settings {
 pub struct ServerSettings {
     pub host: String,
     pub port: u16,
+    /// Indicates if the server runs in development mode
+    #[serde(default)]
+    pub develop: bool,
+    /// Only used in development mode
     #[serde(default)]
     pub debug_no_access_control: bool,
 }

--- a/server/src/test_utils.rs
+++ b/server/src/test_utils.rs
@@ -10,6 +10,7 @@ pub fn get_test_settings(db_name: &str) -> Settings {
         server: ServerSettings {
             host: "localhost".to_string(),
             port: 5432,
+            develop: true,
             debug_no_access_control: true,
         },
         database: get_test_db_settings(db_name),

--- a/service/src/permission_validation.rs
+++ b/service/src/permission_validation.rs
@@ -416,11 +416,11 @@ mod permission_validation_test {
         }
 
         fn store() -> StoreRow {
-            StoreRow {
-                id: "store".to_string(),
-                name_id: name().id,
-                code: "n/a".to_string(),
-            }
+            inline_init(|s: &mut StoreRow| {
+                s.id = "store".to_string();
+                s.name_id = name().id;
+                s.code = "n/a".to_string();
+            })
         }
 
         fn user() -> UserAccountRow {


### PR DESCRIPTION
#864 was already address in a different PR but there where some missing pieces, i.e. server always assumes we are in develop mode and starts without certs and if initial sync failed. For this reason I introduced a develop server settings entry.

If not in development mode the server shutdown if:
1) no certs are found
2) the initial sync failed

Closes #864
Closes #789