### PR TITLE
Add feature to run tests in sqlite memory mode

### DIFF
--- a/repository/Cargo.toml
+++ b/repository/Cargo.toml
@@ -28,5 +28,6 @@ actix-rt = "2.6.0"
 [features]
 default = ["sqlite"]
 sqlite = ["diesel/sqlite", "libsqlite3-sys", "diesel-derive-enum/sqlite"]
+memory = ["diesel/sqlite", "libsqlite3-sys", "diesel-derive-enum/sqlite"]
 postgres = ["diesel/postgres" , "diesel-derive-enum/postgres"]
 

--- a/repository/src/database_settings.rs
+++ b/repository/src/database_settings.rs
@@ -12,6 +12,7 @@ pub struct DatabaseSettings {
     pub database_name: String,
 }
 
+// feature postgres
 #[cfg(feature = "postgres")]
 impl DatabaseSettings {
     pub fn connection_string(&self) -> String {
@@ -29,14 +30,27 @@ impl DatabaseSettings {
     }
 }
 
-#[cfg(not(feature = "postgres"))]
+// feature sqlite
+#[cfg(all(not(feature = "postgres"), not(feature = "memory")))]
 impl DatabaseSettings {
     pub fn connection_string(&self) -> String {
-        format!("{}.sqlite", self.database_name)
+        format!("test_output/{}.sqlite", self.database_name)
     }
 
     pub fn connection_string_without_db(&self) -> String {
-        return self.connection_string();
+        self.connection_string()
+    }
+}
+
+// feature memory
+#[cfg(feature = "memory")]
+impl DatabaseSettings {
+    pub fn connection_string(&self) -> String {
+        format!("file:{}?mode=memory&cache=shared", self.database_name)
+    }
+
+    pub fn connection_string_without_db(&self) -> String {
+        self.connection_string()
     }
 }
 

--- a/repository/src/db_diesel/storage_connection.rs
+++ b/repository/src/db_diesel/storage_connection.rs
@@ -209,13 +209,12 @@ impl StorageConnectionManager {
 
 #[cfg(test)]
 mod connection_manager_tests {
-    use crate::{get_storage_connection_manager, test_db, RepositoryError, TransactionError};
+    use crate::{test_db, RepositoryError, TransactionError};
 
     #[actix_rt::test]
     async fn test_nested_tx() {
         let settings = test_db::get_test_db_settings("omsupply-nested-tx");
-        test_db::setup(&settings).await;
-        let connection_manager = get_storage_connection_manager(&settings);
+        let connection_manager = test_db::setup(&settings).await;
         let connection = connection_manager.connection().unwrap();
 
         assert_eq!(connection.transaction_level.get(), 0);

--- a/repository/src/test_db.rs
+++ b/repository/src/test_db.rs
@@ -31,23 +31,20 @@ fn find_test_migration_directory() -> PathBuf {
 }
 
 #[cfg(feature = "postgres")]
-pub async fn setup(db_settings: &DatabaseSettings) {
-    use diesel::{PgConnection, RunQueryDsl};
+pub async fn setup(db_settings: &DatabaseSettings) -> StorageConnectionManager {
+    use diesel::RunQueryDsl;
 
-    const MIGRATION_PATH: &str = "postgres";
-
+    // Provision a fresh database
     let connection_manager =
-        ConnectionManager::<PgConnection>::new(&db_settings.connection_string_without_db());
+        ConnectionManager::<DBBackendConnection>::new(&db_settings.connection_string_without_db());
     let pool = Pool::new(connection_manager).expect("Failed to connect to database");
     let connection = pool.get().expect("Failed to open connection");
-
     diesel::sql_query(format!(
         "DROP DATABASE IF EXISTS \"{}\";",
         &db_settings.database_name
     ))
     .execute(&connection)
     .unwrap();
-
     diesel::sql_query(format!(
         "CREATE DATABASE \"{}\";",
         &db_settings.database_name
@@ -55,30 +52,32 @@ pub async fn setup(db_settings: &DatabaseSettings) {
     .execute(&connection)
     .unwrap();
 
+    // Create a connection manager to the just created database and run the migrations
     let connection_manager =
-        ConnectionManager::<PgConnection>::new(&db_settings.connection_string());
+        ConnectionManager::<DBBackendConnection>::new(&db_settings.connection_string());
     let pool = Pool::new(connection_manager).expect("Failed to connect to database");
     let connection = pool.get().expect("Failed to open connection");
 
+    const MIGRATION_PATH: &str = "postgres";
     let mut migrations_dir = find_test_migration_directory();
     migrations_dir.push(MIGRATION_PATH);
-
     let mut migrations = mark_migrations_in_directory(&connection, &migrations_dir).unwrap();
     migrations.sort_by(|(m, ..), (n, ..)| m.version().cmp(&n.version()));
-
     for (migration, ..) in migrations.iter() {
         migration.run(&connection).unwrap();
     }
+
+    StorageConnectionManager::new(pool)
 }
 
+// feature sqlite
 #[cfg(not(feature = "postgres"))]
-pub async fn setup(db_settings: &DatabaseSettings) {
-    use diesel::{Connection, SqliteConnection};
+pub async fn setup(db_settings: &DatabaseSettings) -> StorageConnectionManager {
     use std::fs;
 
-    const MIGRATION_PATH: &str = "sqlite";
-
-    let db_path = format!("./{}.sqlite", db_settings.database_name);
+    let db_path = db_settings.connection_string();
+    // Note, if running "in memory" this call is not needed but since the connection string is not
+    // a valid file name it will not delete anything
     fs::remove_file(&db_path).ok();
 
     // create parent dirs
@@ -86,29 +85,25 @@ pub async fn setup(db_settings: &DatabaseSettings) {
     let prefix = path.parent().unwrap();
     fs::create_dir_all(prefix).unwrap();
 
-    let connection = SqliteConnection::establish(&db_path).unwrap();
+    let connection_manager =
+        ConnectionManager::<DBBackendConnection>::new(&db_settings.connection_string());
+    let pool = Pool::builder()
+        //.max_size(1)
+        .min_idle(Some(1))
+        .build(connection_manager)
+        .expect("Failed to connect to database");
+    let connection = pool.get().expect("Failed to open connection");
 
+    const MIGRATION_PATH: &str = "sqlite";
     let mut migrations_dir = find_test_migration_directory();
-
     migrations_dir.push(MIGRATION_PATH);
-
     let mut migrations = mark_migrations_in_directory(&connection, &migrations_dir).unwrap();
     migrations.sort_by(|(m, ..), (n, ..)| m.version().cmp(&n.version()));
-
     for (migration, ..) in migrations.iter() {
         migration.run(&connection).unwrap();
     }
-}
 
-#[cfg(feature = "postgres")]
-fn make_test_db_name(base_name: String) -> String {
-    base_name
-}
-
-#[cfg(not(feature = "postgres"))]
-fn make_test_db_name(base_name: String) -> String {
-    // store all test db files in a test directory
-    format!("test_output/{}", base_name)
+    StorageConnectionManager::new(pool)
 }
 
 // The following settings work for PG and Sqlite (username, password, host and port are
@@ -119,7 +114,7 @@ pub fn get_test_db_settings(db_name: &str) -> DatabaseSettings {
         password: "password".to_string(),
         port: 5432,
         host: "localhost".to_string(),
-        database_name: make_test_db_name(db_name.to_owned()),
+        database_name: db_name.to_string(),
     }
 }
 
@@ -150,19 +145,10 @@ pub async fn setup_all_with_data(
     DatabaseSettings,
 ) {
     let settings = get_test_db_settings(db_name);
-
-    setup(&settings).await;
-
-    let connection_manager =
-        ConnectionManager::<DBBackendConnection>::new(&settings.connection_string());
-    let pool = Pool::new(connection_manager).expect("Failed to connect to database");
-
-    let storage_connection_manager = StorageConnectionManager::new(pool.clone());
-
-    let connection = storage_connection_manager.connection().unwrap();
+    let connection_manager = setup(&settings).await;
+    let connection = connection_manager.connection().unwrap();
 
     let core_data = insert_all_mock_data(&connection, inserts).await;
-
     insert_mock_data(
         &connection,
         MockDataInserts::all(),
@@ -171,5 +157,5 @@ pub async fn setup_all_with_data(
         },
     )
     .await;
-    (core_data, connection, storage_connection_manager, settings)
+    (core_data, connection, connection_manager, settings)
 }

--- a/repository/src/tests.rs
+++ b/repository/src/tests.rs
@@ -269,7 +269,6 @@ mod repository_test {
     use std::convert::TryInto;
 
     use crate::{
-        database_settings::get_storage_connection_manager,
         mock::{
             mock_draft_request_requisition_line, mock_draft_request_requisition_line2,
             mock_inbound_shipment_number_store_a, mock_master_list_master_list_line_filter_test,
@@ -302,8 +301,7 @@ mod repository_test {
     #[actix_rt::test]
     async fn test_name_repository() {
         let settings = test_db::get_test_db_settings("omsupply-database-name-repository");
-        test_db::setup(&settings).await;
-        let connection_manager = get_storage_connection_manager(&settings);
+        let connection_manager = test_db::setup(&settings).await;
         let connection = connection_manager.connection().unwrap();
 
         let repo = NameRepository::new(&connection);
@@ -316,8 +314,7 @@ mod repository_test {
     #[actix_rt::test]
     async fn test_store_repository() {
         let settings = test_db::get_test_db_settings("omsupply-database-store-repository");
-        test_db::setup(&settings).await;
-        let connection_manager = get_storage_connection_manager(&settings);
+        let connection_manager = test_db::setup(&settings).await;
         let connection = connection_manager.connection().unwrap();
 
         // setup
@@ -336,8 +333,7 @@ mod repository_test {
     #[actix_rt::test]
     async fn test_stock_line() {
         let settings = test_db::get_test_db_settings("omsupply-database-item-line-repository");
-        test_db::setup(&settings).await;
-        let connection_manager = get_storage_connection_manager(&settings);
+        let connection_manager = test_db::setup(&settings).await;
         let connection = connection_manager.connection().unwrap();
 
         // setup
@@ -362,8 +358,7 @@ mod repository_test {
     async fn test_stock_line_query() {
         let settings =
             test_db::get_test_db_settings("omsupply-database-item-line-query-repository");
-        test_db::setup(&settings).await;
-        let connection_manager = get_storage_connection_manager(&settings);
+        let connection_manager = test_db::setup(&settings).await;
         let connection = connection_manager.connection().unwrap();
 
         // setup
@@ -409,8 +404,7 @@ mod repository_test {
     #[actix_rt::test]
     async fn test_master_list_row_repository() {
         let settings = test_db::get_test_db_settings("test_master_list_row_repository");
-        test_db::setup(&settings).await;
-        let connection_manager = get_storage_connection_manager(&settings);
+        let connection_manager = test_db::setup(&settings).await;
         let connection = connection_manager.connection().unwrap();
 
         let repo = MasterListRowRepository::new(&connection);
@@ -436,7 +430,6 @@ mod repository_test {
     async fn test_master_list_repository() {
         let (_, connection, _, _) =
             test_db::setup_all("test_master_list_repository", MockDataInserts::all()).await;
-
         let repo = MasterListRepository::new(&connection);
 
         let id_rows: Vec<String> = repo
@@ -517,8 +510,7 @@ mod repository_test {
     async fn test_master_list_line_repository() {
         let settings =
             test_db::get_test_db_settings("omsupply-database-master-list-line-repository");
-        test_db::setup(&settings).await;
-        let connection_manager = get_storage_connection_manager(&settings);
+        let connection_manager = test_db::setup(&settings).await;
         let connection = connection_manager.connection().unwrap();
 
         // setup
@@ -551,8 +543,7 @@ mod repository_test {
     async fn test_master_list_name_join_repository() {
         let settings =
             test_db::get_test_db_settings("omsupply-database-master-list-name-join-repository");
-        test_db::setup(&settings).await;
-        let connection_manager = get_storage_connection_manager(&settings);
+        let connection_manager = test_db::setup(&settings).await;
         let connection = connection_manager.connection().unwrap();
 
         // setup
@@ -577,8 +568,7 @@ mod repository_test {
     #[actix_rt::test]
     async fn test_invoice_repository() {
         let settings = test_db::get_test_db_settings("omsupply-database-invoice-repository");
-        test_db::setup(&settings).await;
-        let connection_manager = get_storage_connection_manager(&settings);
+        let connection_manager = test_db::setup(&settings).await;
         let connection = connection_manager.connection().unwrap();
 
         // setup
@@ -613,8 +603,7 @@ mod repository_test {
     #[actix_rt::test]
     async fn test_invoice_line_repository() {
         let settings = test_db::get_test_db_settings("omsupply-database-invoice-line-repository");
-        test_db::setup(&settings).await;
-        let connection_manager = get_storage_connection_manager(&settings);
+        let connection_manager = test_db::setup(&settings).await;
         let connection = connection_manager.connection().unwrap();
 
         // setup
@@ -655,8 +644,7 @@ mod repository_test {
     async fn test_invoice_line_query_repository() {
         let settings =
             test_db::get_test_db_settings("omsupply-database-invoice-line-query-repository");
-        test_db::setup(&settings).await;
-        let connection_manager = get_storage_connection_manager(&settings);
+        let connection_manager = test_db::setup(&settings).await;
         let connection = connection_manager.connection().unwrap();
 
         // setup
@@ -709,8 +697,7 @@ mod repository_test {
     #[actix_rt::test]
     async fn test_user_account_repository() {
         let settings = test_db::get_test_db_settings("omsupply-database-user-account-repository");
-        test_db::setup(&settings).await;
-        let connection_manager = get_storage_connection_manager(&settings);
+        let connection_manager = test_db::setup(&settings).await;
         let connection = connection_manager.connection().unwrap();
 
         let repo = UserAccountRowRepository::new(&connection);
@@ -729,8 +716,7 @@ mod repository_test {
     #[actix_rt::test]
     async fn test_central_sync_buffer() {
         let settings = test_db::get_test_db_settings("omsupply-database-central-sync_buffer");
-        test_db::setup(&settings).await;
-        let connection_manager = get_storage_connection_manager(&settings);
+        let connection_manager = test_db::setup(&settings).await;
         let connection = connection_manager.connection().unwrap();
 
         let repo = CentralSyncBufferRepository::new(&connection);

--- a/server/src/sync/central_data_synchroniser.rs
+++ b/server/src/sync/central_data_synchroniser.rs
@@ -228,10 +228,7 @@ mod tests {
         },
         test_utils::get_test_settings,
     };
-    use repository::{
-        get_storage_connection_manager, schema::CentralSyncBufferRow, test_db,
-        CentralSyncBufferRepository,
-    };
+    use repository::{schema::CentralSyncBufferRow, test_db, CentralSyncBufferRepository};
     use reqwest::{Client, Url};
 
     use super::CentralDataSynchroniser;
@@ -239,9 +236,7 @@ mod tests {
     #[actix_rt::test]
     async fn test_integrate_central_records() {
         let settings = get_test_settings("omsupply-database-integrate_central_records");
-
-        test_db::setup(&settings.database).await;
-        let connection_manager = get_storage_connection_manager(&settings.database);
+        let connection_manager = test_db::setup(&settings.database).await;
 
         // use test records with cursors that are out of order
         let mut test_records = Vec::new();

--- a/server/src/sync/translation_central/mod.rs
+++ b/server/src/sync/translation_central/mod.rs
@@ -199,13 +199,10 @@ async fn store_integration_records(
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        sync::translation_central::{
-            import_sync_records, test_data::store::get_test_store_records,
-        },
-        test_utils::get_test_settings,
+    use crate::sync::translation_central::{
+        import_sync_records, test_data::store::get_test_store_records,
     };
-    use repository::{get_storage_connection_manager, test_db};
+    use repository::test_db;
 
     use super::test_data::{
         check_records_against_database, extract_sync_buffer_rows,
@@ -219,12 +216,9 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_store_translation_insert() {
-        let settings = get_test_settings("omsupply-database-translation-insert");
-
-        test_db::setup(&settings.database).await;
-        let connection = get_storage_connection_manager(&settings.database)
-            .connection()
-            .unwrap();
+        let settings = test_db::get_test_db_settings("omsupply-database-translation-insert");
+        let connection_manager = test_db::setup(&settings).await;
+        let connection = connection_manager.connection().unwrap();
 
         let mut records = Vec::new();
         // Need to be in order of reference dependency
@@ -246,12 +240,9 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_store_translation_upsert() {
-        let settings = get_test_settings("omsupply-database-translation-upsert");
-
-        test_db::setup(&settings.database).await;
-        let connection = get_storage_connection_manager(&settings.database)
-            .connection()
-            .unwrap();
+        let settings = test_db::get_test_db_settings("omsupply-database-translation-upsert");
+        let connection_manager = test_db::setup(&settings).await;
+        let connection = connection_manager.connection().unwrap();
 
         let mut init_records = Vec::new();
         init_records.append(&mut get_test_name_records());

--- a/service/src/permission_validation.rs
+++ b/service/src/permission_validation.rs
@@ -416,11 +416,11 @@ mod permission_validation_test {
         }
 
         fn store() -> StoreRow {
-            StoreRow {
-                id: "store".to_string(),
-                name_id: name().id,
-                code: "n/a".to_string(),
-            }
+            inline_init(|s: &mut StoreRow| {
+                s.id = "store".to_string();
+                s.name_id = name().id;
+                s.code = "n/a".to_string();
+            })
         }
 
         fn user() -> UserAccountRow {

--- a/service/src/user_account.rs
+++ b/service/src/user_account.rs
@@ -186,7 +186,6 @@ impl<'a> UserAccountService<'a> {
 #[cfg(test)]
 mod user_account_test {
     use repository::{
-        get_storage_connection_manager,
         mock::{mock_user_account_a, mock_user_account_b, MockDataInserts},
         schema::user_permission::{Permission, Resource},
         test_db::{self, setup_all},
@@ -201,8 +200,7 @@ mod user_account_test {
     #[actix_rt::test]
     async fn test_user_auth() {
         let settings = test_db::get_test_db_settings("omsupply-database-user-account-service");
-        test_db::setup(&settings).await;
-        let connection_manager = get_storage_connection_manager(&settings);
+        let connection_manager = test_db::setup(&settings).await;
         let connection = connection_manager.connection().unwrap();
 
         let service = UserAccountService::new(&connection);


### PR DESCRIPTION
Adds a new feature to run test "in memory"

Some results for the test runtime:
postgres: 1m39.591s, 1m52.946s
sqlite: 1m28.498s, 1m23.752s
memory: 18.924s, 18.539s
