### PR TITLE
#867 make sure all basic fields are exposed in query filters and sorts for all types

### DIFF
--- a/graphql/general/src/queries/item.rs
+++ b/graphql/general/src/queries/item.rs
@@ -20,6 +20,7 @@ use service::{
 pub enum ItemSortFieldInput {
     Name,
     Code,
+    Type,
 }
 
 #[derive(InputObject)]
@@ -108,6 +109,7 @@ impl ItemSortInput {
         let key = match self.key {
             from::Name => to::Name,
             from::Code => to::Code,
+            from::Type => to::Type,
         };
 
         ItemSort {

--- a/graphql/invoice/src/invoice_queries.rs
+++ b/graphql/invoice/src/invoice_queries.rs
@@ -42,6 +42,8 @@ pub enum InvoiceSortFieldInput {
     ShippedDatetime,
     DeliveredDatetime,
     VerifiedDatetime,
+    TheirReference,
+    TransportReference,
 }
 
 #[derive(InputObject)]
@@ -70,20 +72,25 @@ pub struct EqualFilterInvoiceStatusInput {
 #[derive(InputObject, Clone)]
 pub struct InvoiceFilterInput {
     pub id: Option<EqualFilterStringInput>,
+    pub name_id: Option<EqualFilterStringInput>,
     pub invoice_number: Option<EqualFilterBigNumberInput>,
     pub other_party_name: Option<SimpleStringFilterInput>,
     pub other_party_id: Option<EqualFilterStringInput>,
     pub store_id: Option<EqualFilterStringInput>,
+    pub user_id: Option<EqualFilterStringInput>,
     pub r#type: Option<EqualFilterInvoiceTypeInput>,
     pub status: Option<EqualFilterInvoiceStatusInput>,
+    pub on_hold: Option<bool>,
     pub comment: Option<SimpleStringFilterInput>,
     pub their_reference: Option<EqualFilterStringInput>,
+    pub transport_reference: Option<EqualFilterStringInput>,
     pub created_datetime: Option<DatetimeFilterInput>,
     pub allocated_datetime: Option<DatetimeFilterInput>,
     pub picked_datetime: Option<DatetimeFilterInput>,
     pub shipped_datetime: Option<DatetimeFilterInput>,
     pub delivered_datetime: Option<DatetimeFilterInput>,
     pub verified_datetime: Option<DatetimeFilterInput>,
+    pub colour: Option<EqualFilterStringInput>,
     pub requisition_id: Option<EqualFilterStringInput>,
     pub linked_invoice_id: Option<EqualFilterStringInput>,
 }
@@ -196,20 +203,24 @@ impl InvoiceFilterInput {
             name_id: self.other_party_id.map(EqualFilter::from),
             name: self.other_party_name.map(SimpleStringFilter::from),
             store_id: self.store_id.map(EqualFilter::from),
+            user_id: self.user_id.map(EqualFilter::from),
             r#type: self
                 .r#type
                 .map(|t| map_filter!(t, InvoiceNodeType::to_domain)),
             status: self
                 .status
                 .map(|t| map_filter!(t, InvoiceNodeStatus::to_domain)),
+            on_hold: self.on_hold,
             comment: self.comment.map(SimpleStringFilter::from),
             their_reference: self.their_reference.map(EqualFilter::from),
+            transport_reference: self.transport_reference.map(EqualFilter::from),
             created_datetime: self.created_datetime.map(DatetimeFilter::from),
             allocated_datetime: self.allocated_datetime.map(DatetimeFilter::from),
             picked_datetime: self.picked_datetime.map(DatetimeFilter::from),
             shipped_datetime: self.shipped_datetime.map(DatetimeFilter::from),
             delivered_datetime: self.delivered_datetime.map(DatetimeFilter::from),
             verified_datetime: self.verified_datetime.map(DatetimeFilter::from),
+            colour: self.colour.map(EqualFilter::from),
             requisition_id: self.requisition_id.map(EqualFilter::from),
             linked_invoice_id: self.linked_invoice_id.map(EqualFilter::from),
         }
@@ -232,6 +243,8 @@ impl InvoiceSortInput {
             from::ShippedDatetime => to::ShippedDatetime,
             from::DeliveredDatetime => to::DeliveredDatetime,
             from::VerifiedDatetime => to::VerifiedDatetime,
+            from::TheirReference => to::TheirReference,
+            from::TransportReference => to::TransportReference,
         };
 
         InvoiceSort {

--- a/graphql/requisition/src/query_tests/requisition.rs
+++ b/graphql/requisition/src/query_tests/requisition.rs
@@ -7,7 +7,7 @@ mod graphql {
     use repository::{
         mock::{mock_name_a, mock_request_draft_requisition_all_fields, MockDataInserts},
         requisition_row::{RequisitionRowStatus, RequisitionRowType},
-        Requisition, RequisitionFilter, RequisitionSort, RequisitionSortField,
+        DateFilter, Requisition, RequisitionFilter, RequisitionSort, RequisitionSortField,
         StorageConnectionManager,
     };
     use repository::{DatetimeFilter, EqualFilter, PaginationOption, SimpleStringFilter};
@@ -103,6 +103,9 @@ mod graphql {
             "id": {
                 "notEqualTo": "id_not_equal_to"
             },
+            "userId": {
+                "notEqualTo": "user_id_not_equal_to"
+            },
             "requisitionNumber": {
                 "equalTo": 20
             },
@@ -120,6 +123,9 @@ mod graphql {
             },
             "finalisedDatetime": {
                 "beforeOrEqualTo": "2021-01-03T00:00:00+00:00"
+            },
+            "expectedDeliveryDate": {
+                "afterOrEqualTo": "2021-01-04"
             },
             "otherPartyName": {
                 "like": "like_other_party_name"
@@ -166,12 +172,14 @@ mod graphql {
             );
             let RequisitionFilter {
                 id,
+                user_id,
                 requisition_number,
                 r#type,
                 status,
                 created_datetime,
                 sent_datetime,
                 finalised_datetime,
+                expected_delivery_date,
                 name,
                 name_id,
                 colour,
@@ -182,6 +190,10 @@ mod graphql {
             } = filter.unwrap();
 
             assert_eq!(id, Some(EqualFilter::not_equal_to("id_not_equal_to")));
+            assert_eq!(
+                user_id,
+                Some(EqualFilter::not_equal_to("user_id_not_equal_to"))
+            );
             assert_eq!(requisition_number, Some(EqualFilter::equal_to_i64(20)));
             assert_eq!(r#type, Some(RequisitionRowType::Request.equal_to()));
             assert_eq!(status, Some(RequisitionRowStatus::Draft.equal_to()));
@@ -202,6 +214,12 @@ mod graphql {
                 Some(DatetimeFilter::before_or_equal_to(
                     NaiveDate::from_ymd(2021, 01, 03).and_hms(0, 0, 0)
                 ))
+            );
+            assert_eq!(
+                expected_delivery_date,
+                Some(DateFilter::after_or_equal_to(NaiveDate::from_ymd(
+                    2021, 01, 04
+                )))
             );
             assert_eq!(
                 name,

--- a/graphql/requisition/src/query_tests/requisitions.rs
+++ b/graphql/requisition/src/query_tests/requisitions.rs
@@ -7,7 +7,7 @@ mod graphql {
     use repository::{
         mock::{mock_name_a, mock_request_draft_requisition_all_fields, MockDataInserts},
         requisition_row::{RequisitionRowStatus, RequisitionRowType},
-        Requisition, RequisitionFilter, RequisitionSort, RequisitionSortField,
+        DateFilter, Requisition, RequisitionFilter, RequisitionSort, RequisitionSortField,
         StorageConnectionManager,
     };
     use repository::{DatetimeFilter, EqualFilter, PaginationOption, SimpleStringFilter};
@@ -102,6 +102,9 @@ mod graphql {
             "id": {
                 "notEqualTo": "id_not_equal_to"
             },
+            "userId": {
+                "notEqualTo": "user_id_not_equal_to"
+            },
             "requisitionNumber": {
                 "equalTo": 20
             },
@@ -119,6 +122,9 @@ mod graphql {
             },
             "finalisedDatetime": {
                 "beforeOrEqualTo": "2021-01-03T00:00:00+00:00"
+            },
+            "expectedDeliveryDate": {
+                "afterOrEqualTo": "2021-01-04"
             },
             "otherPartyName": {
                 "like": "like_other_party_name"
@@ -165,12 +171,14 @@ mod graphql {
             );
             let RequisitionFilter {
                 id,
+                user_id,
                 requisition_number,
                 r#type,
                 status,
                 created_datetime,
                 sent_datetime,
                 finalised_datetime,
+                expected_delivery_date,
                 name,
                 name_id,
                 colour,
@@ -181,6 +189,10 @@ mod graphql {
             } = filter.unwrap();
 
             assert_eq!(id, Some(EqualFilter::not_equal_to("id_not_equal_to")));
+            assert_eq!(
+                user_id,
+                Some(EqualFilter::not_equal_to("user_id_not_equal_to"))
+            );
             assert_eq!(requisition_number, Some(EqualFilter::equal_to_i64(20)));
             assert_eq!(r#type, Some(RequisitionRowType::Request.equal_to()));
             assert_eq!(status, Some(RequisitionRowStatus::Draft.equal_to()));
@@ -201,6 +213,12 @@ mod graphql {
                 Some(DatetimeFilter::before_or_equal_to(
                     NaiveDate::from_ymd(2021, 01, 03).and_hms(0, 0, 0)
                 ))
+            );
+            assert_eq!(
+                expected_delivery_date,
+                Some(DateFilter::after_or_equal_to(NaiveDate::from_ymd(
+                    2021, 01, 04
+                )))
             );
             assert_eq!(
                 name,

--- a/graphql/requisition/src/requisition_queries.rs
+++ b/graphql/requisition/src/requisition_queries.rs
@@ -1,7 +1,7 @@
 use async_graphql::*;
 use graphql_core::{
     generic_filters::{
-        DatetimeFilterInput, EqualFilterBigNumberInput, EqualFilterStringInput,
+        DateFilterInput, DatetimeFilterInput, EqualFilterBigNumberInput, EqualFilterStringInput,
         SimpleStringFilterInput,
     },
     map_filter,
@@ -13,7 +13,7 @@ use graphql_core::{
 use graphql_types::types::{
     RequisitionConnector, RequisitionNode, RequisitionNodeStatus, RequisitionNodeType,
 };
-use repository::{DatetimeFilter, EqualFilter, PaginationOption, SimpleStringFilter};
+use repository::{DateFilter, DatetimeFilter, EqualFilter, PaginationOption, SimpleStringFilter};
 use repository::{RequisitionFilter, RequisitionSort, RequisitionSortField};
 use service::permission_validation::{Resource, ResourceAccessRequest};
 
@@ -28,6 +28,8 @@ pub enum RequisitionSortFieldInput {
     SentDatetime,
     CreatedDatetime,
     FinalisedDatetime,
+    ExpectedDeliveryDate,
+    TheirReference,
 }
 
 #[derive(InputObject)]
@@ -56,12 +58,14 @@ pub struct EqualFilterRequisitionStatusInput {
 #[derive(InputObject, Clone)]
 pub struct RequisitionFilterInput {
     pub id: Option<EqualFilterStringInput>,
+    pub user_id: Option<EqualFilterStringInput>,
     pub requisition_number: Option<EqualFilterBigNumberInput>,
     pub r#type: Option<EqualFilterRequisitionTypeInput>,
     pub status: Option<EqualFilterRequisitionStatusInput>,
     pub created_datetime: Option<DatetimeFilterInput>,
     pub sent_datetime: Option<DatetimeFilterInput>,
     pub finalised_datetime: Option<DatetimeFilterInput>,
+    pub expected_delivery_date: Option<DateFilterInput>,
     pub other_party_name: Option<SimpleStringFilterInput>,
     pub other_party_id: Option<EqualFilterStringInput>,
     pub colour: Option<EqualFilterStringInput>,
@@ -193,6 +197,8 @@ impl RequisitionSortInput {
             from::SentDatetime => to::SentDatetime,
             from::CreatedDatetime => to::CreatedDatetime,
             from::FinalisedDatetime => to::FinalisedDatetime,
+            from::ExpectedDeliveryDate => to::ExpectedDeliveryDate,
+            from::TheirReference => to::TheirReference,
         };
 
         RequisitionSort {
@@ -206,6 +212,7 @@ impl RequisitionFilterInput {
     pub fn to_domain(self) -> RequisitionFilter {
         RequisitionFilter {
             id: self.id.map(EqualFilter::from),
+            user_id: self.user_id.map(EqualFilter::from),
             requisition_number: self.requisition_number.map(EqualFilter::from),
             r#type: self
                 .r#type
@@ -216,6 +223,7 @@ impl RequisitionFilterInput {
             created_datetime: self.created_datetime.map(DatetimeFilter::from),
             sent_datetime: self.sent_datetime.map(DatetimeFilter::from),
             finalised_datetime: self.finalised_datetime.map(DatetimeFilter::from),
+            expected_delivery_date: self.expected_delivery_date.map(DateFilter::from),
             name: self.other_party_name.map(SimpleStringFilter::from),
             name_id: self.other_party_id.map(EqualFilter::from),
             colour: self.colour.map(EqualFilter::from),

--- a/graphql/types/src/types/location.rs
+++ b/graphql/types/src/types/location.rs
@@ -28,6 +28,7 @@ pub struct LocationSortInput {
 pub struct LocationFilterInput {
     pub name: Option<EqualFilterStringInput>,
     pub code: Option<EqualFilterStringInput>,
+    pub on_hold: Option<bool>,
     pub id: Option<EqualFilterStringInput>,
 }
 
@@ -38,6 +39,7 @@ impl From<LocationFilterInput> for LocationFilter {
             code: f.code.map(EqualFilter::from),
             id: f.id.map(EqualFilter::from),
             store_id: None,
+            on_hold: f.on_hold,
         }
     }
 }

--- a/repository/src/db_diesel/invoice.rs
+++ b/repository/src/db_diesel/invoice.rs
@@ -384,6 +384,21 @@ impl InvoiceFilter {
         self.store_id = Some(filter);
         self
     }
+
+    pub fn name_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.name_id = Some(filter);
+        self
+    }
+
+    pub fn name(mut self, filter: SimpleStringFilter) -> Self {
+        self.name = Some(filter);
+        self
+    }
+
+    pub fn their_reference(mut self, filter: EqualFilter<String>) -> Self {
+        self.their_reference = Some(filter);
+        self
+    }
 }
 
 impl InvoiceRowStatus {

--- a/repository/src/db_diesel/invoice.rs
+++ b/repository/src/db_diesel/invoice.rs
@@ -31,16 +31,20 @@ pub struct InvoiceFilter {
     pub name_id: Option<EqualFilter<String>>,
     pub name: Option<SimpleStringFilter>,
     pub store_id: Option<EqualFilter<String>>,
+    pub user_id: Option<EqualFilter<String>>,
     pub r#type: Option<EqualFilter<InvoiceRowType>>,
     pub status: Option<EqualFilter<InvoiceRowStatus>>,
+    pub on_hold: Option<bool>,
     pub comment: Option<SimpleStringFilter>,
     pub their_reference: Option<EqualFilter<String>>,
+    pub transport_reference: Option<EqualFilter<String>>,
     pub created_datetime: Option<DatetimeFilter>,
     pub allocated_datetime: Option<DatetimeFilter>,
     pub picked_datetime: Option<DatetimeFilter>,
     pub shipped_datetime: Option<DatetimeFilter>,
     pub delivered_datetime: Option<DatetimeFilter>,
     pub verified_datetime: Option<DatetimeFilter>,
+    pub colour: Option<EqualFilter<String>>,
     pub requisition_id: Option<EqualFilter<String>>,
     pub linked_invoice_id: Option<EqualFilter<String>>,
 }
@@ -57,6 +61,8 @@ pub enum InvoiceSortField {
     ShippedDatetime,
     DeliveredDatetime,
     VerifiedDatetime,
+    TheirReference,
+    TransportReference,
 }
 
 pub type InvoiceSort = Sort<InvoiceSortField>;
@@ -131,6 +137,12 @@ impl<'a> InvoiceRepository<'a> {
                 InvoiceSortField::Comment => {
                     apply_sort_no_case!(query, sort, invoice_dsl::comment);
                 }
+                InvoiceSortField::TheirReference => {
+                    apply_sort_no_case!(query, sort, invoice_dsl::their_reference);
+                }
+                InvoiceSortField::TransportReference => {
+                    apply_sort_no_case!(query, sort, invoice_dsl::transport_reference);
+                }
             }
         } else {
             query = query.order(invoice_dsl::id.asc())
@@ -177,16 +189,20 @@ fn create_filtered_query<'a>(filter: Option<InvoiceFilter>) -> BoxedInvoiceQuery
             name_id,
             name,
             store_id,
+            user_id,
             r#type,
             status,
+            on_hold,
             comment,
             their_reference,
+            transport_reference,
             created_datetime,
             allocated_datetime,
             picked_datetime,
             shipped_datetime,
             delivered_datetime,
             verified_datetime,
+            colour,
             requisition_id,
             linked_invoice_id,
         } = f;
@@ -200,9 +216,16 @@ fn create_filtered_query<'a>(filter: Option<InvoiceFilter>) -> BoxedInvoiceQuery
         apply_equal_filter!(query, requisition_id, invoice_dsl::requisition_id);
         apply_simple_string_filter!(query, comment, invoice_dsl::comment);
         apply_equal_filter!(query, linked_invoice_id, invoice_dsl::linked_invoice_id);
+        apply_equal_filter!(query, user_id, invoice_dsl::user_id);
+        apply_equal_filter!(query, transport_reference, invoice_dsl::transport_reference);
+        apply_equal_filter!(query, colour, invoice_dsl::colour);
 
         apply_equal_filter!(query, r#type, invoice_dsl::type_);
         apply_equal_filter!(query, status, invoice_dsl::status);
+
+        if let Some(value) = on_hold {
+            query = query.filter(invoice_dsl::on_hold.eq(value));
+        }
 
         apply_date_time_filter!(query, created_datetime, invoice_dsl::created_datetime);
         apply_date_time_filter!(query, allocated_datetime, invoice_dsl::allocated_datetime);
@@ -282,6 +305,11 @@ impl InvoiceFilter {
         self
     }
 
+    pub fn user_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.user_id = Some(filter);
+        self
+    }
+
     pub fn r#type(mut self, filter: EqualFilter<InvoiceRowType>) -> Self {
         self.r#type = Some(filter);
         self
@@ -294,6 +322,16 @@ impl InvoiceFilter {
 
     pub fn status(mut self, filter: EqualFilter<InvoiceRowStatus>) -> Self {
         self.status = Some(filter);
+        self
+    }
+
+    pub fn on_hold(mut self, filter: bool) -> Self {
+        self.on_hold = Some(filter);
+        self
+    }
+
+    pub fn transport_reference(mut self, filter: EqualFilter<String>) -> Self {
+        self.transport_reference = Some(filter);
         self
     }
 
@@ -324,6 +362,11 @@ impl InvoiceFilter {
 
     pub fn verified_datetime(mut self, filter: DatetimeFilter) -> Self {
         self.verified_datetime = Some(filter);
+        self
+    }
+
+    pub fn colour(mut self, filter: EqualFilter<String>) -> Self {
+        self.colour = Some(filter);
         self
     }
 

--- a/repository/src/db_diesel/item.rs
+++ b/repository/src/db_diesel/item.rs
@@ -7,7 +7,9 @@ use super::{
 };
 
 use crate::{
-    diesel_macros::{apply_equal_filter, apply_simple_string_filter, apply_sort_no_case},
+    diesel_macros::{
+        apply_equal_filter, apply_simple_string_filter, apply_sort, apply_sort_no_case,
+    },
     repository_error::RepositoryError,
     EqualFilter, Pagination, SimpleStringFilter, Sort,
 };
@@ -22,6 +24,7 @@ pub struct Item {
 pub enum ItemSortField {
     Name,
     Code,
+    Type,
 }
 
 pub type ItemSort = Sort<ItemSortField>;
@@ -119,6 +122,9 @@ impl<'a> ItemRepository<'a> {
                 }
                 ItemSortField::Code => {
                     apply_sort_no_case!(query, sort, item_dsl::code);
+                }
+                ItemSortField::Type => {
+                    apply_sort!(query, sort, item_dsl::type_);
                 }
             }
         } else {

--- a/repository/src/db_diesel/location.rs
+++ b/repository/src/db_diesel/location.rs
@@ -18,6 +18,7 @@ pub struct LocationFilter {
     pub id: Option<EqualFilter<String>>,
     pub name: Option<EqualFilter<String>>,
     pub code: Option<EqualFilter<String>>,
+    pub on_hold: Option<bool>,
     pub store_id: Option<EqualFilter<String>>,
 }
 
@@ -92,6 +93,11 @@ fn create_filtered_query(filter: Option<LocationFilter>) -> BoxedLocationQuery {
         apply_equal_filter!(query, filter.id, location_dsl::id);
         apply_equal_filter!(query, filter.name, location_dsl::name);
         apply_equal_filter!(query, filter.code, location_dsl::code);
+
+        if let Some(value) = filter.on_hold {
+            query = query.filter(location_dsl::on_hold.eq(value));
+        }
+
         apply_equal_filter!(query, filter.store_id, location_dsl::store_id);
     }
 
@@ -108,6 +114,7 @@ impl LocationFilter {
             id: None,
             name: None,
             code: None,
+            on_hold: None,
             store_id: None,
         }
     }
@@ -124,6 +131,11 @@ impl LocationFilter {
 
     pub fn code(mut self, filter: EqualFilter<String>) -> Self {
         self.code = Some(filter);
+        self
+    }
+
+    pub fn on_hold(mut self, filter: bool) -> Self {
+        self.on_hold = Some(filter);
         self
     }
 

--- a/repository/src/db_diesel/name.rs
+++ b/repository/src/db_diesel/name.rs
@@ -241,6 +241,16 @@ impl NameFilter {
         self.is_store = Some(value);
         self
     }
+
+    pub fn store_code(mut self, filter: SimpleStringFilter) -> Self {
+        self.store_code = Some(filter);
+        self
+    }
+
+    pub fn is_customer(mut self, value: bool) -> Self {
+        self.is_customer = Some(value);
+        self
+    }
 }
 
 impl Name {

--- a/repository/src/db_diesel/requisition/mod.rs
+++ b/repository/src/db_diesel/requisition/mod.rs
@@ -1,5 +1,4 @@
-use crate::SimpleStringFilter;
-use crate::{DatetimeFilter, EqualFilter, Sort};
+use crate::{DateFilter, DatetimeFilter, EqualFilter, SimpleStringFilter, Sort};
 
 use crate::requisition_row::{RequisitionRowStatus, RequisitionRowType};
 
@@ -12,12 +11,14 @@ pub use self::requisition_row::*;
 #[derive(Clone, Debug, PartialEq)]
 pub struct RequisitionFilter {
     pub id: Option<EqualFilter<String>>,
+    pub user_id: Option<EqualFilter<String>>,
     pub requisition_number: Option<EqualFilter<i64>>,
     pub r#type: Option<EqualFilter<RequisitionRowType>>,
     pub status: Option<EqualFilter<RequisitionRowStatus>>,
     pub created_datetime: Option<DatetimeFilter>,
     pub sent_datetime: Option<DatetimeFilter>,
     pub finalised_datetime: Option<DatetimeFilter>,
+    pub expected_delivery_date: Option<DateFilter>,
     pub name_id: Option<EqualFilter<String>>,
     pub name: Option<SimpleStringFilter>,
     pub colour: Option<EqualFilter<String>>,
@@ -37,6 +38,8 @@ pub enum RequisitionSortField {
     SentDatetime,
     CreatedDatetime,
     FinalisedDatetime,
+    ExpectedDeliveryDate,
+    TheirReference,
 }
 
 pub type RequisitionSort = Sort<RequisitionSortField>;
@@ -45,12 +48,14 @@ impl RequisitionFilter {
     pub fn new() -> RequisitionFilter {
         RequisitionFilter {
             id: None,
+            user_id: None,
             requisition_number: None,
             r#type: None,
             status: None,
             created_datetime: None,
             sent_datetime: None,
             finalised_datetime: None,
+            expected_delivery_date: None,
             name_id: None,
             name: None,
             colour: None,
@@ -63,6 +68,11 @@ impl RequisitionFilter {
 
     pub fn id(mut self, filter: EqualFilter<String>) -> Self {
         self.id = Some(filter);
+        self
+    }
+
+    pub fn user_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.user_id = Some(filter);
         self
     }
 

--- a/repository/src/db_diesel/requisition/mod.rs
+++ b/repository/src/db_diesel/requisition/mod.rs
@@ -110,6 +110,41 @@ impl RequisitionFilter {
         self.linked_requisition_id = Some(filter);
         self
     }
+
+    pub fn created_datetime(mut self, filter: DatetimeFilter) -> Self {
+        self.created_datetime = Some(filter);
+        self
+    }
+
+    pub fn sent_datetime(mut self, filter: DatetimeFilter) -> Self {
+        self.sent_datetime = Some(filter);
+        self
+    }
+
+    pub fn finalised_datetime(mut self, filter: DatetimeFilter) -> Self {
+        self.finalised_datetime = Some(filter);
+        self
+    }
+
+    pub fn expected_delivery_date(mut self, filter: DateFilter) -> Self {
+        self.expected_delivery_date = Some(filter);
+        self
+    }
+
+    pub fn name_id(mut self, filter: EqualFilter<String>) -> Self {
+        self.name_id = Some(filter);
+        self
+    }
+
+    pub fn colour(mut self, filter: EqualFilter<String>) -> Self {
+        self.colour = Some(filter);
+        self
+    }
+
+    pub fn their_reference(mut self, filter: SimpleStringFilter) -> Self {
+        self.their_reference = Some(filter);
+        self
+    }
 }
 
 impl RequisitionRowStatus {

--- a/repository/src/db_diesel/requisition/requisition.rs
+++ b/repository/src/db_diesel/requisition/requisition.rs
@@ -6,8 +6,8 @@ use super::{
 use crate::{
     db_diesel::name_row::{name, name::dsl as name_dsl},
     diesel_macros::{
-        apply_date_time_filter, apply_equal_filter, apply_simple_string_filter, apply_sort,
-        apply_sort_no_case,
+        apply_date_filter, apply_date_time_filter, apply_equal_filter, apply_simple_string_filter,
+        apply_sort, apply_sort_no_case,
     },
     repository_error::RepositoryError,
     DBType, NameRow, StorageConnection,
@@ -89,6 +89,12 @@ impl<'a> RequisitionRepository<'a> {
                 RequisitionSortField::FinalisedDatetime => {
                     apply_sort!(query, sort, requisition_dsl::finalised_datetime);
                 }
+                RequisitionSortField::ExpectedDeliveryDate => {
+                    apply_sort!(query, sort, requisition_dsl::expected_delivery_date);
+                }
+                RequisitionSortField::TheirReference => {
+                    apply_sort_no_case!(query, sort, requisition_dsl::their_reference);
+                }
             }
         } else {
             query = query.order(requisition_dsl::id.asc())
@@ -114,12 +120,14 @@ fn create_filtered_query(
 
     if let Some(RequisitionFilter {
         id,
+        user_id,
         requisition_number,
         r#type,
         status,
         created_datetime,
         sent_datetime,
         finalised_datetime,
+        expected_delivery_date,
         name_id,
         name,
         colour,
@@ -142,6 +150,7 @@ fn create_filtered_query(
         );
         apply_equal_filter!(query, r#type, requisition_dsl::type_);
         apply_equal_filter!(query, status, requisition_dsl::status);
+        apply_equal_filter!(query, user_id, requisition_dsl::user_id);
 
         apply_date_time_filter!(query, created_datetime, requisition_dsl::created_datetime);
         apply_date_time_filter!(query, sent_datetime, requisition_dsl::sent_datetime);
@@ -149,6 +158,11 @@ fn create_filtered_query(
             query,
             finalised_datetime,
             requisition_dsl::finalised_datetime
+        );
+        apply_date_filter!(
+            query,
+            expected_delivery_date,
+            requisition_dsl::expected_delivery_date
         );
 
         apply_equal_filter!(query, name_id, requisition_dsl::name_id);

--- a/repository/src/db_diesel/store.rs
+++ b/repository/src/db_diesel/store.rs
@@ -58,6 +58,11 @@ impl StoreFilter {
         self
     }
 
+    pub fn name_code(mut self, filter: SimpleStringFilter) -> Self {
+        self.name_code = Some(filter);
+        self
+    }
+
     pub fn site_id(mut self, filter: EqualFilter<i32>) -> Self {
         self.site_id = Some(filter);
         self

--- a/repository/src/mock/test_requisition_queries.rs
+++ b/repository/src/mock/test_requisition_queries.rs
@@ -58,6 +58,7 @@ pub fn mock_request_draft_requisition_all_fields() -> FullMockRequisition {
     FullMockRequisition {
         requisition: inline_init(|r: &mut RequisitionRow| {
             r.id = requisition_id.clone();
+            r.user_id = Some("user_id".to_owned());
             r.requisition_number = 3;
             r.name_id = mock_name_a().id;
             r.store_id = mock_store_a().id;
@@ -66,6 +67,7 @@ pub fn mock_request_draft_requisition_all_fields() -> FullMockRequisition {
             r.created_datetime = NaiveDate::from_ymd(2021, 01, 01).and_hms(0, 0, 0);
             r.sent_datetime = Some(NaiveDate::from_ymd(2021, 01, 02).and_hms(0, 0, 0));
             r.finalised_datetime = Some(NaiveDate::from_ymd(2021, 01, 03).and_hms(0, 0, 0));
+            r.expected_delivery_date = Some(NaiveDate::from_ymd(2021, 01, 04));
             r.colour = Some("colour".to_owned());
             r.comment = Some("comment".to_owned());
             r.their_reference = Some("their_reference".to_owned());


### PR DESCRIPTION
#867 

name_id and name for requisition queries seem to be under otherPartyName & otherPartyID