### PR TITLE
Remove hard coded template keys and use a template index map instead

### DIFF
--- a/service/src/report/dummy_reports.rs
+++ b/service/src/report/dummy_reports.rs
@@ -6,7 +6,7 @@ use repository::{
 };
 
 use super::definition::{
-    DefaultQuery, ReportDefinition, ReportDefinitionEntry, ReportOutputType, TeraTemplate,
+    DefaultQuery, ReportDefinition, ReportDefinitionEntry, ReportOutputType, TeraTemplate, ReportDefinitionIndex,
 };
 
 pub struct DummyReport {
@@ -18,35 +18,41 @@ pub struct DummyReport {
 
 pub fn invoice_report() -> DummyReport {
     let report = ReportDefinition {
-    entries: HashMap::from([
-        (
-            "template".to_string(),
-            ReportDefinitionEntry::TeraTemplate(TeraTemplate {
-                output: ReportOutputType::Html,
-                template: "Dummy invoice template, invoice id: {{data.invoice.id}}"
-                    .to_string(),
-            }),
-        ),
-        (
-            "template_header".to_string(),
-            ReportDefinitionEntry::TeraTemplate(TeraTemplate {
-                output: ReportOutputType::Html,
-                template: r#"<div style="font-size: 10px; padding-top: 8px; text-align: center; width: 100%;"><span>Some header here.</div>"#.to_string(),
-            }),
-        ),
-        (
-            "template_footer".to_string(),
-            ReportDefinitionEntry::TeraTemplate(TeraTemplate {
-                output: ReportOutputType::Html,
-                template: r#"<div style="font-size: 10px; padding-top: 8px; text-align: center; width: 100%;"><span>Some footer here.</div>"#.to_string(),
-            }),
-        ),
-        (
-            "query".to_string(),
-            ReportDefinitionEntry::DefaultQuery(DefaultQuery::Invoice),
-        ),
-    ]),
-  };
+        index: ReportDefinitionIndex {
+            template: Some("template.html".to_string()),
+            header: Some("template_header.html".to_string()),
+            footer: Some("template_footer.html".to_string()),
+            query: Some("query".to_string()),
+        },
+        entries: HashMap::from([
+            (
+                "template.html".to_string(),
+                ReportDefinitionEntry::TeraTemplate(TeraTemplate {
+                    output: ReportOutputType::Html,
+                    template: "Dummy invoice template, invoice id: {{data.invoice.id}}"
+                        .to_string(),
+                }),
+            ),
+            (
+                "template_header.html".to_string(),
+                ReportDefinitionEntry::TeraTemplate(TeraTemplate {
+                    output: ReportOutputType::Html,
+                    template: r#"<div style="font-size: 10px; padding-top: 8px; text-align: center; width: 100%;"><span>Some header here.</div>"#.to_string(),
+                }),
+            ),
+            (
+                "template_footer.html".to_string(),
+                ReportDefinitionEntry::TeraTemplate(TeraTemplate {
+                    output: ReportOutputType::Html,
+                    template: r#"<div style="font-size: 10px; padding-top: 8px; text-align: center; width: 100%;"><span>Some footer here.</div>"#.to_string(),
+                }),
+            ),
+            (
+                "query".to_string(),
+                ReportDefinitionEntry::DefaultQuery(DefaultQuery::Invoice),
+            ),
+        ]),    
+    };
     DummyReport {
         id: "dummy_report_invoice".to_string(),
         name: "Dummy invoice report".to_string(),
@@ -57,35 +63,41 @@ pub fn invoice_report() -> DummyReport {
 
 pub fn stocktake_report() -> DummyReport {
     let report = ReportDefinition {
-  entries: HashMap::from([
-      (
-          "template".to_string(),
-          ReportDefinitionEntry::TeraTemplate(TeraTemplate {
-              output: ReportOutputType::Html,
-              template: "Dummy stocktake template, stocktake id: {{data.stocktake.id}}"
-                  .to_string(),
-          }),
-      ),
-      (
-          "template_header".to_string(),
-          ReportDefinitionEntry::TeraTemplate(TeraTemplate {
-              output: ReportOutputType::Html,
-              template: r#"<div style="font-size: 10px; padding-top: 8px; text-align: center; width: 100%;"><span>Some header here.</div>"#.to_string(),
-          }),
-      ),
-      (
-          "template_footer".to_string(),
-          ReportDefinitionEntry::TeraTemplate(TeraTemplate {
-              output: ReportOutputType::Html,
-              template: r#"<div style="font-size: 10px; padding-top: 8px; text-align: center; width: 100%;"><span>Some footer here.</div>"#.to_string(),
-          }),
-      ),
-      (
-          "query".to_string(),
-          ReportDefinitionEntry::DefaultQuery(DefaultQuery::Stocktake),
-      ),
-  ]),
-};
+        index: ReportDefinitionIndex {
+            template: Some("template.html".to_string()),
+            header: Some("template_header.html".to_string()),
+            footer: Some("template_footer.html".to_string()),
+            query: Some("query".to_string()),
+        },
+        entries: HashMap::from([
+            (
+                "template.html".to_string(),
+                ReportDefinitionEntry::TeraTemplate(TeraTemplate {
+                    output: ReportOutputType::Html,
+                    template: "Dummy stocktake template, stocktake id: {{data.stocktake.id}}"
+                        .to_string(),
+                }),
+            ),
+            (
+                "template_header.html".to_string(),
+                ReportDefinitionEntry::TeraTemplate(TeraTemplate {
+                    output: ReportOutputType::Html,
+                    template: r#"<div style="font-size: 10px; padding-top: 8px; text-align: center; width: 100%;"><span>Some header here.</div>"#.to_string(),
+                }),
+            ),
+            (
+                "template_footer.html".to_string(),
+                ReportDefinitionEntry::TeraTemplate(TeraTemplate {
+                    output: ReportOutputType::Html,
+                    template: r#"<div style="font-size: 10px; padding-top: 8px; text-align: center; width: 100%;"><span>Some footer here.</div>"#.to_string(),
+                }),
+            ),
+            (
+                "query".to_string(),
+                ReportDefinitionEntry::DefaultQuery(DefaultQuery::Stocktake),
+            ),
+        ]),
+    };
     DummyReport {
         id: "dummy_report_stocktake".to_string(),
         name: "Dummy stocktake report".to_string(),
@@ -96,35 +108,41 @@ pub fn stocktake_report() -> DummyReport {
 
 pub fn requisition_report() -> DummyReport {
     let report = ReportDefinition {
-  entries: HashMap::from([
-      (
-          "template".to_string(),
-          ReportDefinitionEntry::TeraTemplate(TeraTemplate {
-              output: ReportOutputType::Html,
-              template: "Dummy requisition template, requisition id: {{data.requisition.id}}"
-                  .to_string(),
-          }),
-      ),
-      (
-          "template_header".to_string(),
-          ReportDefinitionEntry::TeraTemplate(TeraTemplate {
-              output: ReportOutputType::Html,
-              template: r#"<div style="font-size: 10px; padding-top: 8px; text-align: center; width: 100%;"><span>Some header here.</div>"#.to_string(),
-          }),
-      ),
-      (
-          "template_footer".to_string(),
-          ReportDefinitionEntry::TeraTemplate(TeraTemplate {
-              output: ReportOutputType::Html,
-              template: r#"<div style="font-size: 10px; padding-top: 8px; text-align: center; width: 100%;"><span>Some footer here.</div>"#.to_string(),
-          }),
-      ),
-      (
-          "query".to_string(),
-          ReportDefinitionEntry::DefaultQuery(DefaultQuery::Requisition),
-      ),
-  ]),
-};
+        index: ReportDefinitionIndex {
+            template: Some("template.html".to_string()),
+            header: Some("template_header.html".to_string()),
+            footer: Some("template_footer.html".to_string()),
+            query: Some("query".to_string()),
+        },
+        entries: HashMap::from([
+            (
+                "template.html".to_string(),
+                ReportDefinitionEntry::TeraTemplate(TeraTemplate {
+                    output: ReportOutputType::Html,
+                    template: "Dummy requisition template, requisition id: {{data.requisition.id}}"
+                        .to_string(),
+                }),
+            ),
+            (
+                "template_header.html".to_string(),
+                ReportDefinitionEntry::TeraTemplate(TeraTemplate {
+                    output: ReportOutputType::Html,
+                    template: r#"<div style="font-size: 10px; padding-top: 8px; text-align: center; width: 100%;"><span>Some header here.</div>"#.to_string(),
+                }),
+            ),
+            (
+                "template_footer.html".to_string(),
+                ReportDefinitionEntry::TeraTemplate(TeraTemplate {
+                    output: ReportOutputType::Html,
+                    template: r#"<div style="font-size: 10px; padding-top: 8px; text-align: center; width: 100%;"><span>Some footer here.</div>"#.to_string(),
+                }),
+            ),
+            (
+                "query".to_string(),
+                ReportDefinitionEntry::DefaultQuery(DefaultQuery::Requisition),
+            ),
+        ]),
+    };
     DummyReport {
         id: "dummy_report_requisition".to_string(),
         name: "Dummy requisition report".to_string(),


### PR DESCRIPTION
Add an index to the report definition to make it clearer what entry in the definition file should be used for which purpose.

#887 