### PR TITLE
1079 remove automatic filter of name belonging to current store

### DIFF
--- a/graphql/general/src/lib.rs
+++ b/graphql/general/src/lib.rs
@@ -61,6 +61,15 @@ impl GeneralQueries {
         get_names(ctx, store_id, page, filter, sort)
     }
 
+    pub async fn store(
+        &self,
+        ctx: &Context<'_>,
+        store_id: String,
+        id: String,
+    ) -> Result<StoreResponse> {
+        get_store(ctx, &store_id, &id)
+    }
+
     pub async fn stores(
         &self,
         ctx: &Context<'_>,

--- a/graphql/general/src/lib.rs
+++ b/graphql/general/src/lib.rs
@@ -61,13 +61,8 @@ impl GeneralQueries {
         get_names(ctx, store_id, page, filter, sort)
     }
 
-    pub async fn store(
-        &self,
-        ctx: &Context<'_>,
-        store_id: String,
-        id: String,
-    ) -> Result<StoreResponse> {
-        get_store(ctx, &store_id, &id)
+    pub async fn store(&self, ctx: &Context<'_>, id: String) -> Result<StoreResponse> {
+        get_store(ctx, &id)
     }
 
     pub async fn stores(

--- a/graphql/general/src/queries/store.rs
+++ b/graphql/general/src/queries/store.rs
@@ -54,12 +54,12 @@ pub enum StoresResponse {
     Response(StoreConnector),
 }
 
-pub fn get_store(ctx: &Context<'_>, store_id: &str, id: &str) -> Result<StoreResponse> {
+pub fn get_store(ctx: &Context<'_>, id: &str) -> Result<StoreResponse> {
     validate_auth(
         ctx,
         &ResourceAccessRequest {
             resource: Resource::QueryStore,
-            store_id: Some(store_id.to_string()),
+            store_id: None,
         },
     )?;
 
@@ -207,8 +207,8 @@ mod graphql {
         .await;
 
         let query = r#"
-            query TestQuery($recordId: String!, $storeId: String!) {
-                store(id: $recordId, storeId: $storeId) {
+            query TestQuery($id: String!) {
+                store(id: $id) {
                     ... on NodeError {
                         error {
                         __typename
@@ -222,8 +222,7 @@ mod graphql {
         "#;
 
         let variables = Some(json!({
-            "recordId": "record_id",
-            "storeId": "store_id"
+            "id": "store_id"
         }));
 
         // Test error mapping
@@ -249,7 +248,7 @@ mod graphql {
         // Test ok mapping
         let test_service = TestService(Box::new(|filter| {
             assert_eq!(
-                StoreFilter::new().id(EqualFilter::equal_to("record_id")),
+                StoreFilter::new().id(EqualFilter::equal_to("store_id")),
                 filter
             );
 

--- a/graphql/general/src/queries/store.rs
+++ b/graphql/general/src/queries/store.rs
@@ -58,7 +58,7 @@ pub fn get_store(ctx: &Context<'_>, store_id: &str, id: &str) -> Result<StoreRes
     validate_auth(
         ctx,
         &ResourceAccessRequest {
-            resource: Resource::QueryInvoice,
+            resource: Resource::QueryStore,
             store_id: Some(store_id.to_string()),
         },
     )?;

--- a/graphql/tests/permissions.rs
+++ b/graphql/tests/permissions.rs
@@ -392,6 +392,22 @@ mod permission_tests {
                     store_id: None,
                 },
             },
+            TestData {
+                name: "stores",
+                query: r#"query Query {
+              stores {
+                ... on StoreConnector {
+                  nodes {
+                    id
+                  }
+                }
+              }
+            }"#,
+                expected: ResourceAccessRequest {
+                    resource: Resource::QueryStore,
+                    store_id: None,
+                },
+            },
         ]
     }
 

--- a/graphql/types/src/types/store.rs
+++ b/graphql/types/src/types/store.rs
@@ -23,6 +23,10 @@ impl StoreNode {
         &self.row().code
     }
 
+    pub async fn store_name(&self) -> &str {
+        &self.store.name_row.name
+    }
+
     pub async fn name(&self, ctx: &Context<'_>, store_id: String) -> Result<NameNode> {
         let loader = ctx.get_loader::<DataLoader<NameByIdLoader>>();
 
@@ -52,5 +56,92 @@ impl StoreNode {
 
     pub fn row(&self) -> &StoreRow {
         &self.store.store_row
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use async_graphql::{EmptyMutation, Object};
+    use graphql_core::{assert_graphql_query, test_helpers::setup_graphl_test_with_data};
+    use repository::{
+        mock::{MockData, MockDataInserts},
+        NameRow, Store, StoreRow,
+    };
+    use serde_json::json;
+    use util::inline_init;
+
+    use crate::types::StoreNode;
+
+    #[actix_rt::test]
+    async fn graphql_test_store_loader() {
+        #[derive(Clone)]
+        struct TestQuery;
+
+        fn name() -> NameRow {
+            inline_init(|r: &mut NameRow| {
+                r.id = "name_id".to_string();
+                r.name = "name".to_string()
+            })
+        }
+
+        fn store() -> StoreRow {
+            inline_init(|r: &mut StoreRow| {
+                r.id = "store".to_string();
+                r.name_id = name().id
+            })
+        }
+
+        let (_, _, _, settings) = setup_graphl_test_with_data(
+            TestQuery,
+            EmptyMutation,
+            "graphql_test_store_loader",
+            MockDataInserts::none(),
+            inline_init(|r: &mut MockData| {
+                r.stores = vec![store()];
+                r.names = vec![name()];
+            }),
+        )
+        .await;
+
+        #[Object]
+        impl TestQuery {
+            pub async fn test_query(&self) -> StoreNode {
+                StoreNode {
+                    store: Store {
+                        store_row: store(),
+                        name_row: name(),
+                    },
+                }
+            }
+        }
+
+        let expected = json!({
+            "testQuery": {
+                "__typename": "StoreNode",
+                "storeName": name().name,
+                "name": {
+                    "id": name().id
+                }
+            }
+        }
+        );
+
+        let query = r#"
+        query($storeId: String) {
+            testQuery {
+                __typename
+                storeName
+                name(storeId: $storeId) {
+                    id
+                }
+            }
+        }
+        "#;
+
+        let variables = json!({
+            "storeId": store().id
+        });
+
+        assert_graphql_query!(&settings, &query, &Some(variables), expected, None);
     }
 }

--- a/repository/src/db_diesel/name.rs
+++ b/repository/src/db_diesel/name.rs
@@ -197,9 +197,6 @@ fn create_filtered_query(store_id: String, filter: Option<NameFilter>) -> BoxedN
             Some(false) => query.filter(store_dsl::id.is_null()),
             None => query,
         };
-
-        // Filter out name for current store
-        query = query.filter(store_dsl::id.ne(store_id).or(store_dsl::id.is_null()));
     };
 
     query
@@ -482,27 +479,6 @@ mod tests {
 
         let store_id = &mock_test_name_query_store_1().id;
         // test filter:
-
-        // Name should be filtered out from it's own store
-
-        let result = repo
-            .query_by_filter(
-                store_id,
-                NameFilter::new().name(SimpleStringFilter::equal_to("name_1")),
-            )
-            .unwrap();
-        assert_eq!(result.len(), 0);
-
-        // Name should be filtered out from it's own store
-
-        let result = repo
-            .query_by_filter(
-                &mock_test_name_query_store_2().id,
-                NameFilter::new().name(SimpleStringFilter::equal_to("name_1")),
-            )
-            .unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result.get(0).unwrap().name_row.name, "name_1");
 
         // Two matched, name_2 and name_3
 

--- a/repository/src/db_diesel/store.rs
+++ b/repository/src/db_diesel/store.rs
@@ -18,7 +18,7 @@ pub struct Store {
     pub name_row: NameRow,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct StoreFilter {
     pub id: Option<EqualFilter<String>>,
     pub code: Option<SimpleStringFilter>,

--- a/service/src/report/default_queries.rs
+++ b/service/src/report/default_queries.rs
@@ -101,10 +101,28 @@ query InvoiceQuery($storeId: String, $dataId: String) {
         }
       }
     }
-    ... on NodeError {
-      __typename
-      error {
-        description
+    store(id: $storeId) {
+      ... on StoreNode {
+        id
+        name(storeId: $storeId) {
+          address
+          chargeCode
+          code
+          comment
+          country
+          email
+          name
+          phone
+          website
+        }
+        code
+        storeName
+      }
+      ... on NodeError {
+        __typename
+        error {
+          description
+        }
       }
     }
   }
@@ -165,6 +183,30 @@ const STOCKTAKE_QUERY: &str = r#"query StocktakeQuery($storeId: String, $dataId:
           snapshotNumberOfPacks
           stocktakeId
         }
+      }
+    }
+  }
+  store(id: $storeId) {
+    ... on StoreNode {
+      id
+      name(storeId: $storeId) {
+        address
+        chargeCode
+        code
+        comment
+        country
+        email
+        name
+        phone
+        website
+      }
+      code
+      storeName
+    }
+    ... on NodeError {
+      __typename
+      error {
+        description
       }
     }
   }
@@ -231,6 +273,30 @@ const REQUISITION_QUERY: &str = r#"query RequisitionQuery($storeId: String, $dat
     ... on RecordNotFound {
       __typename
       description
+    }
+  }
+  store(id: $storeId) {
+    ... on StoreNode {
+      id
+      name(storeId: $storeId) {
+        address
+        chargeCode
+        code
+        comment
+        country
+        email
+        name
+        phone
+        website
+      }
+      code
+      storeName
+    }
+    ... on NodeError {
+      __typename
+      error {
+        description
+      }
     }
   }
 }"#;

--- a/service/src/service_provider.rs
+++ b/service/src/service_provider.rs
@@ -107,8 +107,12 @@ pub trait GeneralServiceTrait: Sync + Send {
         get_stores(ctx, pagination, filter, sort)
     }
 
-    fn get_store(&self, ctx: &ServiceContext, id: &str) -> Result<Option<Store>, RepositoryError> {
-        get_store(ctx, id)
+    fn get_store(
+        &self,
+        ctx: &ServiceContext,
+        filter: StoreFilter,
+    ) -> Result<Option<Store>, RepositoryError> {
+        get_store(ctx, filter)
     }
 }
 

--- a/service/src/service_provider.rs
+++ b/service/src/service_provider.rs
@@ -20,7 +20,7 @@ use crate::{
     requisition_line::{RequisitionLineService, RequisitionLineServiceTrait},
     stocktake::{StocktakeService, StocktakeServiceTrait},
     stocktake_line::{StocktakeLineService, StocktakeLineServiceTrait},
-    store::get_stores,
+    store::{get_store, get_stores},
     ListError, ListResult,
 };
 
@@ -105,6 +105,10 @@ pub trait GeneralServiceTrait: Sync + Send {
         sort: Option<StoreSort>,
     ) -> Result<ListResult<Store>, ListError> {
         get_stores(ctx, pagination, filter, sort)
+    }
+
+    fn get_store(&self, ctx: &ServiceContext, id: &str) -> Result<Option<Store>, RepositoryError> {
+        get_store(ctx, id)
     }
 }
 

--- a/service/src/store.rs
+++ b/service/src/store.rs
@@ -1,4 +1,4 @@
-use repository::{EqualFilter, RepositoryError, Store, PaginationOption};
+use repository::{PaginationOption, RepositoryError, Store};
 use repository::{StoreFilter, StoreRepository, StoreSort};
 
 use crate::{
@@ -20,9 +20,11 @@ pub fn get_stores(
     })
 }
 
-pub fn get_store(ctx: &ServiceContext, id: &str) -> Result<Option<Store>, RepositoryError> {
-    let mut result = StoreRepository::new(&ctx.connection)
-        .query_by_filter(StoreFilter::new().id(EqualFilter::equal_to(id)))?;
+pub fn get_store(
+    ctx: &ServiceContext,
+    filter: StoreFilter,
+) -> Result<Option<Store>, RepositoryError> {
+    let mut result = StoreRepository::new(&ctx.connection).query_by_filter(filter)?;
 
     Ok(result.pop())
 }

--- a/service/src/store.rs
+++ b/service/src/store.rs
@@ -1,4 +1,4 @@
-use repository::{PaginationOption, Store};
+use repository::{EqualFilter, RepositoryError, Store, PaginationOption};
 use repository::{StoreFilter, StoreRepository, StoreSort};
 
 use crate::{
@@ -18,4 +18,11 @@ pub fn get_stores(
         rows: repository.query(pagination, filter.clone(), sort)?,
         count: i64_to_u32(repository.count(filter)?),
     })
+}
+
+pub fn get_store(ctx: &ServiceContext, id: &str) -> Result<Option<Store>, RepositoryError> {
+    let mut result = StoreRepository::new(&ctx.connection)
+        .query_by_filter(StoreFilter::new().id(EqualFilter::equal_to(id)))?;
+
+    Ok(result.pop())
 }


### PR DESCRIPTION
closes #1079 

Also added store query, original requirement for this was for reports to be able to get current store name, thus additions of store query.

(I think we can quite easily use `StoreNode` in `me` query now, I didn't want to go too far out of scope of the issue)