### PR TITLE
Add comment why we still have openssl as a dependency

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -28,6 +28,10 @@ util = { path = "../util" }
 actix-cors = "0.6.1"
 actix-web = { version= "4.0.1", features = ["rustls"] } 
 actix-files = "0.6.0"
+# OpenSSL is currently only used indirectly by external crates. For the Android build we need to use
+# the "openssl/vendored" feature to make the cross compilation work, i.e. to avoid linking against
+# the openssl shared lib which is not easily available on the host platform. To enable the
+# "openssl/vendored" feature on Android (see below) the openssl crate needs to be a dependency.
 openssl = { version = "0.10", features = ["v110"] }
 anyhow = "1.0.44"
 config = "0.11.0"
@@ -52,4 +56,5 @@ rand = "0.8.5"
 [features]
 default = ["repository/sqlite"]
 postgres = ["repository/postgres"]
+# See openssl comment regarding the "openssl/vendored" feature
 android = ["repository/sqlite", "openssl/vendored"]


### PR DESCRIPTION
@andreievg though I better put a comment into the Cargo.toml file regarding your question why we still need openssl.