### PR TITLE
Can login with wrong credential #1085

### DIFF
--- a/service/src/apis/login_v4.rs
+++ b/service/src/apis/login_v4.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
 pub enum LoginV4Error {
-    Unauthorized,
+    Unauthorised,
     ConnectionError(reqwest::Error),
 }
 
@@ -139,10 +139,12 @@ impl LoginApiV4 {
             .map_err(|e| LoginV4Error::ConnectionError(e))?;
 
         if reqwest::StatusCode::UNAUTHORIZED == response.status() {
-            return Err(LoginV4Error::Unauthorized);
+            return Err(LoginV4Error::Unauthorised);
         }
 
         let response = response
+            .error_for_status()
+            .map_err(|e| LoginV4Error::ConnectionError(e))?
             .json()
             .await
             .map_err(|e| LoginV4Error::ConnectionError(e))?;

--- a/service/src/login.rs
+++ b/service/src/login.rs
@@ -483,6 +483,7 @@ mod test {
             );
         }
         // If central server is not accessible after trying to login with old password, make sure old password does not work
+        // Issue #1101 in remote-server: Extra login protection when user password has changed
         // {
         //     let mock_server = MockServer::start();
         //     mock_server.mock(|when, then| {

--- a/service/src/login.rs
+++ b/service/src/login.rs
@@ -151,7 +151,7 @@ impl LoginService {
         {
             Ok(user_data) => user_data,
             Err(err) => match err {
-                LoginV4Error::Unauthorized => {
+                LoginV4Error::Unauthorised => {
                     return Err(FetchUserError::Unauthenticated);
                 }
                 LoginV4Error::ConnectionError(_) => {
@@ -331,8 +331,11 @@ mod test {
     };
 
     use crate::{
-        apis::login_v4::LoginResponseV4, auth_data::AuthData, login::LoginInput,
-        login_mock_data::LOGIN_V4_RESPONSE_1, service_provider::ServiceProvider,
+        apis::login_v4::LoginResponseV4,
+        auth_data::AuthData,
+        login::{LoginError, LoginInput},
+        login_mock_data::LOGIN_V4_RESPONSE_1,
+        service_provider::ServiceProvider,
         token_bucket::TokenBucket,
     };
 
@@ -343,53 +346,169 @@ mod test {
         let (_, _, connection_manager, _) =
             setup_all("login_test", MockDataInserts::none().names().stores()).await;
         let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider.context().unwrap();
 
-        let mock_server = MockServer::start();
-        mock_server.mock(|when, then| {
-            when.method(POST).path("/api/v4/login".to_string());
-            then.status(200).body(LOGIN_V4_RESPONSE_1);
-        });
-
-        let central_server_url = mock_server.base_url();
         let auth_data = AuthData {
             auth_token_secret: "secret".to_string(),
             token_bucket: Arc::new(RwLock::new(TokenBucket::new())),
             danger_no_ssl: true,
             debug_no_access_control: false,
         };
-        LoginService::login(
-            &service_provider,
-            &auth_data,
-            LoginInput {
-                username: "Gryffindor".to_string(),
-                password: "password".to_string(),
-                central_server_url,
-            },
-            0,
-        )
-        .await
-        .unwrap();
 
         let expected: LoginResponseV4 = serde_json::from_str(LOGIN_V4_RESPONSE_1).unwrap();
         let expected_user_info = expected.user_info.unwrap();
 
-        let context = service_provider.context().unwrap();
-        let user = UserRepository::new(&context.connection)
-            .query_one(UserFilter::new().id(EqualFilter::equal_to(&expected_user_info.user.id)))
-            .unwrap()
-            .unwrap();
-        assert_eq!(expected_user_info.user.name, user.user_row.username);
-        assert_eq!(
-            expected_user_info.user_stores.first().unwrap().store_id,
-            user.stores.first().unwrap().store_row.id
-        );
+        {
+            let mock_server = MockServer::start();
+            mock_server.mock(|when, then| {
+                when.method(POST).path("/api/v4/login".to_string());
+                then.status(200).body(LOGIN_V4_RESPONSE_1);
+            });
 
-        let permissions = UserPermissionRepository::new(&context.connection)
-            .query_by_filter(
-                UserPermissionFilter::new()
-                    .user_id(EqualFilter::equal_to(&expected_user_info.user.id)),
+            let central_server_url = mock_server.base_url();
+
+            LoginService::login(
+                &service_provider,
+                &auth_data,
+                LoginInput {
+                    username: "Gryffindor".to_string(),
+                    password: "password".to_string(),
+                    central_server_url,
+                },
+                0,
             )
+            .await
             .unwrap();
-        assert!(permissions.len() > 0);
+
+            let user = UserRepository::new(&context.connection)
+                .query_one(UserFilter::new().id(EqualFilter::equal_to(&expected_user_info.user.id)))
+                .unwrap()
+                .unwrap();
+            assert_eq!(expected_user_info.user.name, user.user_row.username);
+            assert_eq!(
+                expected_user_info.user_stores.first().unwrap().store_id,
+                user.stores.first().unwrap().store_row.id
+            );
+
+            let permissions = UserPermissionRepository::new(&context.connection)
+                .query_by_filter(
+                    UserPermissionFilter::new()
+                        .user_id(EqualFilter::equal_to(&expected_user_info.user.id)),
+                )
+                .unwrap();
+            assert!(permissions.len() > 0);
+        }
+        // If server password has changed, and trying to login with other then old password, return LoginFailure
+        {
+            let mock_server = MockServer::start();
+            mock_server.mock(|when, then| {
+                when.method(POST).path("/api/v4/login".to_string());
+                then.status(401);
+            });
+
+            let central_server_url = mock_server.base_url();
+
+            let result = LoginService::login(
+                &service_provider,
+                &auth_data,
+                LoginInput {
+                    username: "Gryffindor".to_string(),
+                    password: "password2".to_string(),
+                    central_server_url,
+                },
+                0,
+            )
+            .await;
+
+            assert!(
+                matches!(result, Err(LoginError::LoginFailure)),
+                "expected login failure, got {:#?}",
+                result
+            );
+        }
+        // Old password should still work in offline mode or if central return an error
+        {
+            let mock_server = MockServer::start();
+            mock_server.mock(|when, then| {
+                when.method(POST).path("/api/v4/login".to_string());
+                then.status(500);
+            });
+
+            let central_server_url = mock_server.base_url();
+
+            let result = LoginService::login(
+                &service_provider,
+                &auth_data,
+                LoginInput {
+                    username: "Gryffindor".to_string(),
+                    password: "password".to_string(),
+                    central_server_url,
+                },
+                0,
+            )
+            .await;
+
+            assert!(
+                matches!(result, Ok(_)),
+                "expected Ok token pair, got {:#?}",
+                result
+            );
+        }
+        // If server password has changed, and trying to login with old password, return LoginError::LoginFailure
+        {
+            let mock_server = MockServer::start();
+            mock_server.mock(|when, then| {
+                when.method(POST).path("/api/v4/login".to_string());
+                then.status(401);
+            });
+
+            let central_server_url = mock_server.base_url();
+
+            let result = LoginService::login(
+                &service_provider,
+                &auth_data,
+                LoginInput {
+                    username: "Gryffindor".to_string(),
+                    password: "password2".to_string(),
+                    central_server_url,
+                },
+                0,
+            )
+            .await;
+
+            assert!(
+                matches!(result, Err(LoginError::LoginFailure)),
+                "expected login failure, got {:#?}",
+                result
+            );
+        }
+        // If central server is not accessible after trying to login with old password, make sure old password does not work
+        // {
+        //     let mock_server = MockServer::start();
+        //     mock_server.mock(|when, then| {
+        //         when.method(POST).path("/api/v4/login".to_string());
+        //         then.status(500);
+        //     });
+
+        //     let central_server_url = mock_server.base_url();
+
+        //     let result = LoginService::login(
+        //         &service_provider,
+        //         &auth_data,
+        //         LoginInput {
+        //             username: "Gryffindor".to_string(),
+        //             password: "password".to_string(),
+        //             central_server_url,
+        //         },
+        //         0,
+        //     )
+        //     .await;
+
+        //     assert!(
+        //         matches!(result, Err(LoginError::LoginFailure)),
+        //         "expected LoginFailure, got {:#?}",
+        //         result
+        //     );
+        // }
     }
 }


### PR DESCRIPTION
#1085 

User shouldn't be able to log in with old password in api now if password has been changed in central.

Note: Still can use old password if not logged into the central server and new password has not been saved in remote

Test: 
- [ ] Change password in central
- [ ] Try to login with old pass in api while still connected to central
- [ ] Disconnect from central and try to log in with old password
- [ ] Connect back to central and save new password by logging in
